### PR TITLE
partially reverts `49550d7`

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -42,21 +42,12 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 
-      - name: Upload pool coverage to codecov.io
+      - name: Upload pool apps coverage to codecov.io
         uses: codecov/codecov-action@v4
         with:
-          directory: ./pool-apps/pool/target/tarpaulin-reports/pool-coverage
-          file: ./pool-apps/pool/target/tarpaulin-reports/pool-coverage/cobertura.xml
-          flags: pool
-          token: ${{ secrets.CODECOV_TOKEN }}
-        continue-on-error: true
-
-      - name: Upload jd-server coverage to codecov.io
-        uses: codecov/codecov-action@v4
-        with:
-          directory: ./pool-apps/jd-server/target/tarpaulin-reports/jd-server-coverage
-          file: ./pool-apps/jd-server/target/tarpaulin-reports/jd-server-coverage/cobertura.xml
-          flags: jd_server
+          directory: ./pool-apps/target/tarpaulin-reports/pool-apps-coverage
+          file: ./pool-apps/target/tarpaulin-reports/pool-apps-coverage/cobertura.xml
+          flags: pool_apps
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 
@@ -68,13 +59,6 @@ jobs:
           flags: miner_apps
           token: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
-
-      - name: Upload mining-device coverage to codecov.io
-        uses: codecov/codecov-action@v4
-        with:
-          directory: ./miner-apps/mining-device/target/tarpaulin-reports/mining-device-coverage
-          file: ./miner-apps/mining-device/target/tarpaulin-reports/mining-device-coverage/cobertura.xml
-          flags: mining_device
 
       - name: Upload bitcoin-core-sv2 coverage to codecov.io
         uses: codecov/codecov-action@v4
@@ -91,8 +75,6 @@ jobs:
           name: coverage-reports
           path: |
             stratum-apps/target/tarpaulin-reports/
-            pool-apps/pool/target/tarpaulin-reports/
-            pool-apps/jd-server/target/tarpaulin-reports/
+            pool-apps/target/tarpaulin-reports/
             miner-apps/target/tarpaulin-reports/
-            miner-apps/mining-device/target/tarpaulin-reports/
         if: always()

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -39,32 +39,18 @@ cd stratum-apps || exit 1
 tarpaulin "stratum-apps"
 cd - > /dev/null || exit 1
 
-# Pool Coverage
+# Pool Apps Coverage (includes pool and jd-server)
 echo ""
-echo "Running coverage for pool..."
-cd pool-apps/pool || exit 1
-tarpaulin "pool"
+echo "Running coverage for pool-apps workspace..."
+cd pool-apps || exit 1
+tarpaulin "pool-apps"
 cd - > /dev/null || exit 1
 
-# JD Server Coverage (separate workspace from pool)
-echo ""
-echo "Running coverage for jd-server..."
-cd pool-apps/jd-server || exit 1
-tarpaulin "jd-server"
-cd - > /dev/null || exit 1
-
-# Miner Apps Coverage (includes jd-client and translator)
+# Miner Apps Coverage (includes jd-client, translator, and test-utils)
 echo ""
 echo "Running coverage for miner-apps workspace..."
 cd miner-apps || exit 1
 tarpaulin "miner-apps"
-cd - > /dev/null || exit 1
-
-# Mining Device Coverage (separate workspace from miner-apps)
-echo ""
-echo "Running coverage for mining-device..."
-cd miner-apps/mining-device || exit 1
-tarpaulin "mining-device"
 cd - > /dev/null || exit 1
 
 echo ""
@@ -72,8 +58,6 @@ echo "✅ Coverage analysis completed for all available workspaces."
 echo ""
 echo "Reports generated:"
 echo "  - stratum-apps/target/tarpaulin-reports/stratum-apps-coverage/"
-echo "  - pool-apps/pool/target/tarpaulin-reports/pool-coverage/"
-echo "  - pool-apps/jd-server/target/tarpaulin-reports/jd-server-coverage/"
+echo "  - pool-apps/target/tarpaulin-reports/pool-apps-coverage/"
 echo "  - miner-apps/target/tarpaulin-reports/miner-apps-coverage/"
-echo "  - miner-apps/mining-device/target/tarpaulin-reports/mining-device-coverage/"
 echo "  - integration-tests/target/tarpaulin-reports/integration-tests-coverage/"


### PR DESCRIPTION
follow up to #99 due to https://github.com/stratum-mining/sv2-apps/actions/runs/19713012966/job/56480214654

partially reverts 49550d782bf7762bd8a44c0c558399687f238655 with regards to changes on `coverage.yaml` and `coverage.sh`

we don't really care about coverage on `jd_server` and `mining_device` for now

---

validated after merging https://github.com/plebhash/sv2-apps/pull/2 on my fork: https://github.com/plebhash/sv2-apps/actions/runs/19716234022/job/56488950464