### PR TITLE
fix: validate username and truncate worker name at authorize time

### DIFF
--- a/miner-apps/translator/src/lib/sv1/downstream/data.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream/data.rs
@@ -22,7 +22,10 @@ pub struct DownstreamData {
     pub version_rolling_mask: Option<HexU32Be>,
     pub version_rolling_min_bit: Option<HexU32Be>,
     pub last_job_version_field: Option<u32>,
-    pub authorized_worker_name: String,
+    /// The raw string received from SV1 mining.authorize (e.g., "username.worker1")
+    pub worker_name_from_authorize: String,
+    /// The worker suffix extracted from mining.authorize for TLV extension (e.g., "worker1" from "username.worker1")
+    /// If no '.' delimiter exists, contains the full authorize name.
     pub user_identity: String,
     pub target: Target,
     pub hashrate: Option<Hashrate>,
@@ -56,7 +59,7 @@ impl DownstreamData {
             version_rolling_mask: None,
             version_rolling_min_bit: None,
             last_job_version_field: None,
-            authorized_worker_name: String::new(),
+            worker_name_from_authorize: String::new(),
             user_identity: String::new(),
             target,
             hashrate,

--- a/miner-apps/translator/src/lib/sv1_monitoring.rs
+++ b/miner-apps/translator/src/lib/sv1_monitoring.rs
@@ -12,7 +12,7 @@ fn downstream_to_sv1_client_info(downstream: &Downstream) -> Option<Sv1ClientInf
         .safe_lock(|dd| Sv1ClientInfo {
             client_id: dd.downstream_id,
             channel_id: dd.channel_id,
-            authorized_worker_name: dd.authorized_worker_name.clone(),
+            authorized_worker_name: dd.worker_name_from_authorize.clone(),
             user_identity: dd.user_identity.clone(),
             target_hex: hex::encode(dd.target.to_be_bytes()),
             hashrate: dd.hashrate,


### PR DESCRIPTION
The UserIdentity TLV field has a protocol-specified maximum of 32 bytes. When downstream miners send mining.authorize with long worker names, the translator would panic on unwrap().

This fix:
- Rejects mining.authorize if the username portion (before the dot) exceeds 32 bytes, as this indicates an invalid configuration
- Truncates only the worker name portion if the total length exceeds 32 bytes, preserving the username
- Adds defensive error handling in sv1_server.rs as a fallback