### PR TITLE
add workflow to build  binaries when a new release is created

### DIFF
--- a/.github/workflows/binary-release.yaml
+++ b/.github/workflows/binary-release.yaml
@@ -1,0 +1,135 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build-and-upload:
+    runs-on: ${{ matrix.os}}
+    strategy:
+      matrix:
+        include:
+          # Linux x86_64
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+
+          # Linux ARM64
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+
+          # macOS Intel
+          - os: macos-15-intel
+            target: x86_64-apple-darwin
+
+          # macOS ARM64
+          - os: macos-15
+            target: aarch64-apple-darwin
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@1.85
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            miner-apps/target
+            pool-apps/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Install musl tools
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+
+      - name: Add musl targets
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          rustup target add x86_64-unknown-linux-musl
+          rustup target add aarch64-unknown-linux-musl
+
+      - name: Build (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          cargo build --release --locked --manifest-path=miner-apps/jd-client/Cargo.toml --target ${{ matrix.target }}
+          cargo build --release --locked --manifest-path=pool-apps/jd-server/Cargo.toml --target ${{ matrix.target }}
+          cargo build --release --locked --manifest-path=pool-apps/pool/Cargo.toml --target ${{ matrix.target }}
+          cargo build --release --locked --manifest-path=miner-apps/translator/Cargo.toml --target ${{ matrix.target }}
+
+      - name: Build (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          cargo build --release --locked --manifest-path=miner-apps/jd-client/Cargo.toml
+          cargo build --release --locked --manifest-path=pool-apps/jd-server/Cargo.toml
+          cargo build --release --locked --manifest-path=pool-apps/pool/Cargo.toml
+          cargo build --release --locked --manifest-path=miner-apps/translator/Cargo.toml
+
+      - name: Package Miner Apps (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          mkdir -p miner-apps-release/jd-client miner-apps-release/translator
+          cp miner-apps/target/${{ matrix.target }}/release/jd_client_sv2 miner-apps-release/jd-client/
+          cp miner-apps/target/${{ matrix.target }}/release/translator_sv2 miner-apps-release/translator/
+          cp -r miner-apps/jd-client/config-examples miner-apps-release/jd-client/
+          cp -r miner-apps/translator/config-examples miner-apps-release/translator/
+          tar -czvf miner-apps-${{ matrix.target }}.tar.gz -C miner-apps-release .
+
+      - name: Package Pool Apps (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          mkdir -p pool-apps-release/jd-server pool-apps-release/pool
+          cp pool-apps/target/${{ matrix.target }}/release/jd_server pool-apps-release/jd-server/
+          cp pool-apps/target/${{ matrix.target }}/release/pool_sv2 pool-apps-release/pool/
+          cp -r pool-apps/jd-server/config-examples pool-apps-release/jd-server/
+          cp -r pool-apps/pool/config-examples pool-apps-release/pool/
+          tar -czvf pool-apps-${{ matrix.target }}.tar.gz -C pool-apps-release .
+
+      - name: Package Miner Apps (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          mkdir -p miner-apps-release/jd-client miner-apps-release/translator
+          cp miner-apps/target/release/jd_client_sv2 miner-apps-release/jd-client/
+          cp miner-apps/target/release/translator_sv2 miner-apps-release/translator/
+          cp -r miner-apps/jd-client/config-examples miner-apps-release/jd-client/
+          cp -r miner-apps/translator/config-examples miner-apps-release/translator/
+          tar -czvf miner-apps-${{ matrix.target }}.tar.gz -C miner-apps-release .
+
+      - name: Package Pool Apps (macOS)
+        if: startsWith(matrix.os, 'macos')
+        run: |
+          mkdir -p pool-apps-release/jd-server pool-apps-release/pool
+          cp pool-apps/target/release/jd_server pool-apps-release/jd-server/
+          cp pool-apps/target/release/pool_sv2 pool-apps-release/pool/
+          cp -r pool-apps/jd-server/config-examples pool-apps-release/jd-server/
+          cp -r pool-apps/pool/config-examples pool-apps-release/pool/
+          tar -czvf pool-apps-${{ matrix.target }}.tar.gz -C pool-apps-release .
+
+      - name: Upload Miner Apps Asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: miner-apps-${{ matrix.target }}.tar.gz
+          asset_name: miner-apps-${{ matrix.target }}.tar.gz
+          tag: ${{ github.ref }}
+
+      - name: Upload Pool Apps Asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: pool-apps-${{ matrix.target }}.tar.gz
+          asset_name: pool-apps-${{ matrix.target }}.tar.gz
+          tag: ${{ github.ref }}
+
+


### PR DESCRIPTION
partially address #50 

This PR addresses the part of the issue requiring binary release for `sv2-apps`.

We starting providing builds for these platforms:

1 - linux x86_64
2 - linux arm64
3 - macos intel
4 - macos M1

The binaries will be bundled like this:

<img width="2358" height="1500" alt="image" src="https://github.com/user-attachments/assets/17cc9d7b-62cb-4434-8ea7-0008531008ad" />
