### PR TITLE
Add auto-detection of node.sock location for Bitcoin Core IPC

### DIFF
--- a/docker/config/jdc-config.toml.template
+++ b/docker/config/jdc-config.toml.template
@@ -67,6 +67,6 @@ jds_port = "${JDC_UPSTREAM_JDS_PORT}"
 
 # Bitcoin Core IPC config
 [template_provider_type.BitcoinCoreIpc]
-unix_socket_path = "/app/node.sock"
+network = "mainnet"
 fee_threshold = ${JDC_FEE_THRESHOLD}
 min_interval = ${JDC_MIN_INTERVAL}

--- a/docker/config/pool-config.toml.template
+++ b/docker/config/pool-config.toml.template
@@ -42,6 +42,6 @@ required_extensions = [
 
 # Bitcoin Core IPC config
 [template_provider_type.BitcoinCoreIpc]
-unix_socket_path = "/app/node.sock"
+network = "mainnet"
 fee_threshold = ${POOL_FEE_THRESHOLD}
 min_interval = ${POOL_MIN_INTERVAL}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - docker_env
     volumes:
       - ./config/pool-config.toml.template:/app/pool-config.toml.template:ro
-      - "${BITCOIN_SOCKET_PATH?}:/app/node.sock"
+      - "${BITCOIN_SOCKET_PATH?}:/root/.bitcoin/node.sock"
     entrypoint: >
       sh -c '
         envsubst < /app/pool-config.toml.template> /app/pool-config.toml &&
@@ -55,7 +55,7 @@ services:
       - docker_env
     volumes:
       - ./config/jdc-config.toml.template:/app/jdc-config.toml.template:ro
-      - "${BITCOIN_SOCKET_PATH?}:/app/node.sock"
+      - "${BITCOIN_SOCKET_PATH?}:/root/.bitcoin/node.sock"
     entrypoint: >
       sh -c '
         envsubst < /app/jdc-config.toml.template> /app/jdc-config.toml &&

--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -869,6 +869,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1795,6 +1816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,6 +2150,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -2470,6 +2508,7 @@ dependencies = [
  "bs58",
  "clap",
  "config",
+ "dirs",
  "futures",
  "generic-array",
  "miniscript 13.0.0",
@@ -2641,6 +2680,26 @@ version = "4.0.2"
 source = "git+https://github.com/stratum-mining/stratum?branch=main#ba72b21964bef236955c6e9343edb93835350a41"
 dependencies = [
  "binary_sv2 5.0.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
 ]
 
 [[package]]

--- a/integration-tests/lib/mod.rs
+++ b/integration-tests/lib/mod.rs
@@ -56,9 +56,18 @@ pub fn sv2_tp_config(address: SocketAddr) -> TemplateProviderType {
 }
 
 /// Helper to create BitcoinCoreIpc config with default thresholds.
-pub fn ipc_config(socket_path: std::path::PathBuf) -> TemplateProviderType {
+pub fn ipc_config(data_dir: std::path::PathBuf, is_signet: bool) -> TemplateProviderType {
+    use stratum_apps::tp_type::BitcoinNetwork;
+
+    let network = if is_signet {
+        BitcoinNetwork::Signet
+    } else {
+        BitcoinNetwork::Regtest
+    };
+
     TemplateProviderType::BitcoinCoreIpc {
-        unix_socket_path: socket_path,
+        network,
+        data_dir: Some(data_dir),
         fee_threshold: 0,
         min_interval: 1,
     }

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -722,6 +722,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,13 +741,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -1233,9 +1254,9 @@ checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags",
  "libc",
@@ -1371,6 +1392,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-multimap"
@@ -1668,7 +1695,18 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1916,6 +1954,7 @@ dependencies = [
  "bs58",
  "clap",
  "config",
+ "dirs",
  "futures",
  "generic-array",
  "miniscript",
@@ -2035,7 +2074,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -2043,6 +2091,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/miner-apps/jd-client/README.md
+++ b/miner-apps/jd-client/README.md
@@ -77,7 +77,8 @@ The configuration file contains the following information:
      - `address` - The Template Provider's network address
      - `public_key` - (Optional) The TP's authority public key for connection verification
    - `[template_provider_type.BitcoinCoreIpc]` - Connects directly to Bitcoin Core via IPC, with the following parameters:
-     - `unix_socket_path` - Path to the Bitcoin Core IPC UNIX socket
+     - `network` - Bitcoin network (mainnet, testnet4, signet, regtest) for determining socket path
+     - `data_dir` - (Optional) Custom Bitcoin data directory. Uses OS default if not set
      - `fee_threshold` - Minimum fee threshold to trigger new templates
 
 For connections with a Sv2 Template Provider, you may want to verify that your TP connection is authentic. You can get the `public_key` from the logs of your TP, for example:

--- a/miner-apps/jd-client/config-examples/mainnet/jdc-config-bitcoin-core-ipc-hosted-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/mainnet/jdc-config-bitcoin-core-ipc-hosted-infra-example.toml
@@ -73,7 +73,10 @@ jds_port = 3334
 # jds_port = "34264"
 
 # Bitcoin Core IPC config
+# Supported networks: mainnet, testnet4, signet, regtest
+# Default data_dir: ~/.bitcoin (Linux) or ~/Library/Application Support/Bitcoin (macOS)
 [template_provider_type.BitcoinCoreIpc]
-unix_socket_path = "/path/to/node.sock"
+network = "mainnet"
+# data_dir = "/custom/bitcoin/data"  # Optional: override default data directory
 fee_threshold = 100
 min_interval = 5

--- a/miner-apps/jd-client/config-examples/mainnet/jdc-config-bitcoin-core-ipc-local-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/mainnet/jdc-config-bitcoin-core-ipc-local-infra-example.toml
@@ -73,7 +73,10 @@ jds_port = 3334
 # jds_port = "34264"
 
 # Bitcoin Core IPC config
+# Supported networks: mainnet, testnet4, signet, regtest
+# Default data_dir: ~/.bitcoin (Linux) or ~/Library/Application Support/Bitcoin (macOS)
 [template_provider_type.BitcoinCoreIpc]
-unix_socket_path = "/path/to/node.sock"
+network = "mainnet"
+# data_dir = "/custom/bitcoin/data"  # Optional: override default data directory
 fee_threshold = 100
 min_interval = 5

--- a/miner-apps/jd-client/config-examples/signet/jdc-config-bitcoin-core-ipc-local-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/signet/jdc-config-bitcoin-core-ipc-local-infra-example.toml
@@ -73,7 +73,10 @@ jds_port = 33334
 # jds_port = "34264"
 
 # Bitcoin Core IPC config
+# Supported networks: mainnet, testnet4, signet, regtest
+# Default data_dir: ~/.bitcoin (Linux) or ~/Library/Application Support/Bitcoin (macOS)
 [template_provider_type.BitcoinCoreIpc]
-unix_socket_path = "/path/to/node.sock"
+network = "signet"
+# data_dir = "/custom/bitcoin/data"  # Optional: override default data directory
 fee_threshold = 100
 min_interval = 5

--- a/miner-apps/jd-client/config-examples/testnet4/jdc-config-bitcoin-core-ipc-hosted-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/testnet4/jdc-config-bitcoin-core-ipc-hosted-infra-example.toml
@@ -73,7 +73,10 @@ jds_port = 43334
 # jds_port = "34264"
 
 # Bitcoin Core IPC config
+# Supported networks: mainnet, testnet4, signet, regtest
+# Default data_dir: ~/.bitcoin (Linux) or ~/Library/Application Support/Bitcoin (macOS)
 [template_provider_type.BitcoinCoreIpc]
-unix_socket_path = "/path/to/node.sock"
+network = "testnet4"
+# data_dir = "/custom/bitcoin/data"  # Optional: override default data directory
 fee_threshold = 100
 min_interval = 5

--- a/miner-apps/jd-client/config-examples/testnet4/jdc-config-bitcoin-core-ipc-local-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/testnet4/jdc-config-bitcoin-core-ipc-local-infra-example.toml
@@ -73,7 +73,10 @@ jds_port = 43334
 # jds_port = "34264"
 
 # Bitcoin Core IPC config
+# Supported networks: mainnet, testnet4, signet, regtest
+# Default data_dir: ~/.bitcoin (Linux) or ~/Library/Application Support/Bitcoin (macOS)
 [template_provider_type.BitcoinCoreIpc]
-unix_socket_path = "/path/to/node.sock"
+network = "testnet4"
+# data_dir = "/custom/bitcoin/data"  # Optional: override default data directory
 fee_threshold = 100
 min_interval = 5

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -148,16 +148,29 @@ impl JobDeclaratorClient {
                 info!("Sv2 Template Provider setup done");
             }
             TemplateProviderType::BitcoinCoreIpc {
-                unix_socket_path,
+                network,
+                data_dir,
                 fee_threshold,
                 min_interval,
             } => {
+                let unix_socket_path = stratum_apps::tp_type::resolve_ipc_socket_path(
+                    &network, data_dir,
+                )
+                .expect(
+                    "Could not determine Bitcoin data directory. Please set data_dir in config.",
+                );
+
+                info!(
+                    "Using Bitcoin Core IPC socket at: {}",
+                    unix_socket_path.display()
+                );
+
                 // incoming and outgoing TDP channels from the perspective of BitcoinCoreSv2
                 let incoming_tdp_receiver = channel_manager_to_tp_receiver.clone();
                 let outgoing_tdp_sender = tp_to_channel_manager_sender.clone();
 
                 let bitcoin_core_config = BitcoinCoreSv2Config {
-                    unix_socket_path: unix_socket_path.clone(),
+                    unix_socket_path,
                     fee_threshold,
                     min_interval,
                     incoming_tdp_receiver,

--- a/pool-apps/Cargo.lock
+++ b/pool-apps/Cargo.lock
@@ -713,6 +713,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,13 +732,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dirs-sys-next"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -1199,9 +1220,9 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags",
  "libc",
@@ -1337,6 +1358,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-multimap"
@@ -1651,7 +1678,18 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1904,6 +1942,7 @@ dependencies = [
  "bs58",
  "clap",
  "config",
+ "dirs",
  "futures",
  "generic-array",
  "miniscript",
@@ -1993,7 +2032,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -2001,6 +2049,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/pool-apps/pool/README.md
+++ b/pool-apps/pool/README.md
@@ -59,7 +59,8 @@ The configuration file contains the following information:
      - `address` - The Template Provider's network address
      - `public_key` - (Optional) The TP's authority public key for connection verification
    - `[template_provider_type.BitcoinCoreIpc]` - Connects directly to Bitcoin Core via IPC, with the following parameters:
-     - `unix_socket_path` - Path to the Bitcoin Core IPC UNIX socket
+     - `network` - Bitcoin network (mainnet, testnet4, signet, regtest) for determining socket path
+     - `data_dir` - (Optional) Custom Bitcoin data directory. Uses OS default if not set
      - `fee_threshold` - Minimum fee threshold to trigger new templates
 
 For connections with a Sv2 Template Provider, you may want to verify that your TP connection is authentic. You can get the `public_key` from the logs of your TP, for example:

--- a/pool-apps/pool/config-examples/mainnet/pool-config-bitcoin-core-ipc-example.toml
+++ b/pool-apps/pool/config-examples/mainnet/pool-config-bitcoin-core-ipc-example.toml
@@ -41,7 +41,10 @@ required_extensions = [
 ]
 
 # Bitcoin Core IPC config
+# Supported networks: mainnet, testnet4, signet, regtest
+# Default data_dir: ~/.bitcoin (Linux) or ~/Library/Application Support/Bitcoin (macOS)
 [template_provider_type.BitcoinCoreIpc]
-unix_socket_path = "/path/to/node.sock"
+network = "mainnet"
+# data_dir = "/custom/bitcoin/data"  # Optional: override default data directory
 fee_threshold = 100
 min_interval = 5

--- a/pool-apps/pool/config-examples/signet/pool-config-bitcoin-core-ipc-example.toml
+++ b/pool-apps/pool/config-examples/signet/pool-config-bitcoin-core-ipc-example.toml
@@ -41,7 +41,10 @@ required_extensions = [
 ]
 
 # Bitcoin Core IPC config
+# Supported networks: mainnet, testnet4, signet, regtest
+# Default data_dir: ~/.bitcoin (Linux) or ~/Library/Application Support/Bitcoin (macOS)
 [template_provider_type.BitcoinCoreIpc]
-unix_socket_path = "/path/to/node.sock"
+network = "signet"
+# data_dir = "/custom/bitcoin/data"  # Optional: override default data directory
 fee_threshold = 100
 min_interval = 5

--- a/pool-apps/pool/config-examples/testnet4/pool-config-bitcoin-core-ipc-example.toml
+++ b/pool-apps/pool/config-examples/testnet4/pool-config-bitcoin-core-ipc-example.toml
@@ -41,7 +41,10 @@ required_extensions = [
 ]
 
 # Bitcoin Core IPC config
+# Supported networks: mainnet, testnet4, signet, regtest
+# Default data_dir: ~/.bitcoin (Linux) or ~/Library/Application Support/Bitcoin (macOS)
 [template_provider_type.BitcoinCoreIpc]
-unix_socket_path = "/path/to/node.sock"
+network = "testnet4"
+# data_dir = "/custom/bitcoin/data"  # Optional: override default data directory
 fee_threshold = 100
 min_interval = 5

--- a/pool-apps/pool/src/lib/error.rs
+++ b/pool-apps/pool/src/lib/error.rs
@@ -185,6 +185,8 @@ pub enum PoolErrorKind {
     ChangeEndpoint,
     /// Could not initiate subsystem
     CouldNotInitiateSystem,
+    /// Configuration error
+    Configuration(String),
 }
 
 impl std::fmt::Display for PoolErrorKind {
@@ -269,11 +271,12 @@ impl std::fmt::Display for PoolErrorKind {
             }
             SetupConnectionError => {
                 write!(f, "Failed to Setup connection")
-            },
+            }
             ChangeEndpoint => {
                 write!(f, "Change endpoint")
-            },
+            }
             CouldNotInitiateSystem => write!(f, "Could not initiate subsystem"),
+            Configuration(e) => write!(f, "Configuration error: {e}"),
         }
     }
 }

--- a/pool-apps/pool/src/lib/mod.rs
+++ b/pool-apps/pool/src/lib/mod.rs
@@ -113,10 +113,22 @@ impl PoolSv2 {
                 info!("Sv2 Template Provider setup done");
             }
             TemplateProviderType::BitcoinCoreIpc {
-                unix_socket_path,
+                network,
+                data_dir,
                 fee_threshold,
                 min_interval,
             } => {
+                let unix_socket_path =
+                    stratum_apps::tp_type::resolve_ipc_socket_path(&network, data_dir)
+                        .ok_or_else(|| PoolErrorKind::Configuration(
+                            "Could not determine Bitcoin data directory. Please set data_dir in config.".to_string()
+                        ))?;
+
+                info!(
+                    "Using Bitcoin Core IPC socket at: {}",
+                    unix_socket_path.display()
+                );
+
                 // incoming and outgoing TDP channels from the perspective of BitcoinCoreSv2
                 let incoming_tdp_receiver = channel_manager_to_tp_receiver.clone();
                 let outgoing_tdp_sender = tp_to_channel_manager_sender.clone();

--- a/stratum-apps/Cargo.toml
+++ b/stratum-apps/Cargo.toml
@@ -33,6 +33,7 @@ tracing = { version = "0.1" }
 
 # Key utils dependencies
 bs58 = { version = "0.4.0", default-features = false, features = ["check", "alloc"] }
+dirs = "6.0"
 secp256k1 = { version = "0.28.2", default-features = false, features = ["alloc", "rand"] }
 rand = { version = "0.8.5", default-features = false }
 rustversion = "1.0"

--- a/stratum-apps/src/tp_type.rs
+++ b/stratum-apps/src/tp_type.rs
@@ -1,6 +1,61 @@
 use crate::key_utils::Secp256k1PublicKey;
 use std::path::PathBuf;
 
+/// Bitcoin network for determining node.sock location
+#[derive(Clone, Debug, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BitcoinNetwork {
+    Mainnet,
+    Testnet4,
+    Signet,
+    Regtest,
+}
+
+impl BitcoinNetwork {
+    /// Returns the subdirectory name for this network.
+    /// Mainnet uses the root data directory.
+    fn subdir(&self) -> Option<&'static str> {
+        match self {
+            BitcoinNetwork::Mainnet => None,
+            BitcoinNetwork::Testnet4 => Some("testnet4"),
+            BitcoinNetwork::Signet => Some("signet"),
+            BitcoinNetwork::Regtest => Some("regtest"),
+        }
+    }
+}
+
+/// Returns the default Bitcoin Core data directory for the current OS.
+fn default_bitcoin_data_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "linux")]
+    {
+        dirs::home_dir().map(|h| h.join(".bitcoin"))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        dirs::home_dir().map(|h| h.join("Library/Application Support/Bitcoin"))
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}
+
+/// Resolves the IPC socket path from network and optional data_dir.
+/// Constructs path from network + optional data_dir (or OS default).
+///
+/// Returns `None` if data_dir cannot be determined (neither provided nor OS default available).
+pub fn resolve_ipc_socket_path(
+    network: &BitcoinNetwork,
+    data_dir: Option<PathBuf>,
+) -> Option<PathBuf> {
+    let base_dir = data_dir.or_else(default_bitcoin_data_dir)?;
+
+    Some(match network.subdir() {
+        Some(subdir) => base_dir.join(subdir).join("node.sock"),
+        None => base_dir.join("node.sock"),
+    })
+}
+
 /// Which type of Template Provider will be used,
 /// along with the relevant config parameters for each.
 #[derive(Clone, Debug, serde::Deserialize)]
@@ -10,8 +65,54 @@ pub enum TemplateProviderType {
         public_key: Option<Secp256k1PublicKey>,
     },
     BitcoinCoreIpc {
-        unix_socket_path: PathBuf,
+        /// Network for determining socket path subdirectory.
+        network: BitcoinNetwork,
+        /// Custom Bitcoin data directory. Uses OS default if not set.
+        data_dir: Option<PathBuf>,
         fee_threshold: u64,
         min_interval: u8,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn network_with_data_dir_mainnet() {
+        let result =
+            resolve_ipc_socket_path(&BitcoinNetwork::Mainnet, Some(PathBuf::from("/data")));
+        assert_eq!(result, Some(PathBuf::from("/data/node.sock")));
+    }
+
+    #[test]
+    fn network_with_data_dir_regtest() {
+        let result =
+            resolve_ipc_socket_path(&BitcoinNetwork::Regtest, Some(PathBuf::from("/data")));
+        assert_eq!(result, Some(PathBuf::from("/data/regtest/node.sock")));
+    }
+
+    #[test]
+    fn network_with_data_dir_signet() {
+        let result = resolve_ipc_socket_path(&BitcoinNetwork::Signet, Some(PathBuf::from("/data")));
+        assert_eq!(result, Some(PathBuf::from("/data/signet/node.sock")));
+    }
+
+    #[test]
+    fn network_with_data_dir_testnet4() {
+        let result =
+            resolve_ipc_socket_path(&BitcoinNetwork::Testnet4, Some(PathBuf::from("/data")));
+        assert_eq!(result, Some(PathBuf::from("/data/testnet4/node.sock")));
+    }
+
+    #[test]
+    fn missing_data_dir_uses_os_default() {
+        // This test verifies behavior when data_dir is None
+        // Result depends on OS - will be Some on Linux/macOS, None on unsupported OS
+        let result = resolve_ipc_socket_path(&BitcoinNetwork::Regtest, None);
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        assert!(result.is_some());
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        assert!(result.is_none());
+    }
 }


### PR DESCRIPTION
- Add BitcoinNetwork enum and resolve_ipc_socket_path() to stratum-apps
- Make unix_socket_path optional, add network and data_dir fields
- Update Pool and JDC to use the resolver
- Update config examples to use new format

Closes #118