### PR TITLE
add mimalloc

### DIFF
--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -1669,6 +1669,7 @@ dependencies = [
  "config",
  "hex",
  "hotpath",
+ "mimalloc",
  "serde",
  "stratum-apps",
  "tokio",
@@ -1760,6 +1761,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,6 +1827,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -2209,6 +2229,7 @@ dependencies = [
  "config",
  "hex",
  "hotpath",
+ "mimalloc",
  "serde",
  "stratum-apps",
  "tokio",
@@ -3257,6 +3278,7 @@ dependencies = [
  "dashmap",
  "hex",
  "hotpath",
+ "mimalloc",
  "serde",
  "serde_json",
  "stratum-apps",

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -1529,6 +1529,7 @@ dependencies = [
  "config",
  "hex",
  "hotpath",
+ "mimalloc",
  "serde",
  "stratum-apps",
  "tokio",
@@ -1575,6 +1576,16 @@ name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "libredox"
@@ -1633,6 +1644,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -2880,6 +2900,7 @@ dependencies = [
  "dashmap",
  "hex",
  "hotpath",
+ "mimalloc",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/miner-apps/jd-client/Cargo.toml
+++ b/miner-apps/jd-client/Cargo.toml
@@ -26,6 +26,7 @@ clap = { version = "4.5.39", features = ["derive"] }
 bitcoin_core_sv2 = { path = "../../bitcoin-core-sv2" }
 hex = "0.4.3"
 hotpath = "0.9"
+mimalloc = "0.1.48"
 
 [features]
 hotpath = ["hotpath/hotpath"]

--- a/miner-apps/jd-client/src/main.rs
+++ b/miner-apps/jd-client/src/main.rs
@@ -2,6 +2,11 @@ use jd_client_sv2::JobDeclaratorClient;
 use stratum_apps::config_helpers::logging::init_logging;
 
 use crate::args::process_cli_args;
+use mimalloc::MiMalloc;
+
+// Add mimalloc
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 mod args;
 

--- a/miner-apps/jd-client/src/main.rs
+++ b/miner-apps/jd-client/src/main.rs
@@ -2,9 +2,11 @@ use jd_client_sv2::JobDeclaratorClient;
 use stratum_apps::config_helpers::logging::init_logging;
 
 use crate::args::process_cli_args;
+#[cfg(not(feature = "hotpath-alloc"))]
 use mimalloc::MiMalloc;
 
 // Add mimalloc
+#[cfg(not(feature = "hotpath-alloc"))]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 

--- a/miner-apps/translator/Cargo.toml
+++ b/miner-apps/translator/Cargo.toml
@@ -31,6 +31,7 @@ clap = { version = "4.5.39", features = ["derive"] }
 hex = "0.4.3"
 hotpath = "0.9"
 dashmap = "6.1.0"
+mimalloc = "0.1.48"
 
 [features]
 hotpath = ["hotpath/hotpath"]

--- a/miner-apps/translator/src/main.rs
+++ b/miner-apps/translator/src/main.rs
@@ -3,9 +3,11 @@ use stratum_apps::config_helpers::logging::init_logging;
 pub use translator_sv2::{config, error, status, sv1, sv2, TranslatorSv2};
 
 use crate::args::process_cli_args;
+#[cfg(not(feature = "hotpath-alloc"))]
 use mimalloc::MiMalloc;
 
 // Add mimalloc
+#[cfg(not(feature = "hotpath-alloc"))]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 

--- a/miner-apps/translator/src/main.rs
+++ b/miner-apps/translator/src/main.rs
@@ -3,6 +3,11 @@ use stratum_apps::config_helpers::logging::init_logging;
 pub use translator_sv2::{config, error, status, sv1, sv2, TranslatorSv2};
 
 use crate::args::process_cli_args;
+use mimalloc::MiMalloc;
+
+// Add mimalloc
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 #[cfg(all(feature = "hotpath-alloc", not(test)))]
 #[tokio::main(flavor = "current_thread")]

--- a/pool-apps/Cargo.lock
+++ b/pool-apps/Cargo.lock
@@ -1538,6 +1538,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,6 +1604,15 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -1895,6 +1914,7 @@ dependencies = [
  "config",
  "hex",
  "hotpath",
+ "mimalloc",
  "serde",
  "stratum-apps",
  "tokio",

--- a/pool-apps/pool/Cargo.toml
+++ b/pool-apps/pool/Cargo.toml
@@ -27,6 +27,7 @@ clap = { version = "4.5.39", features = ["derive"] }
 bitcoin_core_sv2 = { path = "../../bitcoin-core-sv2" }
 hex = "0.4.3"
 hotpath = "0.9"
+mimalloc = "0.1.48"
 
 [features]
 hotpath = ["hotpath/hotpath"]

--- a/pool-apps/pool/src/main.rs
+++ b/pool-apps/pool/src/main.rs
@@ -2,6 +2,11 @@ use pool_sv2::PoolSv2;
 use stratum_apps::config_helpers::logging::init_logging;
 
 use crate::args::process_cli_args;
+use mimalloc::MiMalloc;
+
+// Add mimalloc
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 mod args;
 

--- a/pool-apps/pool/src/main.rs
+++ b/pool-apps/pool/src/main.rs
@@ -2,9 +2,12 @@ use pool_sv2::PoolSv2;
 use stratum_apps::config_helpers::logging::init_logging;
 
 use crate::args::process_cli_args;
+
+#[cfg(not(feature = "hotpath-alloc"))]
 use mimalloc::MiMalloc;
 
 // Add mimalloc
+#[cfg(not(feature = "hotpath-alloc"))]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 


### PR DESCRIPTION
This PR switches the binaries to use mimalloc instead of the default glibc allocator, which can exhibit higher fragmentation and contention under our workload.