### PR TITLE
Add clean_queue method to Sniffer

### DIFF
--- a/integration-tests/lib/message_aggregator.rs
+++ b/integration-tests/lib/message_aggregator.rs
@@ -50,6 +50,13 @@ impl MessagesAggregator {
             .unwrap()
     }
 
+    /// Clears all messages from the queue.
+    pub fn clear(&self) {
+        self.messages
+            .safe_lock(|messages| messages.clear())
+            .unwrap();
+    }
+
     /// returns true if contains message_type
     pub fn has_message_type(&self, message_type: u8) -> bool {
         let has_message: bool = self

--- a/integration-tests/lib/sniffer.rs
+++ b/integration-tests/lib/sniffer.rs
@@ -255,6 +255,18 @@ impl<'a> Sniffer<'a> {
         }
     }
 
+    /// Clears all messages from the specified direction's queue.
+    pub fn clean_queue(&self, message_direction: MessageDirection) {
+        match message_direction {
+            MessageDirection::ToDownstream => {
+                self.messages_from_upstream.clear();
+            }
+            MessageDirection::ToUpstream => {
+                self.messages_from_downstream.clear();
+            }
+        }
+    }
+
     /// Checks whether the sniffer has received a message of the specified type.
     pub fn includes_message_type(
         &self,


### PR DESCRIPTION
Adds a clean_queue(MessageDirection) method that clears all messages from the specified direction's queue. This allows tests to flush the sniffer without waiting for a specific message type.

Closes #155