### PR TITLE
impl Display trait for `network_helpers::error`

### DIFF
--- a/miner-apps/translator/src/lib/sv2/upstream/upstream.rs
+++ b/miner-apps/translator/src/lib/sv2/upstream/upstream.rs
@@ -130,7 +130,7 @@ impl Upstream {
                     }
                     Err(e) => {
                         error!(
-                            "Failed Noise handshake with {}: {e:?}. Retrying...",
+                            "Failed Noise handshake with {}: {e}. Retrying...",
                             upstream.addr
                         );
                     }

--- a/stratum-apps/src/network_helpers/mod.rs
+++ b/stratum-apps/src/network_helpers/mod.rs
@@ -15,6 +15,7 @@ pub mod noise_stream;
 pub mod sv1_connection;
 
 use async_channel::{RecvError, SendError};
+use std::fmt;
 use stratum_core::codec_sv2::Error as CodecError;
 
 /// Networking errors that can occur in SV2 connections
@@ -30,6 +31,24 @@ pub enum Error {
     SendError,
     /// Socket was closed, likely by the peer
     SocketClosed,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::HandshakeRemoteInvalidMessage => {
+                write!(f, "Invalid handshake message received from remote peer")
+            }
+
+            Error::CodecError(e) => write!(f, "{}", e),
+
+            Error::RecvError => write!(f, "Error receiving from async channel"),
+
+            Error::SendError => write!(f, "Error sending to async channel"),
+
+            Error::SocketClosed => write!(f, "Socket was closed (likely by the peer)"),
+        }
+    }
 }
 
 impl From<CodecError> for Error {


### PR DESCRIPTION
to be merged AFTER https://github.com/stratum-mining/stratum/pull/2017 because this PR is expecting that `SignatureNoiseMessage` impl Display trait, otherwise it will just continue printing the 74 bytes blob.


Before display trait:
```bash
2025-12-02T14:16:24.691962Z ERROR translator_sv2::sv2::upstream::upstream: Failed Noise handshake with 188.40.233.17:34254: CodecError(NoiseSv2Error(InvalidCertificate([0, 0, 190, 244, 46, 105, 206, 2, 47, 105, 146, 164, 238, 218, 246, 86, 50, 46, 132, 248, 120, 123, 118, 153, 4, 114, 57, 4, 38, 69, 151, 151, 236, 168, 65, 8, 171, 78, 155, 197, 49, 22, 124, 242, 209, 235, 58, 247, 35, 255, 50, 197, 166, 89, 214, 131, 117, 189, 48, 206, 159, 209, 220, 99, 110, 212, 215, 210, 225, 183, 35, 226, 102, 46]))). Retrying...
```

after display trait:
```bash
2025-12-03T23:56:47.689861Z ERROR translator_sv2::sv2::upstream::upstream: Failed Noise handshake with 188.40.233.17:34254: Invalid Certificate: SignatureNoiseMessage { version: 0, valid_from: 1764806224, not_valid_after: 1764809824, signature: 679a439dedcd34e2524a0812237575f3734fb69ccdf8b03c3019d286b63fd7c72acbbab2df28ff8541a06ad0b850e37bc0f282621ff0255a3e1b33212542f600 }. Retrying...
```