### PR TITLE
update rust-miniscript to 13.0.0

### DIFF
--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -1184,6 +1184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee770c000993d17c185713463d5ebfbd1af9afae4c17cc295640104383bfbf0"
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,12 +1565,13 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.3.5"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487906208f38448e186e3deb02f2b8ef046a9078b0de00bdb28bf4fb9b76951c"
+checksum = "867b1f11e0545ad5ebbddd8a9f18756d9657a6758bf10d96cf15ddd0b726b650"
 dependencies = [
  "bech32",
  "bitcoin",
+ "hex-conservative 1.0.0",
 ]
 
 [[package]]

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -1431,6 +1431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee770c000993d17c185713463d5ebfbd1af9afae4c17cc295640104383bfbf0"
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,12 +1711,13 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.3.5"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487906208f38448e186e3deb02f2b8ef046a9078b0de00bdb28bf4fb9b76951c"
+checksum = "867b1f11e0545ad5ebbddd8a9f18756d9657a6758bf10d96cf15ddd0b726b650"
 dependencies = [
  "bech32",
  "bitcoin",
+ "hex-conservative 1.0.0",
 ]
 
 [[package]]

--- a/pool-apps/Cargo.lock
+++ b/pool-apps/Cargo.lock
@@ -1041,6 +1041,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ee770c000993d17c185713463d5ebfbd1af9afae4c17cc295640104383bfbf0"
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,12 +1330,13 @@ dependencies = [
 
 [[package]]
 name = "miniscript"
-version = "12.3.5"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487906208f38448e186e3deb02f2b8ef046a9078b0de00bdb28bf4fb9b76951c"
+checksum = "867b1f11e0545ad5ebbddd8a9f18756d9657a6758bf10d96cf15ddd0b726b650"
 dependencies = [
  "bech32",
  "bitcoin",
+ "hex-conservative 1.0.0",
 ]
 
 [[package]]

--- a/pool-apps/jd-server/src/lib/config.rs
+++ b/pool-apps/jd-server/src/lib/config.rs
@@ -268,29 +268,20 @@ mod tests {
     fn test_get_coinbase_reward_script_empty() {
         let error =
             load_coinbase_config_str("\"\"").expect_err("cannot parse config with empty txout");
-        assert_eq!(
-            error.to_string(),
-            "Miniscript: unexpected «(0 args) while parsing Miniscript»",
-        );
+        assert_eq!(error.to_string(), "Miniscript: unrecognized name ''",);
     }
 
     #[test]
     fn test_get_invalid_miniscript_in_coinbase_reward_script() {
         let error = load_coinbase_config_str(&format!("\"INVALID\""))
             .expect_err("Cannot parse config with bad miniscript");
-        assert_eq!(
-            error.to_string(),
-            "Miniscript: unexpected «INVALID(0 args) while parsing Miniscript»",
-        );
+        assert_eq!(error.to_string(), "Miniscript: unrecognized name 'INVALID'",);
     }
 
     #[test]
     fn test_get_invalid_value_in_coinbase_reward_script() {
         let error = load_coinbase_config_str(&format!("\"wpkh({TEST_INVALID_PK_HEX})\""))
             .expect_err("Cannot parse config with bad pubkeys");
-        assert_eq!(
-            error.to_string(),
-            "Miniscript: unexpected «Error while parsing simple public key»",
-        );
+        assert_eq!(error.to_string(), "Miniscript: string error",);
     }
 }

--- a/stratum-apps/Cargo.toml
+++ b/stratum-apps/Cargo.toml
@@ -24,7 +24,7 @@ tokio-util = { version = "0.7.10", default-features = false, features = ["codec"
 
 # Config helpers dependencies  
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
-miniscript = { version = "12.3.4", default-features = false, features = ["no-std"] }
+miniscript = { version = "13.0.0", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1" }
 

--- a/stratum-apps/src/config_helpers/coinbase_output/errors.rs
+++ b/stratum-apps/src/config_helpers/coinbase_output/errors.rs
@@ -7,16 +7,6 @@ use miniscript::bitcoin::{address, hex};
 pub enum Error {
     /// Error parsing a Bitcoin address
     Address(address::ParseError),
-    // TODO rust-miniscript 13 will have functions to do these checks for us so we don't
-    // need to pollute our own error enum with this fiddly stuff
-    /// addr() descriptor did not have exactly 1 child
-    AddrDescriptorNChildren(usize),
-    /// raw() descriptor child did not have 0 children
-    AddrDescriptorGrandchild,
-    /// raw() descriptor did not have exactly 1 child
-    RawDescriptorNChildren(usize),
-    /// addr() descriptor child did not have 0 children
-    RawDescriptorGrandchild,
     /// Error parsing a raw descriptor as hex.
     Hex(hex::HexToBytesError),
     /// Invalid `output_script_value` for script type. It must be a valid public key/script
@@ -32,12 +22,6 @@ impl fmt::Display for Error {
         use Error::*;
         match self {
             Address(ref e) => write!(f, "Bitcoin address: {e}"),
-            AddrDescriptorNChildren(0) => write!(f, "Found addr() descriptor with no address"),
-            AddrDescriptorNChildren(n) => write!(f, "Found addr() descriptor with {n} children; must be exactly one valid address"),
-            AddrDescriptorGrandchild => write!(f, "Found descriptor of the form addr(X(y)); X must be a valid address and have no subexpression"),
-            RawDescriptorNChildren(0) => write!(f, "Found raw() descriptor with no hex-encoded script"),
-            RawDescriptorNChildren(n) => write!(f, "Found raw() descriptor with {n} children; must be exactly one hex-encoded script"),
-            RawDescriptorGrandchild => write!(f, "Found descriptor of the form raw(X(y)); X must be a hex-encoded script and have no subexpression"),
             Hex(ref e) => write!(f, "Decoding hex-formatted script: {e}"),
             UnknownOutputScriptType => write!(f, "Unknown script type in config"),
             InvalidOutputScript => write!(f, "Invalid output_script_value for your script type. It must be a valid public key/script"),


### PR DESCRIPTION
This simplifies a bunch of parsing code, and improves most of the error messages, with two exceptions (which I will file upstream bugs about):

* Our "invalid checksum length" error no longer outputs the correct checksum, which is inconvenient.
* The error for `musig(A,B)` complains about being unable to parse `B` rather than being confused about the name 'musig'.

This lets us delete a bunch of variants from our coinbase output parsing error.