### PR TITLE
fix `hotpath` panic on `coverage` CI

### DIFF
--- a/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
@@ -85,7 +85,7 @@ impl<'a> From<(usize, Mining<'a>)> for RouteMessageTo<'a> {
     }
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl RouteMessageTo<'_> {
     /// Forwards the message to its corresponding destination channel.
     ///
@@ -136,7 +136,7 @@ impl RouteMessageTo<'_> {
     }
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleMiningMessagesFromClientAsync for ChannelManager {
     type Error = JDCError;
 

--- a/miner-apps/jd-client/src/lib/channel_manager/extensions_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/extensions_message_handler.rs
@@ -10,7 +10,7 @@ use stratum_apps::{
 };
 use tracing::{error, info};
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleExtensionsFromServerAsync for ChannelManager {
     type Error = JDCError;
 

--- a/miner-apps/jd-client/src/lib/channel_manager/jd_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/jd_message_handler.rs
@@ -24,7 +24,7 @@ use crate::{
     status::{State, Status},
 };
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleJobDeclarationMessagesFromServerAsync for ChannelManager {
     type Error = JDCError;
 

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -256,7 +256,7 @@ pub struct ChannelManager {
     pub upstream_state: AtomicUpstreamState,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl ChannelManager {
     /// Constructor method used to instantiate the Channel Manager
     #[allow(clippy::too_many_arguments)]

--- a/miner-apps/jd-client/src/lib/channel_manager/template_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/template_message_handler.rs
@@ -18,7 +18,7 @@ use crate::{
     jd_mode::{get_jd_mode, JdMode},
 };
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
     type Error = JDCError;
 

--- a/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
@@ -27,7 +27,7 @@ use crate::{
     utils::{create_close_channel_msg, UpstreamState},
 };
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleMiningMessagesFromServerAsync for ChannelManager {
     type Error = JDCError;
 

--- a/miner-apps/jd-client/src/lib/downstream/common_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/downstream/common_message_handler.rs
@@ -13,7 +13,7 @@ use stratum_apps::{
 };
 use tracing::info;
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleCommonMessagesFromClientAsync for Downstream {
     type Error = JDCError;
 

--- a/miner-apps/jd-client/src/lib/downstream/extensions_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/downstream/extensions_message_handler.rs
@@ -11,7 +11,7 @@ use stratum_apps::{
 };
 use tracing::{error, info};
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleExtensionsFromClientAsync for Downstream {
     type Error = JDCError;
 

--- a/miner-apps/jd-client/src/lib/downstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/downstream/mod.rs
@@ -84,7 +84,7 @@ pub struct Downstream {
     pub downstream_id: DownstreamId,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl Downstream {
     /// Creates a new [`Downstream`] instance and spawns the necessary I/O tasks.
     #[allow(clippy::too_many_arguments)]

--- a/miner-apps/jd-client/src/lib/io_task.rs
+++ b/miner-apps/jd-client/src/lib/io_task.rs
@@ -18,7 +18,7 @@ use crate::{
 /// Spawns async reader and writer tasks for handling framed I/O with shutdown support.
 #[track_caller]
 #[allow(clippy::too_many_arguments)]
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 pub fn spawn_io_tasks(
     task_manager: Arc<TaskManager>,
     mut reader: NoiseTcpReadHalf<Message>,

--- a/miner-apps/jd-client/src/lib/job_declarator/message_handler.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/message_handler.rs
@@ -13,7 +13,7 @@ use crate::{
     job_declarator::JobDeclarator,
 };
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleCommonMessagesFromServerAsync for JobDeclarator {
     type Error = JDCError;
 

--- a/miner-apps/jd-client/src/lib/job_declarator/mod.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/mod.rs
@@ -60,7 +60,7 @@ pub struct JobDeclarator {
     mode: ConfigJDCMode,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl JobDeclarator {
     /// Creates a new JobDeclarator instance by connecting and performing a Noise handshake.
     ///

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -46,7 +46,7 @@ pub struct JobDeclaratorClient {
     notify_shutdown: broadcast::Sender<ShutdownMessage>,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl JobDeclaratorClient {
     /// Creates a new [`JobDeclaratorClient`] instance.
     pub fn new(config: JobDeclaratorClientConfig) -> Self {
@@ -480,7 +480,7 @@ impl JobDeclaratorClient {
 
 // Attempts to initialize a single upstream (pool + JDS pair).
 #[allow(clippy::too_many_arguments)]
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 async fn try_initialize_single(
     upstream_addr: &(SocketAddr, SocketAddr, Secp256k1PublicKey, bool),
     upstream_to_channel_manager_sender: Sender<Sv2Frame>,

--- a/miner-apps/jd-client/src/lib/status.rs
+++ b/miner-apps/jd-client/src/lib/status.rs
@@ -59,7 +59,7 @@ impl From<&StatusSender> for StatusType {
     }
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl StatusSender {
     /// Sends a status update for the associated component.
     pub async fn send(&self, status: Status) -> Result<(), async_channel::SendError<Status>> {
@@ -117,7 +117,7 @@ pub struct Status {
 }
 
 /// Sends a shutdown status for the given component, logging the error cause.
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 async fn send_status(sender: &StatusSender, error: JDCError) {
     let state = match sender {
         StatusSender::Downstream { downstream_id, .. } => {
@@ -151,7 +151,7 @@ async fn send_status(sender: &StatusSender, error: JDCError) {
 }
 
 /// Logs an error and propagates a corresponding shutdown status for the component.
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 pub async fn handle_error(sender: &StatusSender, e: JDCError) {
     error!("Error in {:?}: {:?}", sender, e);
     send_status(sender, e).await;

--- a/miner-apps/jd-client/src/lib/template_receiver/bitcoin_core.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/bitcoin_core.rs
@@ -20,7 +20,7 @@ pub struct BitcoinCoreSv2Config {
 }
 
 #[allow(clippy::too_many_arguments)]
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 pub async fn connect_to_bitcoin_core(
     bitcoin_core_config: BitcoinCoreSv2Config,
     notify_shutdown: broadcast::Sender<ShutdownMessage>,

--- a/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/message_handler.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/message_handler.rs
@@ -9,7 +9,7 @@ use tracing::{info, warn};
 
 use crate::{error::JDCError, template_receiver::sv2_tp::Sv2Tp};
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleCommonMessagesFromServerAsync for Sv2Tp {
     type Error = JDCError;
 

--- a/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
@@ -79,7 +79,7 @@ pub struct Sv2Tp {
     tp_address: String,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl Sv2Tp {
     /// Establish a new connection to a Template Provider.
     ///

--- a/miner-apps/jd-client/src/lib/upstream/message_handler.rs
+++ b/miner-apps/jd-client/src/lib/upstream/message_handler.rs
@@ -9,7 +9,7 @@ use tracing::{info, warn};
 
 use crate::{error::JDCError, upstream::Upstream};
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleCommonMessagesFromServerAsync for Upstream {
     type Error = JDCError;
 

--- a/miner-apps/jd-client/src/lib/upstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/upstream/mod.rs
@@ -71,7 +71,7 @@ pub struct Upstream {
     required_extensions: Vec<u16>,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl Upstream {
     /// Create a new [`Upstream`] connection to the given address.
     ///

--- a/miner-apps/jd-client/src/main.rs
+++ b/miner-apps/jd-client/src/main.rs
@@ -5,19 +5,19 @@ use crate::args::process_cli_args;
 
 mod args;
 
-#[cfg(feature = "hotpath-alloc")]
+#[cfg(all(feature = "hotpath-alloc", not(test)))]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     inner_main().await;
 }
 
-#[cfg(not(feature = "hotpath-alloc"))]
+#[cfg(not(all(feature = "hotpath-alloc", not(test))))]
 #[tokio::main]
 async fn main() {
     inner_main().await;
 }
 
-#[hotpath::main]
+#[cfg_attr(not(test), hotpath::main)]
 async fn inner_main() {
     let jdc_config = process_cli_args().unwrap_or_else(|e| {
         eprintln!("Job Declarator Client config error: {e}");

--- a/miner-apps/translator/src/lib/io_task.rs
+++ b/miner-apps/translator/src/lib/io_task.rs
@@ -12,7 +12,7 @@ use tracing::{error, trace, warn, Instrument as _};
 
 use crate::utils::ShutdownMessage;
 
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 #[track_caller]
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_io_tasks(

--- a/miner-apps/translator/src/lib/mod.rs
+++ b/miner-apps/translator/src/lib/mod.rs
@@ -43,7 +43,7 @@ pub struct TranslatorSv2 {
     config: TranslatorConfig,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl TranslatorSv2 {
     /// Creates a new `TranslatorSv2`.
     ///
@@ -316,7 +316,7 @@ impl TranslatorSv2 {
 
 // Attempts to initialize a single upstream.
 #[allow(clippy::too_many_arguments)]
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 async fn try_initialize_upstream(
     upstream_addr: &UpstreamEntry,
     upstream_to_channel_manager_sender: Sender<Sv2Frame>,

--- a/miner-apps/translator/src/lib/status.rs
+++ b/miner-apps/translator/src/lib/status.rs
@@ -32,7 +32,7 @@ pub enum StatusSender {
 
 impl StatusSender {
     /// Sends a [`Status`] update.
-    #[hotpath::measure]
+    #[cfg_attr(not(test), hotpath::measure)]
     pub async fn send(&self, status: Status) -> Result<(), async_channel::SendError<Status>> {
         match self {
             Self::Downstream { downstream_id, tx } => {
@@ -81,7 +81,7 @@ pub struct Status {
 }
 
 /// Constructs and sends a [`Status`] update based on the [`Sender`] and error context.
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 async fn send_status(sender: &StatusSender, error: TproxyError) {
     let state = match sender {
         StatusSender::Downstream { downstream_id, .. } => {
@@ -114,7 +114,7 @@ async fn send_status(sender: &StatusSender, error: TproxyError) {
 ///
 /// Used by the `handle_result!` macro across the codebase.
 /// Decides whether the task should `Continue` or `Break` based on the error type and source.
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 pub async fn handle_error(sender: &StatusSender, e: TproxyError) {
     error!("Error in {:?}: {:?}", sender, e);
     send_status(sender, e).await;

--- a/miner-apps/translator/src/lib/sv1/downstream/channel.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream/channel.rs
@@ -16,7 +16,7 @@ pub struct DownstreamChannelState {
         broadcast::Receiver<(ChannelId, Option<DownstreamId>, json_rpc::Message)>, /* channel_id, optional downstream_id, message */
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl DownstreamChannelState {
     pub fn new(
         downstream_sv1_sender: Sender<json_rpc::Message>,

--- a/miner-apps/translator/src/lib/sv1/downstream/downstream.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream/downstream.rs
@@ -44,7 +44,7 @@ pub struct Downstream {
     downstream_channel_state: DownstreamChannelState,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl Downstream {
     /// Creates a new downstream connection instance.
     #[allow(clippy::too_many_arguments)]

--- a/miner-apps/translator/src/lib/sv1/downstream/message_handler.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream/message_handler.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 
 // Implements `IsServer` for `Downstream` to handle the Sv1 messages.
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl IsServer<'static> for DownstreamData {
     fn handle_configure(
         &mut self,

--- a/miner-apps/translator/src/lib/sv1/sv1_server/channel.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/channel.rs
@@ -17,7 +17,7 @@ pub struct Sv1ServerChannelState {
     pub channel_manager_sender: Sender<(Mining<'static>, Option<Vec<Tlv>>)>,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl Sv1ServerChannelState {
     pub fn new(
         channel_manager_receiver: Receiver<(Mining<'static>, Option<Vec<Tlv>>)>,

--- a/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
@@ -28,7 +28,7 @@ pub struct DifficultyManager {
     is_aggregated: bool,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl DifficultyManager {
     /// Creates a new difficulty manager instance.
     ///

--- a/miner-apps/translator/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/sv1_server.rs
@@ -70,7 +70,7 @@ pub struct Sv1Server {
     miner_counter: AtomicU32,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl Sv1Server {
     /// Drops the server's channel state, cleaning up resources.
     pub fn drop(&self) {

--- a/miner-apps/translator/src/lib/sv2/channel_manager/channel.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/channel.rs
@@ -16,7 +16,7 @@ pub struct ChannelState {
     pub status_sender: Sender<Status>,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl ChannelState {
     pub fn new(
         upstream_sender: Sender<Sv2Frame>,

--- a/miner-apps/translator/src/lib/sv2/channel_manager/channel_manager.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/channel_manager.rs
@@ -60,7 +60,7 @@ pub struct ChannelManager {
     pub required_extensions: Vec<u16>,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl ChannelManager {
     /// Creates a new ChannelManager instance.
     ///

--- a/miner-apps/translator/src/lib/sv2/channel_manager/data.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/data.rs
@@ -57,7 +57,7 @@ pub struct ChannelManagerData {
     pub negotiated_extensions: Vec<u16>,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl ChannelManagerData {
     /// Creates a new ChannelManagerData instance.
     ///

--- a/miner-apps/translator/src/lib/sv2/channel_manager/extensions_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/extensions_message_handler.rs
@@ -10,7 +10,7 @@ use stratum_apps::{
 };
 use tracing::{error, info};
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleExtensionsFromServerAsync for ChannelManager {
     type Error = TproxyError;
 

--- a/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
@@ -28,7 +28,7 @@ use stratum_apps::{
 };
 use tracing::{debug, error, info, warn};
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleMiningMessagesFromServerAsync for ChannelManager {
     type Error = TproxyError;
 

--- a/miner-apps/translator/src/lib/sv2/upstream/channel.rs
+++ b/miner-apps/translator/src/lib/sv2/upstream/channel.rs
@@ -14,7 +14,7 @@ pub struct UpstreamChannelState {
     pub channel_manager_receiver: Receiver<Sv2Frame>,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl UpstreamChannelState {
     pub fn new(
         upstream_receiver: Receiver<Sv2Frame>,

--- a/miner-apps/translator/src/lib/sv2/upstream/common_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv2/upstream/common_message_handler.rs
@@ -8,7 +8,7 @@ use stratum_apps::stratum_core::{
 };
 use tracing::{error, info};
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleCommonMessagesFromServerAsync for Upstream {
     type Error = TproxyError;
 

--- a/miner-apps/translator/src/lib/sv2/upstream/upstream.rs
+++ b/miner-apps/translator/src/lib/sv2/upstream/upstream.rs
@@ -50,7 +50,7 @@ pub struct Upstream {
     pub required_extensions: Vec<u16>,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl Upstream {
     /// Creates a new upstream connection by attempting to connect to configured servers.
     ///

--- a/miner-apps/translator/src/main.rs
+++ b/miner-apps/translator/src/main.rs
@@ -4,13 +4,13 @@ pub use translator_sv2::{config, error, status, sv1, sv2, TranslatorSv2};
 
 use crate::args::process_cli_args;
 
-#[cfg(feature = "hotpath-alloc")]
+#[cfg(all(feature = "hotpath-alloc", not(test)))]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     inner_main().await;
 }
 
-#[cfg(not(feature = "hotpath-alloc"))]
+#[cfg(not(all(feature = "hotpath-alloc", not(test))))]
 #[tokio::main]
 async fn main() {
     inner_main().await;
@@ -20,7 +20,7 @@ async fn main() {
 ///
 /// Loads the configuration from TOML and initializes the main runtime
 /// defined in `translator_sv2::TranslatorSv2`. Errors during startup are logged.
-#[hotpath::main]
+#[cfg_attr(not(test), hotpath::main)]
 async fn inner_main() {
     let proxy_config = process_cli_args().unwrap_or_else(|e| {
         eprintln!("Translator proxy config error: {e}");

--- a/pool-apps/pool/src/args.rs
+++ b/pool-apps/pool/src/args.rs
@@ -26,7 +26,7 @@ pub struct Args {
     pub log_file: Option<PathBuf>,
 }
 
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 /// Parses CLI arguments and loads the PoolConfig from the specified file.
 pub fn process_cli_args() -> PoolConfig {
     let args = Args::parse();

--- a/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
@@ -29,7 +29,7 @@ use crate::{
     error::PoolError,
 };
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleMiningMessagesFromClientAsync for ChannelManager {
     type Error = PoolError;
 

--- a/pool-apps/pool/src/lib/channel_manager/mod.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mod.rs
@@ -100,7 +100,7 @@ pub struct ChannelManager {
     required_extensions: Vec<u16>,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl ChannelManager {
     /// Constructor method used to instantiate the ChannelManager
     #[allow(clippy::too_many_arguments)]

--- a/pool-apps/pool/src/lib/channel_manager/template_distribution_message_handler.rs
+++ b/pool-apps/pool/src/lib/channel_manager/template_distribution_message_handler.rs
@@ -15,7 +15,7 @@ use crate::{
     error::PoolError,
 };
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
     type Error = PoolError;
 

--- a/pool-apps/pool/src/lib/downstream/common_message_handler.rs
+++ b/pool-apps/pool/src/lib/downstream/common_message_handler.rs
@@ -12,7 +12,7 @@ use stratum_apps::{
 };
 use tracing::info;
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleCommonMessagesFromClientAsync for Downstream {
     type Error = PoolError;
 

--- a/pool-apps/pool/src/lib/downstream/extensions_message_handler.rs
+++ b/pool-apps/pool/src/lib/downstream/extensions_message_handler.rs
@@ -11,7 +11,7 @@ use stratum_apps::{
 };
 use tracing::{error, info};
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleExtensionsFromClientAsync for Downstream {
     type Error = PoolError;
 

--- a/pool-apps/pool/src/lib/downstream/mod.rs
+++ b/pool-apps/pool/src/lib/downstream/mod.rs
@@ -91,7 +91,7 @@ pub struct Downstream {
     pub required_extensions: Vec<u16>,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl Downstream {
     /// Creates a new [`Downstream`] instance and spawns the necessary I/O tasks.
     #[allow(clippy::too_many_arguments)]

--- a/pool-apps/pool/src/lib/io_task.rs
+++ b/pool-apps/pool/src/lib/io_task.rs
@@ -18,7 +18,7 @@ use crate::{
 /// Spawns async reader and writer tasks for handling framed I/O with shutdown support.
 #[track_caller]
 #[allow(clippy::too_many_arguments)]
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 pub fn spawn_io_tasks(
     task_manager: Arc<TaskManager>,
     mut reader: NoiseTcpReadHalf<Message>,

--- a/pool-apps/pool/src/lib/mod.rs
+++ b/pool-apps/pool/src/lib/mod.rs
@@ -37,7 +37,7 @@ pub struct PoolSv2 {
     notify_shutdown: broadcast::Sender<ShutdownMessage>,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl PoolSv2 {
     pub fn new(config: PoolConfig) -> Self {
         let (notify_shutdown, _) = tokio::sync::broadcast::channel::<ShutdownMessage>(100);

--- a/pool-apps/pool/src/lib/status.rs
+++ b/pool-apps/pool/src/lib/status.rs
@@ -49,7 +49,7 @@ impl From<&StatusSender> for StatusType {
     }
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl StatusSender {
     /// Sends a status update for the associated component.
     pub async fn send(&self, status: Status) -> Result<(), async_channel::SendError<Status>> {
@@ -94,7 +94,7 @@ pub struct Status {
     pub state: State,
 }
 
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 /// Sends a shutdown status for the given component, logging the error cause.
 async fn send_status(sender: &StatusSender, error: PoolError) {
     let state = match sender {

--- a/pool-apps/pool/src/lib/template_receiver/bitcoin_core.rs
+++ b/pool-apps/pool/src/lib/template_receiver/bitcoin_core.rs
@@ -19,7 +19,7 @@ pub struct BitcoinCoreSv2Config {
     pub cancellation_token: CancellationToken,
 }
 
-#[hotpath::measure]
+#[cfg_attr(not(test), hotpath::measure)]
 pub async fn connect_to_bitcoin_core(
     bitcoin_core_config: BitcoinCoreSv2Config,
     notify_shutdown: broadcast::Sender<ShutdownMessage>,

--- a/pool-apps/pool/src/lib/template_receiver/sv2_tp/common_message_handler.rs
+++ b/pool-apps/pool/src/lib/template_receiver/sv2_tp/common_message_handler.rs
@@ -9,7 +9,7 @@ use tracing::{error, info};
 
 use crate::{error::PoolError, template_receiver::sv2_tp::Sv2Tp};
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl HandleCommonMessagesFromServerAsync for Sv2Tp {
     type Error = PoolError;
 

--- a/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
@@ -40,7 +40,7 @@ pub struct Sv2Tp {
     sv2_tp_channel: Sv2TpChannel,
 }
 
-#[hotpath::measure_all]
+#[cfg_attr(not(test), hotpath::measure_all)]
 impl Sv2Tp {
     /// Establish a new connection to a Sv2 Template Provider.
     ///

--- a/pool-apps/pool/src/main.rs
+++ b/pool-apps/pool/src/main.rs
@@ -5,19 +5,19 @@ use crate::args::process_cli_args;
 
 mod args;
 
-#[cfg(feature = "hotpath-alloc")]
+#[cfg(all(feature = "hotpath-alloc", not(test)))]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     inner_main().await;
 }
 
-#[cfg(not(feature = "hotpath-alloc"))]
+#[cfg(not(all(feature = "hotpath-alloc", not(test))))]
 #[tokio::main]
 async fn main() {
     inner_main().await;
 }
 
-#[hotpath::main]
+#[cfg_attr(not(test), hotpath::main)]
 async fn inner_main() {
     let config = process_cli_args();
     init_logging(config.log_dir());


### PR DESCRIPTION
`coverage.yml` CI is failing with a panic when running `cargo tarpaulin --all-features`:

https://github.com/stratum-mining/sv2-apps/actions/runs/20828110335/job/59841279502

the reason is that `--hotpath-alloc` feature (which is included in `--all-features`) requires initialization via `#[hotpath::main]` in the binary's main function.

but test executables generated by `cargo test` (which is what `tarpaulin` uses) don't include our `main.rs`, causing the panic when library code with hotpath attributes was executed due to `--all-features`.

so this PR makes all hotpath instrumentation points conditional on not being in test mode using `#[cfg_attr(not(test), hotpath::*)]`
