### PR TITLE
patch `release-apps.sh`

### DIFF
--- a/scripts/release-apps.sh
+++ b/scripts/release-apps.sh
@@ -24,8 +24,8 @@ if [ "$EXIT_CODE" -eq 0 ] ; then
   exit 0
 fi
 
-# If cargo failed, check whether it was 'already uploaded'
-if echo "$OUTPUT" | grep -q "already uploaded"; then
+# If cargo failed, check whether it was 'already exists'
+if echo "$OUTPUT" | grep -q "already exists"; then
   echo "Crate is already published: $CRATE_DIR"
   exit 0
 fi


### PR DESCRIPTION
it was originally copied from stratum repo, where we use cargo 1.75

this version of cargo returns a `already uploaded` string

but on this repo, we're using cargo 1.85, which returns `already exists` string