### PR TITLE
Add btrust logo to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For corporate entities interested in providing more substantial support, such as
 SRI contributors are independently, financially supported by following entities: 
 
 <p float="left">
+  <a href="https://btrust.tech"><img src="https://raw.githubusercontent.com/stratum-mining/stratumprotocol.org/refs/heads/main/public/assets/btrust-boxed.png" width="250" /></a>
   <a href="https://hrf.org"><img src="https://raw.githubusercontent.com/stratum-mining/stratumprotocol.org/refs/heads/main/public/assets/hrf-logo-boxed.svg" width="250" /></a>
   <a href="https://spiral.xyz"><img src="https://raw.githubusercontent.com/stratum-mining/stratumprotocol.org/refs/heads/main/public/assets/Spiral-logo-boxed.svg" width="250" /></a>
   <a href="https://opensats.org/"><img src="https://raw.githubusercontent.com/stratum-mining/stratumprotocol.org/refs/heads/main/public/assets/opensats-logo-boxed.svg" width="250" /></a>


### PR DESCRIPTION
Btrust recently started supporting @xyephy. https://x.com/btrustteam/status/1999519261501374863

This PR adds their logo to readme.

Before
<img width="1041" height="589" alt="Screenshot 2026-01-27 at 13 16 37" src="https://github.com/user-attachments/assets/4aac32fa-f4e4-42f4-809d-1bf4f5d7356e" />


After
<img width="1021" height="575" alt="Screenshot 2026-01-27 at 13 19 22" src="https://github.com/user-attachments/assets/00b0f17a-63f0-4399-b110-c2d5abd6178a" />
