### PR TITLE
Feat/coinbase rotation

### DIFF
--- a/miner-apps/jd-client/config-examples/testnet4/jdc-config-local-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/testnet4/jdc-config-local-infra-example.toml
@@ -35,7 +35,17 @@ jdc_signature = "Sv2MinerSignature"
 #     https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#appendix-b-index-of-script-expressions
 # Although the `musig` descriptor is not yet supported and the legacy `combo` descriptor never
 # will be. If you have an address, embed it in a descriptor like `addr(<address here>)`.
+#
+# For automatic address rotation (quantum-resistant payout hygiene), use a wildcard descriptor:
+#   coinbase_reward_script = "wpkh(tpub.../0/*)"
+# This derives a fresh address for each block found. Requires coinbase_index_file.
 coinbase_reward_script = "addr(tb1qpusf5256yxv50qt0pm0tue8k952fsu5lzsphft)"
+
+# Coinbase rotation settings (only used when coinbase_reward_script has a wildcard)
+# Path to persist the current derivation index (required for rotation)
+# coinbase_index_file = "/var/lib/jdc/coinbase_index.dat"
+# Starting index if no persistence file exists (default: 0)
+# coinbase_start_index = 0
 
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.

--- a/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
@@ -955,6 +955,8 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
     //    - Translate the share into an upstream `SubmitSharesExtended`.
     //    - Validate with the upstream channel.
     //    - Forward valid shares (or block solutions) upstream.
+    //
+    // 3. If a block is found in solo mining mode, rotate the coinbase address.
     async fn handle_submit_shares_standard(
         &mut self,
         client_id: Option<usize>,
@@ -975,7 +977,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             })
         };
 
-        let messages = self.channel_manager_data.super_safe_lock(|channel_manager_data| {
+        let (messages, solo_block_found) = self.channel_manager_data.super_safe_lock(|channel_manager_data| {
             let Some(downstream) = channel_manager_data.downstream.get_mut(&downstream_id) else {
                 warn!("No downstream found for downstream_id={downstream_id}");
                 return Err(JDCError::disconnect(JDCErrorKind::DownstreamNotFound(downstream_id), downstream_id));
@@ -987,14 +989,15 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
 
             downstream.downstream_data.super_safe_lock(|data| {
                 let mut messages: Vec<RouteMessageTo> = vec![];
+                let mut solo_block_found = false;
 
                 let Some(standard_channel) = data.standard_channels.get_mut(&channel_id) else {
                     error!("SubmitSharesError: channel_id: {channel_id}, sequence_number: {}, error_code: invalid-channel-id", msg.sequence_number);
-                    return Ok(vec![(downstream_id, build_error("invalid-channel-id")).into()]);
+                    return Ok((vec![(downstream_id, build_error("invalid-channel-id")).into()], false));
                 };
 
                 let Some(vardiff) = channel_manager_data.vardiff.get_mut(&(downstream_id, channel_id).into()) else {
-                    return Ok(vec![(downstream_id, Mining::CloseChannel(create_close_channel_msg(channel_id, "invalid-channel-id"))).into()]);
+                    return Ok((vec![(downstream_id, Mining::CloseChannel(create_close_channel_msg(channel_id, "invalid-channel-id"))).into()], false));
                 };
                 vardiff.increment_shares_since_last_update();
                 let res = standard_channel.validate_share(msg.clone());
@@ -1048,6 +1051,11 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                             downstream.downstream_id,
                             Mining::SubmitSharesSuccess(success),
                         ).into());
+
+                        // Track block found in solo mining mode (no upstream channel)
+                        if channel_manager_data.upstream_channel.is_none() {
+                            solo_block_found = true;
+                        }
                     }
                     Err(err) => {
                         let code = match err {
@@ -1064,7 +1072,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 }
 
                 if !is_downstream_share_valid {
-                    return Ok(messages);
+                    return Ok((messages, solo_block_found));
                 }
 
                 if let Some(upstream_channel) = channel_manager_data.upstream_channel.as_mut() {
@@ -1168,7 +1176,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                     }
                 }
 
-                Ok(messages)
+                Ok((messages, solo_block_found))
             })
         })?;
 
@@ -1179,6 +1187,11 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             if let Err(e) = message.forward(&self.channel_manager_channel).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
+        }
+
+        // Rotate coinbase address if block found in solo mining mode
+        if solo_block_found {
+            self.rotate_coinbase_address();
         }
 
         Ok(())
@@ -1195,6 +1208,8 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
     //    - Translate the share into an upstream `SubmitSharesExtended`.
     //    - Validate with the upstream channel.
     //    - Forward valid shares (or block solutions) upstream.
+    //
+    // 3. If a block is found in solo mining mode, rotate the coinbase address.
     async fn handle_submit_shares_extended(
         &mut self,
         client_id: Option<usize>,
@@ -1216,7 +1231,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             })
         };
 
-        let messages = self.channel_manager_data.super_safe_lock(|channel_manager_data| {
+        let (messages, solo_block_found) = self.channel_manager_data.super_safe_lock(|channel_manager_data| {
             let Some(downstream) = channel_manager_data.downstream.get_mut(&downstream_id) else {
                 warn!("No downstream found for downstream_id={downstream_id}");
                 return Err(JDCError::disconnect(JDCErrorKind::DownstreamNotFound(downstream_id), downstream_id));
@@ -1227,10 +1242,11 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             };
             downstream.downstream_data.super_safe_lock(|data| {
                 let mut messages: Vec<RouteMessageTo> = vec![];
+                let mut solo_block_found = false;
 
                 let Some(extended_channel) = data.extended_channels.get_mut(&channel_id) else {
                     error!("SubmitSharesError: channel_id: {channel_id}, sequence_number: {}, error_code: invalid-channel-id", msg.sequence_number);
-                    return Ok(vec![(downstream_id, build_error("invalid-channel-id")).into()]);
+                    return Ok((vec![(downstream_id, build_error("invalid-channel-id")).into()], false));
                 };
                 // here we extract and set the user_identity from the TLV fields if the extension is negotiated
                 let user_identity = if negotiated_extensions.as_ref().is_ok_and(|exts| exts.contains(&EXTENSION_TYPE_WORKER_HASHRATE_TRACKING)) {
@@ -1250,7 +1266,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 }
 
                 let Some(vardiff) = channel_manager_data.vardiff.get_mut(&(downstream_id, channel_id).into()) else {
-                    return Ok(vec![(downstream_id, Mining::CloseChannel(create_close_channel_msg(channel_id, "invalid-channel-id"))).into()]);
+                    return Ok((vec![(downstream_id, Mining::CloseChannel(create_close_channel_msg(channel_id, "invalid-channel-id"))).into()], false));
                 };
                 vardiff.increment_shares_since_last_update();
                 let res = extended_channel.validate_share(msg.clone());
@@ -1303,6 +1319,11 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                             downstream.downstream_id,
                             Mining::SubmitSharesSuccess(success),
                         ).into());
+
+                        // Track block found in solo mining mode (no upstream channel)
+                        if channel_manager_data.upstream_channel.is_none() {
+                            solo_block_found = true;
+                        }
                     }
                     Err(err) => {
                         let code = match err {
@@ -1320,7 +1341,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 }
 
                 if !is_downstream_share_valid{
-                    return Ok(messages);
+                    return Ok((messages, solo_block_found));
                 }
 
                 if let Some(upstream_channel) = channel_manager_data.upstream_channel.as_mut() {
@@ -1431,7 +1452,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                     }
                 }
 
-                Ok(messages)
+                Ok((messages, solo_block_found))
             })
         })?;
 
@@ -1442,6 +1463,11 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             if let Err(e) = message.forward(&self.channel_manager_channel).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
+        }
+
+        // Rotate coinbase address if block found in solo mining mode
+        if solo_block_found {
+            self.rotate_coinbase_address();
         }
 
         Ok(())

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BinaryHeap, HashMap, VecDeque},
     net::SocketAddr,
+    path::PathBuf,
     sync::{
         atomic::{AtomicU32, AtomicUsize, Ordering},
         Arc,
@@ -11,12 +12,16 @@ use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
     coinbase_output_constraints::coinbase_output_constraints_message,
+    config_helpers::XpubDerivator,
     custom_mutex::Mutex,
     fallback_coordinator::FallbackCoordinator,
     key_utils::{Secp256k1PublicKey, Secp256k1SecretKey},
     network_helpers::accept_noise_connection,
     stratum_core::{
-        bitcoin::{consensus, Amount, Target, TxOut},
+        bitcoin::{
+            consensus::{self, Encodable},
+            Amount, Target, TxOut,
+        },
         channels_sv2::{
             client::extended::ExtendedChannel,
             outputs::deserialize_outputs,
@@ -267,6 +272,9 @@ pub struct ChannelManager {
     /// 3. Connected: An upstream channel is successfully established.
     /// 4. SoloMining: No upstream is available; the JDC operates in solo mining mode. case.
     pub upstream_state: AtomicUpstreamState,
+    /// Optional xpub derivator for coinbase rotation in solo mining mode.
+    /// When configured with a wildcard descriptor, derives new addresses on each block found.
+    xpub_derivator: Option<Arc<XpubDerivator>>,
 }
 
 #[cfg_attr(not(test), hotpath::measure_all)]
@@ -302,6 +310,84 @@ impl ChannelManager {
 
         let extranonce_prefix_factory_extended = make_extranonce_factory();
         let extranonce_prefix_factory_standard = make_extranonce_factory();
+
+        let channel_manager_channel = ChannelManagerChannel {
+            upstream_sender,
+            upstream_receiver,
+            jd_sender,
+            jd_receiver,
+            tp_sender,
+            tp_receiver,
+            downstream_sender,
+            downstream_receiver,
+        };
+
+        // Initialize XpubDerivator for coinbase rotation if configured with wildcard descriptor
+        // This must be done BEFORE creating channel_manager_data so we can use
+        // the derivator's current_script_pubkey() for the initial coinbase_outputs
+        let xpub_derivator = if config.coinbase_reward_script().has_wildcard() {
+            let descriptor_str = config
+                .coinbase_reward_script()
+                .wildcard_descriptor_str()
+                .expect("wildcard descriptor must be present when has_wildcard() is true");
+
+            let index_file = config.coinbase_index_file().map(PathBuf::from).ok_or_else(|| {
+                error!("coinbase_index_file is required when coinbase_reward_script has a wildcard");
+                JDCError::shutdown(JDCErrorKind::InvalidConfiguration(
+                    "coinbase_index_file is required when coinbase_reward_script has a wildcard".to_string()
+                ))
+            })?;
+
+            let derivator =
+                XpubDerivator::new(descriptor_str, config.coinbase_start_index(), index_file)
+                    .map_err(|e| {
+                        error!("Failed to initialize XpubDerivator: {}", e);
+                        JDCError::shutdown(JDCErrorKind::InvalidConfiguration(format!(
+                            "failed to initialize coinbase rotation: {}",
+                            e
+                        )))
+                    })?;
+
+            info!(
+                "Coinbase rotation enabled: starting at index {}",
+                derivator.current_index()
+            );
+
+            Some(Arc::new(derivator))
+        } else {
+            None
+        };
+
+        // If we have an xpub derivator, use its current_script_pubkey() for the initial
+        // coinbase_outputs. This ensures we use the correct address from the persisted
+        // index (or start_index) rather than always using index 0.
+        let coinbase_outputs = if let Some(ref derivator) = xpub_derivator {
+            match derivator.current_script_pubkey() {
+                Ok(script) => {
+                    let txout = TxOut {
+                        value: Amount::from_sat(0),
+                        script_pubkey: script,
+                    };
+                    let mut encoded = vec![];
+                    if let Err(e) = vec![txout].consensus_encode(&mut encoded) {
+                        error!("Failed to encode coinbase outputs from derivator: {}", e);
+                        return Err(JDCError::shutdown(JDCErrorKind::InvalidConfiguration(
+                            format!("failed to encode coinbase outputs: {}", e),
+                        )));
+                    }
+                    encoded
+                }
+                Err(e) => {
+                    error!("Failed to derive initial coinbase script: {}", e);
+                    return Err(JDCError::shutdown(JDCErrorKind::InvalidConfiguration(
+                        format!("failed to derive initial coinbase script: {}", e),
+                    )));
+                }
+            }
+        } else {
+            // No derivator - use the passed-in coinbase_outputs (static address)
+            coinbase_outputs
+        };
 
         let channel_manager_data = Arc::new(Mutex::new(ChannelManagerData {
             downstream: HashMap::new(),
@@ -339,7 +425,6 @@ impl ChannelManager {
             downstream_sender: Arc::new(Mutex::new(HashMap::new())),
             downstream_receiver,
         };
-
         let channel_manager = ChannelManager {
             channel_manager_data,
             channel_manager_channel,
@@ -348,6 +433,7 @@ impl ChannelManager {
             miner_tag_string: config.jdc_signature().to_string(),
             user_identity: config.user_identity().to_string(),
             upstream_state: AtomicUpstreamState::new(UpstreamState::SoloMining),
+            xpub_derivator,
         };
 
         Ok(channel_manager)
@@ -1233,5 +1319,62 @@ impl ChannelManager {
             })?;
 
         Ok(())
+    }
+
+    /// Rotates the coinbase address to the next derived address.
+    ///
+    /// This method is called when a block is found in solo mining mode.
+    /// It derives the address at the block height (if provided) or the next
+    /// sequential index, then updates the `coinbase_outputs` in the channel
+    /// manager data.
+    ///
+    /// Only effective when:
+    /// 1. `xpub_derivator` is configured (wildcard descriptor)
+    /// 2. JDC is in solo mining mode
+    ///
+    /// The index is persisted to disk for restart recovery.
+    pub fn rotate_coinbase_address(&self) {
+        // Only rotate if we have an xpub derivator configured
+        let Some(derivator) = &self.xpub_derivator else {
+            return;
+        };
+
+        // Only rotate in solo mining mode
+        if self.upstream_state.get() != UpstreamState::SoloMining {
+            debug!("Skipping coinbase rotation: not in solo mining mode");
+            return;
+        }
+
+        match derivator.next_script_pubkey() {
+            Ok(script_pubkey) => {
+                let new_index = derivator.current_index();
+                info!(
+                    "Coinbase rotation: rotated to index {} (script: {})",
+                    new_index,
+                    script_pubkey.to_hex_string()
+                );
+
+                // Update coinbase_outputs in channel manager data
+                self.channel_manager_data
+                    .super_safe_lock(|channel_manager_data| {
+                        // Create new TxOut with the derived script
+                        let new_output = TxOut {
+                            value: Amount::from_sat(0), // Value will be set from template
+                            script_pubkey,
+                        };
+
+                        // Serialize the new output
+                        let mut output_bytes = Vec::new();
+                        new_output
+                            .consensus_encode(&mut output_bytes)
+                            .expect("TxOut encoding should never fail");
+
+                        channel_manager_data.coinbase_outputs = output_bytes;
+                    });
+            }
+            Err(e) => {
+                error!("Failed to rotate coinbase address: {}", e);
+            }
+        }
     }
 }

--- a/miner-apps/jd-client/src/lib/config.rs
+++ b/miner-apps/jd-client/src/lib/config.rs
@@ -81,7 +81,6 @@ pub struct JobDeclaratorClientConfig {
 fn default_monitoring_cache_refresh_secs() -> u64 {
     15
 }
-}
 
 impl JobDeclaratorClientConfig {
     #[allow(clippy::too_many_arguments)]

--- a/miner-apps/jd-client/src/lib/config.rs
+++ b/miner-apps/jd-client/src/lib/config.rs
@@ -57,8 +57,30 @@ pub struct JobDeclaratorClientConfig {
     /// Optional monitoring server bind address
     #[serde(default)]
     monitoring_address: Option<SocketAddr>,
+    #[serde(default = "default_monitoring_cache_refresh_secs")]
+    monitoring_cache_refresh_secs: u64,
+
+    /// Starting derivation index for coinbase rotation (default: 0).
+    ///
+    /// Only used when `coinbase_reward_script` contains a wildcard descriptor
+    /// (e.g., `wpkh(xpub.../0/*)`). Ignored for static addresses.
     #[serde(default)]
-    monitoring_cache_refresh_secs: Option<u64>,
+    coinbase_start_index: u32,
+
+    /// Path to persist the current coinbase derivation index.
+    ///
+    /// Required when `coinbase_reward_script` contains a wildcard descriptor.
+    /// The index is persisted after each block found, allowing address derivation
+    /// to resume at the correct index after restarts.
+    ///
+    /// Parent directories will be created if they don't exist.
+    #[serde(default, deserialize_with = "opt_path_from_toml")]
+    coinbase_index_file: Option<PathBuf>,
+}
+
+fn default_monitoring_cache_refresh_secs() -> u64 {
+    15
+}
 }
 
 impl JobDeclaratorClientConfig {
@@ -99,7 +121,9 @@ impl JobDeclaratorClientConfig {
             supported_extensions,
             required_extensions,
             monitoring_address,
-            monitoring_cache_refresh_secs,
+            monitoring_cache_refresh_secs: monitoring_cache_refresh_secs.unwrap_or(15),
+            coinbase_start_index: 0,
+            coinbase_index_file: None,
         }
     }
 
@@ -109,7 +133,7 @@ impl JobDeclaratorClientConfig {
     }
 
     /// Returns the monitoring cache refresh interval in seconds.
-    pub fn monitoring_cache_refresh_secs(&self) -> Option<u64> {
+    pub fn monitoring_cache_refresh_secs(&self) -> u64 {
         self.monitoring_cache_refresh_secs
     }
 
@@ -195,6 +219,21 @@ impl JobDeclaratorClientConfig {
     /// Returns the required extensions.
     pub fn required_extensions(&self) -> &[u16] {
         &self.required_extensions
+    }
+
+    /// Returns the coinbase reward script.
+    pub fn coinbase_reward_script(&self) -> &CoinbaseRewardScript {
+        &self.coinbase_reward_script
+    }
+
+    /// Returns the starting derivation index for coinbase rotation.
+    pub fn coinbase_start_index(&self) -> u32 {
+        self.coinbase_start_index
+    }
+
+    /// Returns the path to the coinbase derivation index file.
+    pub fn coinbase_index_file(&self) -> Option<&Path> {
+        self.coinbase_index_file.as_deref()
     }
 }
 

--- a/miner-apps/jd-client/src/lib/error.rs
+++ b/miner-apps/jd-client/src/lib/error.rs
@@ -250,6 +250,8 @@ pub enum JDCErrorKind {
     InvalidKey,
     /// Upstream not found
     UpstreamNotFound,
+    /// Invalid configuration
+    InvalidConfiguration(String),
 }
 
 impl std::error::Error for JDCErrorKind {}
@@ -389,6 +391,7 @@ impl fmt::Display for JDCErrorKind {
             CouldNotInitiateSystem => write!(f, "Could not initiate subsystem"),
             InvalidKey => write!(f, "Invalid key used during noise handshake"),
             UpstreamNotFound => write!(f, "Upstream not found"),
+            InvalidConfiguration(ref msg) => write!(f, "Invalid configuration: {msg}"),
         }
     }
 }

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -132,9 +132,7 @@ impl JobDeclaratorClient {
                 monitoring_addr,
                 Some(Arc::new(channel_manager.clone())), // SV2 channels opened with servers
                 Some(Arc::new(channel_manager.clone())), // SV2 channels opened with clients
-                std::time::Duration::from_secs(
-                    self.config.monitoring_cache_refresh_secs().unwrap_or(15),
-                ),
+                std::time::Duration::from_secs(self.config.monitoring_cache_refresh_secs()),
             )
             .expect("Failed to initialize monitoring server");
 
@@ -504,7 +502,7 @@ impl JobDeclaratorClient {
                                         monitoring_addr,
                                         Some(Arc::new(channel_manager_clone.clone())),
                                         Some(Arc::new(channel_manager_clone.clone())),
-                                        std::time::Duration::from_secs(self.config.monitoring_cache_refresh_secs().unwrap_or(15)),
+                                        std::time::Duration::from_secs(self.config.monitoring_cache_refresh_secs()),
                                     )
                                     .expect("Failed to initialize monitoring server");
 

--- a/pool-apps/pool/config-examples/testnet4/pool-config-local-sv2-tp-example.toml
+++ b/pool-apps/pool/config-examples/testnet4/pool-config-local-sv2-tp-example.toml
@@ -8,7 +8,17 @@ listen_address = "0.0.0.0:43333"
 #     https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#appendix-b-index-of-script-expressions
 # Although the `musig` descriptor is not yet supported and the legacy `combo` descriptor never
 # will be. If you have an address, embed it in a descriptor like `addr(<address here>)`.
+#
+# For automatic address rotation (quantum-resistant payout hygiene), use a wildcard descriptor:
+#   coinbase_reward_script = "wpkh(tpub.../0/*)"
+# This derives a fresh address for each block found. Requires coinbase_index_file.
 coinbase_reward_script = "addr(tb1qa0sm0hxzj0x25rh8gw5xlzwlsfvvyz8u96w3p8)"
+
+# Coinbase rotation settings (only used when coinbase_reward_script has a wildcard)
+# Path to persist the current derivation index (required for rotation)
+# coinbase_index_file = "/var/lib/pool/coinbase_index.dat"
+# Starting index if no persistence file exists (default: 0)
+# coinbase_start_index = 0
 
 # Server Id (number to guarantee unique search space allocation across different Pool servers)
 server_id = 1

--- a/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
@@ -574,7 +574,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
         let downstream_id =
             client_id.expect("client_id must be present for downstream_id extraction");
 
-        let messages = self.channel_manager_data.super_safe_lock(|channel_manager_data| {
+        let (messages, block_found) = self.channel_manager_data.super_safe_lock(|channel_manager_data| {
             let channel_id = msg.channel_id;
 
             let Some(downstream) = channel_manager_data.downstream.get(&downstream_id) else {
@@ -583,6 +583,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
 
             downstream.downstream_data.super_safe_lock(|downstream_data| {
                 let mut messages: Vec<RouteMessageTo> = Vec::new();
+                let mut block_found = false;
                 let Some(standard_channel) = downstream_data.standard_channels.get_mut(&channel_id) else {
                     let submit_shares_error = SubmitSharesError {
                         channel_id,
@@ -593,11 +594,11 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                             .expect("error code must be valid string"),
                     };
                     error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: invalid-channel-id ❌", downstream_id, channel_id, msg.sequence_number);
-                    return Ok(vec![(downstream_id, Mining::SubmitSharesError(submit_shares_error)).into()]);
+                    return Ok((vec![(downstream_id, Mining::SubmitSharesError(submit_shares_error)).into()], false));
                 };
 
                 let Some(vardiff) = channel_manager_data.vardiff.get_mut(&(downstream_id, channel_id).into()) else {
-                    return Ok(vec![(downstream_id, Mining::CloseChannel(create_close_channel_msg(channel_id, "invalid-channel-id"))).into()]);
+                    return Ok((vec![(downstream_id, Mining::CloseChannel(create_close_channel_msg(channel_id, "invalid-channel-id"))).into()], false));
                 };
 
                 let res = standard_channel.validate_share(msg.clone());
@@ -627,6 +628,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                     }
                     Ok(ShareValidationResult::BlockFound(share_hash, template_id, coinbase)) => {
                         info!("SubmitSharesStandard: 💰 Block Found!!! 💰{share_hash}");
+                        block_found = true;
                         // if we have a template id (i.e.: this was not a custom job)
                         // we can propagate the solution to the TP
                         if let Some(template_id) = template_id {
@@ -715,7 +717,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                     }
                 }
 
-                Ok(messages)
+                Ok((messages, block_found))
             })
         })?;
 
@@ -726,6 +728,11 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             if let Err(e) = message.forward(&self.channel_manager_channel).await {
                 error!("Failed to forward message {e:?}");
             }
+        }
+
+        // Rotate coinbase address after block found
+        if block_found {
+            self.rotate_coinbase_address();
         }
 
         Ok(())
@@ -759,7 +766,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             None
         };
 
-        let messages = self.channel_manager_data.super_safe_lock(|channel_manager_data| {
+        let (messages, block_found) = self.channel_manager_data.super_safe_lock(|channel_manager_data| {
             let channel_id = msg.channel_id;
             let Some(downstream) = channel_manager_data.downstream.get(&downstream_id) else {
                 return Err(PoolError::disconnect(PoolErrorKind::DownstreamNotFound(downstream_id), downstream_id));
@@ -767,6 +774,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
 
             downstream.downstream_data.super_safe_lock(|downstream_data| {
                 let mut messages: Vec<RouteMessageTo> = Vec::new();
+                let mut block_found = false;
                 let Some(extended_channel) = downstream_data.extended_channels.get_mut(&channel_id) else {
                     let error = SubmitSharesError {
                         channel_id,
@@ -777,7 +785,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                             .expect("error code must be valid string"),
                     };
                     error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: invalid-channel-id ❌", downstream_id, channel_id, msg.sequence_number);
-                    return Ok(vec![(downstream_id, Mining::SubmitSharesError(error)).into()]);
+                    return Ok((vec![(downstream_id, Mining::SubmitSharesError(error)).into()], false));
                 };
 
                 if let Some(_user_identity) = user_identity {
@@ -785,7 +793,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 }
 
                 let Some(vardiff) = channel_manager_data.vardiff.get_mut(&(downstream_id, channel_id).into()) else {
-                    return Ok(vec![(downstream_id, Mining::CloseChannel(create_close_channel_msg(channel_id, "invalid-channel-id"))).into()]);
+                    return Ok((vec![(downstream_id, Mining::CloseChannel(create_close_channel_msg(channel_id, "invalid-channel-id"))).into()], false));
                 };
 
                 let res = extended_channel.validate_share(msg.clone());
@@ -813,6 +821,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                     }
                     Ok(ShareValidationResult::BlockFound(share_hash, template_id, coinbase)) => {
                         info!("SubmitSharesExtended: 💰 Block Found!!! 💰{share_hash}");
+                        block_found = true;
                         // if we have a template id (i.e.: this was not a custom job)
                         // we can propagate the solution to the TP
                         if let Some(template_id) = template_id {
@@ -912,7 +921,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                     }
                 }
 
-                Ok(messages)
+                Ok((messages, block_found))
             })
         })?;
 
@@ -923,6 +932,11 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             if let Err(e) = message.forward(&self.channel_manager_channel).await {
                 error!("Failed to forward message {e:?}");
             }
+        }
+
+        // Rotate coinbase address after block found
+        if block_found {
+            self.rotate_coinbase_address();
         }
 
         Ok(())

--- a/pool-apps/pool/src/lib/channel_manager/mod.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mod.rs
@@ -12,12 +12,12 @@ use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use core::sync::atomic::Ordering;
 use stratum_apps::{
     coinbase_output_constraints::coinbase_output_constraints_message_with_offset,
-    config_helpers::CoinbaseRewardScript,
+    config_helpers::{CoinbaseRewardScript, XpubDerivator},
     custom_mutex::Mutex,
     key_utils::{Secp256k1PublicKey, Secp256k1SecretKey},
     network_helpers::accept_noise_connection,
     stratum_core::{
-        bitcoin::{Amount, TxOut},
+        bitcoin::{consensus::Encodable, Amount, TxOut},
         channels_sv2::{
             server::{
                 extended::ExtendedChannel,
@@ -104,6 +104,9 @@ pub struct ChannelManager {
     required_extensions: Vec<u16>,
     /// Embedded Job Declaration engine (present when `[jds]` config is set).
     job_declarator: Option<JobDeclarator>,
+    /// Optional xpub derivator for coinbase rotation.
+    /// When set, the coinbase address rotates to a new derived address after each block is found.
+    xpub_derivator: Option<Arc<XpubDerivator>>,
 }
 
 #[cfg_attr(not(test), hotpath::measure_all)]
@@ -140,6 +143,76 @@ impl ChannelManager {
         let extranonce_prefix_factory_extended = make_extranonce_factory();
         let extranonce_prefix_factory_standard = make_extranonce_factory();
 
+        let channel_manager_channel = ChannelManagerChannel {
+            tp_sender,
+            tp_receiver,
+            downstream_sender,
+            downstream_receiver,
+        };
+
+        // Initialize xpub derivator if the coinbase reward script has a wildcard
+        // This must be done BEFORE creating channel_manager_data so we can use
+        // the derivator's current_script_pubkey() for the initial coinbase_outputs
+        let xpub_derivator = if config.coinbase_reward_script().has_wildcard() {
+            let descriptor_str = config
+                .coinbase_reward_script()
+                .wildcard_descriptor_str()
+                .expect("wildcard descriptor must exist when has_wildcard() is true");
+
+            let index_file = config.coinbase_index_file().ok_or_else(|| {
+                error!("coinbase_index_file is required when using a wildcard descriptor");
+                PoolError::shutdown(PoolErrorKind::InvalidConfiguration)
+            })?;
+
+            match XpubDerivator::new(
+                descriptor_str,
+                config.coinbase_start_index(),
+                index_file.to_path_buf(),
+            ) {
+                Ok(derivator) => {
+                    info!(
+                        "Coinbase rotation enabled. Starting at index {}, persisting to {:?}",
+                        derivator.current_index(),
+                        index_file
+                    );
+                    Some(Arc::new(derivator))
+                }
+                Err(e) => {
+                    error!("Failed to initialize xpub derivator: {}", e);
+                    return Err(PoolError::shutdown(PoolErrorKind::InvalidConfiguration));
+                }
+            }
+        } else {
+            None
+        };
+
+        // If we have an xpub derivator, use its current_script_pubkey() for the initial
+        // coinbase_outputs. This ensures we use the correct address from the persisted
+        // index (or start_index) rather than always using index 0.
+        let coinbase_outputs = if let Some(ref derivator) = xpub_derivator {
+            match derivator.current_script_pubkey() {
+                Ok(script) => {
+                    let txout = TxOut {
+                        value: Amount::from_sat(0),
+                        script_pubkey: script,
+                    };
+                    let mut encoded = vec![];
+                    if let Err(e) = vec![txout].consensus_encode(&mut encoded) {
+                        error!("Failed to encode coinbase outputs from derivator: {}", e);
+                        return Err(PoolError::shutdown(PoolErrorKind::InvalidConfiguration));
+                    }
+                    encoded
+                }
+                Err(e) => {
+                    error!("Failed to derive initial coinbase script: {}", e);
+                    return Err(PoolError::shutdown(PoolErrorKind::InvalidConfiguration));
+                }
+            }
+        } else {
+            // No derivator - use the passed-in coinbase_outputs (static address)
+            coinbase_outputs
+        };
+
         let channel_manager_data = Arc::new(Mutex::new(ChannelManagerData {
             downstream: HashMap::new(),
             extranonce_prefix_factory_extended,
@@ -157,7 +230,6 @@ impl ChannelManager {
             downstream_sender: Arc::new(Mutex::new(HashMap::new())),
             downstream_receiver,
         };
-
         let channel_manager = ChannelManager {
             channel_manager_data,
             channel_manager_channel,
@@ -168,6 +240,7 @@ impl ChannelManager {
             supported_extensions: config.supported_extensions().to_vec(),
             required_extensions: config.required_extensions().to_vec(),
             job_declarator,
+            xpub_derivator,
         };
 
         Ok(channel_manager)
@@ -662,6 +735,51 @@ impl ChannelManager {
             })?;
 
         Ok(())
+    }
+
+    /// Rotates the coinbase address to the next derived address.
+    ///
+    /// This should be called after a block is found. It:
+    /// 1. Derives the address at the block height (if provided) or the next sequential index
+    /// 2. Persists the index/height to disk
+    /// 3. Updates the internal coinbase_outputs for future templates
+    ///
+    /// If no xpub derivator is configured (static address), this is a no-op.
+    pub fn rotate_coinbase_address(&self) {
+        let Some(derivator) = &self.xpub_derivator else {
+            return;
+        };
+
+        match derivator.next_script_pubkey() {
+            Ok(new_script) => {
+                let new_index = derivator.current_index();
+                info!(
+                    "Rotated coinbase address to index {}. New script: {}",
+                    new_index,
+                    new_script.to_hex_string()
+                );
+
+                // Update the coinbase_outputs in ChannelManagerData
+                let new_txout = TxOut {
+                    value: Amount::from_sat(0),
+                    script_pubkey: new_script,
+                };
+
+                // Encode outputs using consensus encoding (same format as initialization)
+                let mut new_outputs = vec![];
+                if let Err(e) = vec![new_txout].consensus_encode(&mut new_outputs) {
+                    error!("Failed to encode new coinbase outputs: {}", e);
+                    return;
+                }
+
+                self.channel_manager_data.super_safe_lock(|data| {
+                    data.coinbase_outputs = new_outputs;
+                });
+            }
+            Err(e) => {
+                error!("Failed to rotate coinbase address: {}", e);
+            }
+        }
     }
 }
 

--- a/pool-apps/pool/src/lib/config.rs
+++ b/pool-apps/pool/src/lib/config.rs
@@ -48,14 +48,14 @@ pub struct PoolConfig {
     monitoring_address: Option<SocketAddr>,
     #[serde(default = "default_monitoring_cache_refresh_secs")]
     monitoring_cache_refresh_secs: u64,
+    #[serde(default)]
+    jds: Option<JDSPartialConfig>,
 
     /// Starting derivation index for coinbase rotation (default: 0).
     ///
     /// Only used when `coinbase_reward_script` contains a wildcard descriptor
     /// (e.g., `wpkh(xpub.../0/*)`). Ignored for static addresses.
     #[serde(default)]
-    jds: Option<JDSPartialConfig>,
-    monitoring_cache_refresh_secs: Option<u64>,
     coinbase_start_index: u32,
 
     /// Path to persist the current coinbase derivation index.
@@ -71,7 +71,6 @@ pub struct PoolConfig {
 
 fn default_monitoring_cache_refresh_secs() -> u64 {
     15
-}
 }
 
 impl PoolConfig {

--- a/pool-apps/pool/src/lib/config.rs
+++ b/pool-apps/pool/src/lib/config.rs
@@ -46,10 +46,32 @@ pub struct PoolConfig {
     required_extensions: Vec<u16>,
     #[serde(default)]
     monitoring_address: Option<SocketAddr>,
+    #[serde(default = "default_monitoring_cache_refresh_secs")]
+    monitoring_cache_refresh_secs: u64,
+
+    /// Starting derivation index for coinbase rotation (default: 0).
+    ///
+    /// Only used when `coinbase_reward_script` contains a wildcard descriptor
+    /// (e.g., `wpkh(xpub.../0/*)`). Ignored for static addresses.
     #[serde(default)]
     jds: Option<JDSPartialConfig>,
-    #[serde(default)]
     monitoring_cache_refresh_secs: Option<u64>,
+    coinbase_start_index: u32,
+
+    /// Path to persist the current coinbase derivation index.
+    ///
+    /// Required when `coinbase_reward_script` contains a wildcard descriptor.
+    /// The index is persisted after each block found, allowing address derivation
+    /// to resume at the correct index after restarts.
+    ///
+    /// Parent directories will be created if they don't exist.
+    #[serde(default, deserialize_with = "opt_path_from_toml")]
+    coinbase_index_file: Option<PathBuf>,
+}
+
+fn default_monitoring_cache_refresh_secs() -> u64 {
+    15
+}
 }
 
 impl PoolConfig {
@@ -88,7 +110,9 @@ impl PoolConfig {
             supported_extensions,
             required_extensions,
             monitoring_address,
-            monitoring_cache_refresh_secs,
+            monitoring_cache_refresh_secs: monitoring_cache_refresh_secs.unwrap_or(15),
+            coinbase_start_index: 0,
+            coinbase_index_file: None,
             jds,
         }
     }
@@ -182,7 +206,7 @@ impl PoolConfig {
     }
 
     /// Returns the monitoring cache refresh interval in seconds.
-    pub fn monitoring_cache_refresh_secs(&self) -> Option<u64> {
+    pub fn monitoring_cache_refresh_secs(&self) -> u64 {
         self.monitoring_cache_refresh_secs
     }
 
@@ -205,6 +229,16 @@ impl PoolConfig {
         );
 
         Ok(Some(jds_config))
+    }
+
+    /// Returns the starting derivation index for coinbase rotation.
+    pub fn coinbase_start_index(&self) -> u32 {
+        self.coinbase_start_index
+    }
+
+    /// Returns the path to the coinbase derivation index file.
+    pub fn coinbase_index_file(&self) -> Option<&Path> {
+        self.coinbase_index_file.as_deref()
     }
 }
 

--- a/pool-apps/pool/src/lib/error.rs
+++ b/pool-apps/pool/src/lib/error.rs
@@ -187,6 +187,8 @@ pub enum PoolErrorKind {
     CouldNotInitiateSystem,
     /// Configuration error
     Configuration(String),
+    /// Invalid configuration (validation failed at runtime)
+    InvalidConfiguration,
     /// Job not found
     JobNotFound,
     /// Invalid Key
@@ -283,6 +285,7 @@ impl std::fmt::Display for PoolErrorKind {
             }
             CouldNotInitiateSystem => write!(f, "Could not initiate subsystem"),
             Configuration(e) => write!(f, "Configuration error: {e}"),
+            InvalidConfiguration => write!(f, "Invalid configuration"),
             JobNotFound => write!(f, "Job not found"),
             InvalidKey => write!(f, "Invalid key used during noise handshake"),
             PayoutModeError(e) => write!(f, "Unable to parse the PayoutMode: {e}"),

--- a/pool-apps/pool/src/lib/mod.rs
+++ b/pool-apps/pool/src/lib/mod.rs
@@ -171,9 +171,7 @@ impl PoolSv2 {
                 monitoring_addr,
                 None, // Pool doesn't have channels opened with servers
                 Some(Arc::new(channel_manager.clone())), // channels opened with clients
-                std::time::Duration::from_secs(
-                    self.config.monitoring_cache_refresh_secs().unwrap_or(15),
-                ),
+                std::time::Duration::from_secs(self.config.monitoring_cache_refresh_secs()),
             )
             .expect("Failed to initialize monitoring server");
 

--- a/stratum-apps/Cargo.lock
+++ b/stratum-apps/Cargo.lock
@@ -71,6 +71,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,7 +495,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
@@ -704,6 +710,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,6 +748,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -872,6 +890,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "ghash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +959,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -940,6 +980,12 @@ checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1150,6 +1196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1301,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1321,12 @@ dependencies = [
  "bitflags",
  "libc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1600,6 +1664,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1659,6 +1733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,7 +1771,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1709,7 +1789,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
 ]
@@ -1806,6 +1886,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1870,6 +1963,12 @@ checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -2068,6 +2167,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "stratum-core",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tower",
@@ -2186,6 +2286,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "template_distribution_sv2"
@@ -2638,6 +2751,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +2936,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/stratum-apps/Cargo.toml
+++ b/stratum-apps/Cargo.toml
@@ -27,7 +27,7 @@ tokio-util = { version = "0.7.10", default-features = false, features = ["codec"
 
 # Config helpers dependencies
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
-miniscript = { version = "13.0.0", default-features = false }
+miniscript = { version = "13.0.0", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing = { version = "0.1" }
 
@@ -84,6 +84,7 @@ mining_device = ["config"]
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 hyper = "1.1.0"
+tempfile = "3.10"
 
 [package.metadata.docs.rs]
 features = ["pool", "jd_client", "jd_server", "translator", "sv1", "rpc"]

--- a/stratum-apps/src/config_helpers/coinbase_output/mod.rs
+++ b/stratum-apps/src/config_helpers/coinbase_output/mod.rs
@@ -3,6 +3,7 @@ mod serde_types;
 
 use miniscript::{
     bitcoin::{address::NetworkUnchecked, Address, Network, ScriptBuf},
+    descriptor::DescriptorPublicKey,
     DefiniteDescriptorKey, Descriptor,
 };
 
@@ -11,16 +12,54 @@ pub use errors::Error;
 /// Coinbase output transaction.
 ///
 /// Typically used for parsing coinbase outputs defined in SRI role configuration files.
+///
+/// Supports two modes:
+/// 1. **Static address**: A fixed address (e.g., `addr(bc1q...)`) - `script_pubkey` is set directly
+/// 2. **Wildcard descriptor**: A derivable descriptor (e.g., `wpkh(xpub.../0/*)`) - stores the
+///    descriptor string for later derivation via [`XpubDerivator`](crate::config_helpers::XpubDerivator)
+///
+/// Use [`has_wildcard()`](Self::has_wildcard) to check which mode is active.
 #[derive(Debug, serde::Deserialize, Clone)]
 #[serde(try_from = "serde_types::SerdeCoinbaseOutput")]
 pub struct CoinbaseRewardScript {
+    /// The script pubkey for static addresses, or the index-0 derived script for wildcards.
     script_pubkey: ScriptBuf,
+    /// Whether this output is valid for mainnet.
     ok_for_mainnet: bool,
+    /// For wildcard descriptors, stores the original descriptor string for later derivation.
+    /// None for static addresses.
+    /// Note: We store the string instead of `Descriptor<DescriptorPublicKey>` because the latter
+    /// is not `Send + Sync` due to internal `RefCell` usage for taproot caching.
+    wildcard_descriptor_str: Option<String>,
 }
 
 impl CoinbaseRewardScript {
     /// Creates a new [`CoinbaseRewardScript`] from a descriptor string.
+    ///
+    /// Supports both static descriptors (e.g., `addr(bc1q...)`) and wildcard descriptors
+    /// (e.g., `wpkh(xpub.../0/*)`).
+    ///
+    /// For wildcard descriptors, the initial `script_pubkey` is derived at index 0.
+    /// Use [`has_wildcard()`](Self::has_wildcard) and [`wildcard_descriptor_str()`](Self::wildcard_descriptor_str)
+    /// to access the underlying descriptor for runtime derivation.
     pub fn from_descriptor(s: &str) -> Result<Self, Error> {
+        // First, try to parse as a wildcard descriptor (DescriptorPublicKey).
+        // This handles descriptors like wpkh(xpub.../0/*).
+        if let Ok(wildcard_desc) = s.parse::<Descriptor<DescriptorPublicKey>>() {
+            if wildcard_desc.has_wildcard() {
+                // Derive at index 0 to get the initial script_pubkey
+                let definite = wildcard_desc
+                    .at_derivation_index(0)
+                    .map_err(|e| Error::Miniscript(miniscript::Error::Unexpected(e.to_string())))?;
+
+                return Ok(Self {
+                    script_pubkey: definite.script_pubkey(),
+                    ok_for_mainnet: true,
+                    wildcard_descriptor_str: Some(s.to_string()),
+                });
+            }
+        }
+
         // Taproot descriptors cannot be parsed with `expression::Tree::from_str` and
         // need special handling. So we special-case them early and just pass to
         // rust-miniscript. In Miniscript 13 we will not need to do this.
@@ -31,6 +70,7 @@ impl CoinbaseRewardScript {
                 // Descriptors don't have a way to specify a network, so we assume
                 // they are OK to be used on mainnet.
                 ok_for_mainnet: true,
+                wildcard_descriptor_str: None,
             });
         }
 
@@ -45,6 +85,7 @@ impl CoinbaseRewardScript {
                 Ok(Self {
                     script_pubkey: addr.assume_checked_ref().script_pubkey(),
                     ok_for_mainnet: addr.is_valid_for_network(Network::Bitcoin),
+                    wildcard_descriptor_str: None,
                 })
             }
             "raw" => {
@@ -59,6 +100,7 @@ impl CoinbaseRewardScript {
                     script_pubkey: ScriptBuf::from_hex(&script_hex)?,
                     // Users of hex scriptpubkeys are on their own.
                     ok_for_mainnet: true,
+                    wildcard_descriptor_str: None,
                 })
             }
             _ => {
@@ -70,6 +112,7 @@ impl CoinbaseRewardScript {
                     // Descriptors don't have a way to specify a network, so we assume
                     // they are OK to be used on mainnet.
                     ok_for_mainnet: true,
+                    wildcard_descriptor_str: None,
                 })
             }
         }
@@ -84,9 +127,31 @@ impl CoinbaseRewardScript {
         self.ok_for_mainnet
     }
 
-    /// The `scriptPubKey` associated with the coinbase output
+    /// The `scriptPubKey` associated with the coinbase output.
+    ///
+    /// For wildcard descriptors, this returns the script derived at index 0.
+    /// To get scripts at other indices, use [`wildcard_descriptor_str()`](Self::wildcard_descriptor_str)
+    /// with [`XpubDerivator`](crate::config_helpers::XpubDerivator).
     pub fn script_pubkey(&self) -> ScriptBuf {
         self.script_pubkey.clone()
+    }
+
+    /// Returns `true` if this is a wildcard descriptor that supports rotation.
+    ///
+    /// Wildcard descriptors contain `/*` in the derivation path (e.g., `wpkh(xpub.../0/*)`).
+    /// When rotation is enabled, a new address should be derived for each block found.
+    pub fn has_wildcard(&self) -> bool {
+        self.wildcard_descriptor_str.is_some()
+    }
+
+    /// Returns the underlying wildcard descriptor string, if any.
+    ///
+    /// Use this with [`XpubDerivator`](crate::config_helpers::XpubDerivator) to derive
+    /// addresses at specific indices for coinbase rotation.
+    ///
+    /// Returns `None` for static addresses (non-wildcard descriptors).
+    pub fn wildcard_descriptor_str(&self) -> Option<&str> {
+        self.wildcard_descriptor_str.as_deref()
     }
 }
 
@@ -326,12 +391,15 @@ mod tests {
             CoinbaseRewardScript::from_descriptor("pkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/1'/2/3)").unwrap_err().to_string(),
             "Miniscript: key with hardened derivation steps cannot be a DerivedDescriptorKey",
         );
-        // no wildcards allowed (at least for now; gmax thinks it would be cool if we would
-        // instantiate it with the blockheight or something, but need to work out UX)
-        assert_eq!(
-            CoinbaseRewardScript::from_descriptor("pkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/*)").unwrap_err().to_string(),
-            "Miniscript: key with a wildcard cannot be a DerivedDescriptorKey",
-        );
+        // wildcards ARE now allowed - they create a wildcard descriptor for rotation
+        let wildcard_desc = CoinbaseRewardScript::from_descriptor(
+            "pkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/*)"
+        ).unwrap();
+        assert!(wildcard_desc.has_wildcard());
+        assert!(wildcard_desc.wildcard_descriptor_str().is_some());
+        // script_pubkey should be derived at index 0
+        assert!(!wildcard_desc.script_pubkey().is_empty());
+
         // No multipath descriptors allowed; this is not a wallet with change
         assert_eq!(
             CoinbaseRewardScript::from_descriptor("pkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/<0;1>)").unwrap_err().to_string(),
@@ -351,5 +419,70 @@ mod tests {
             CoinbaseRewardScript::from_descriptor("pkh(xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi)").unwrap_err().to_string(),
             "Miniscript: public keys must be 64, 66 or 130 characters in size",
         );
+    }
+
+    #[test]
+    fn test_wildcard_wpkh_descriptor() {
+        // wpkh with wildcard - common format for BIP84 wallets
+        let desc = CoinbaseRewardScript::from_descriptor(
+            "wpkh(tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp/0/*)"
+        ).unwrap();
+
+        assert!(desc.has_wildcard());
+        assert!(desc.wildcard_descriptor_str().is_some());
+
+        // script_pubkey should be a valid p2wpkh script (starts with 0x0014)
+        let script = desc.script_pubkey();
+        assert!(script.to_hex_string().starts_with("0014"));
+    }
+
+    #[test]
+    fn test_wildcard_tr_descriptor() {
+        // Taproot with wildcard
+        let desc = CoinbaseRewardScript::from_descriptor(
+            "tr(tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp/0/*)"
+        ).unwrap();
+
+        assert!(desc.has_wildcard());
+        assert!(desc.wildcard_descriptor_str().is_some());
+
+        // script_pubkey should be a valid p2tr script (starts with 0x5120)
+        let script = desc.script_pubkey();
+        assert!(script.to_hex_string().starts_with("5120"));
+    }
+
+    #[test]
+    fn test_non_wildcard_has_no_descriptor() {
+        // Static address - no wildcard
+        let desc = CoinbaseRewardScript::from_descriptor(
+            "addr(tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx)",
+        )
+        .unwrap();
+
+        assert!(!desc.has_wildcard());
+        assert!(desc.wildcard_descriptor_str().is_none());
+    }
+
+    #[test]
+    fn test_xpub_without_wildcard_has_no_descriptor() {
+        // xpub with fixed path (no wildcard)
+        let desc = CoinbaseRewardScript::from_descriptor(
+            "wpkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/0/0)"
+        ).unwrap();
+
+        assert!(!desc.has_wildcard());
+        assert!(desc.wildcard_descriptor_str().is_none());
+    }
+
+    #[test]
+    fn test_mainnet_xpub_wildcard() {
+        // Mainnet xpub with wildcard
+        let desc = CoinbaseRewardScript::from_descriptor(
+            "wpkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/0/*)"
+        ).unwrap();
+
+        assert!(desc.has_wildcard());
+        // Mainnet xpubs are allowed
+        assert!(desc.ok_for_mainnet());
     }
 }

--- a/stratum-apps/src/config_helpers/coinbase_output/serde_types.rs
+++ b/stratum-apps/src/config_helpers/coinbase_output/serde_types.rs
@@ -99,6 +99,8 @@ impl TryFrom<LegacyCoinbaseOutput> for super::CoinbaseRewardScript {
             script_pubkey,
             // legacy encoding gives no way to specify testnet or mainnet
             ok_for_mainnet: true,
+            // Legacy format doesn't support wildcards
+            wildcard_descriptor_str: None,
         })
     }
 }

--- a/stratum-apps/src/config_helpers/mod.rs
+++ b/stratum-apps/src/config_helpers/mod.rs
@@ -3,12 +3,16 @@
 //! This module provides utilities for:
 //! - Parsing configuration files (TOML, etc.)
 //! - Handling coinbase output specifications
+//! - xpub-based coinbase rotation
 //! - Setting up logging and tracing
 //!
 //! Originally from the `config_helpers_sv2` crate.
 
 mod coinbase_output;
 pub use coinbase_output::{CoinbaseRewardScript, Error as CoinbaseOutputError};
+
+mod xpub_derivation;
+pub use xpub_derivation::{XpubDerivationError, XpubDerivator};
 
 pub mod logging;
 

--- a/stratum-apps/src/config_helpers/xpub_derivation.rs
+++ b/stratum-apps/src/config_helpers/xpub_derivation.rs
@@ -1,0 +1,552 @@
+//! xpub-based coinbase address derivation with persistence.
+//!
+//! This module provides utilities for deriving sequential Bitcoin addresses from an
+//! extended public key (xpub/tpub) descriptor. It's designed for coinbase rotation
+//! in mining pools, where each block found uses a new address derived from the xpub.
+//!
+//! # Features
+//!
+//! - Parses wildcard descriptors like `wpkh(xpub.../0/*)`
+//! - Derives addresses at sequential indices
+//! - Persists the current index to disk (survives restarts)
+//! - Thread-safe (uses atomic operations for index)
+//!
+//! # Example
+//!
+//! ```ignore
+//! use stratum_apps::config_helpers::xpub_derivation::XpubDerivator;
+//! use std::path::PathBuf;
+//!
+//! let descriptor_str = "wpkh(tpub.../0/*)";
+//! let derivator = XpubDerivator::new(descriptor_str, 0, PathBuf::from("/tmp/index.dat")).unwrap();
+//!
+//! // Get current address (peek)
+//! let current = derivator.current_script_pubkey().unwrap();
+//!
+//! // Get next address and increment (rotate)
+//! let next = derivator.next_script_pubkey().unwrap();
+//! ```
+
+use miniscript::{bitcoin::ScriptBuf, descriptor::DescriptorPublicKey, Descriptor};
+use std::{
+    fmt, fs, io,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+/// Errors that can occur during xpub derivation.
+#[derive(Debug)]
+pub enum XpubDerivationError {
+    /// The descriptor does not have a wildcard.
+    NoWildcard,
+    /// Failed to parse the descriptor string.
+    ParseError(String),
+    /// Failed to derive at the specified index.
+    DerivationFailed(String),
+    /// Failed to persist the index to disk.
+    PersistenceError(io::Error),
+    /// Failed to create parent directories for index file.
+    CreateDirectoryError(io::Error),
+}
+
+impl fmt::Display for XpubDerivationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            XpubDerivationError::NoWildcard => {
+                write!(f, "descriptor does not have a wildcard (e.g., /0/*)")
+            }
+            XpubDerivationError::ParseError(msg) => {
+                write!(f, "failed to parse descriptor: {}", msg)
+            }
+            XpubDerivationError::DerivationFailed(msg) => {
+                write!(f, "failed to derive at index: {}", msg)
+            }
+            XpubDerivationError::PersistenceError(e) => {
+                write!(f, "failed to persist index: {}", e)
+            }
+            XpubDerivationError::CreateDirectoryError(e) => {
+                write!(f, "failed to create index file directory: {}", e)
+            }
+        }
+    }
+}
+
+impl std::error::Error for XpubDerivationError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            XpubDerivationError::PersistenceError(e) => Some(e),
+            XpubDerivationError::CreateDirectoryError(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+/// Manages xpub-based address derivation with persistence.
+///
+/// This struct holds a wildcard descriptor and maintains the current derivation
+/// index. The index is persisted to disk so that address derivation can resume
+/// after restarts without reusing addresses.
+///
+/// # Thread Safety
+///
+/// The derivation index uses `AtomicU32` for thread-safe access. Multiple threads
+/// can safely call `next_script_pubkey()` concurrently, though the order of
+/// indices assigned is not guaranteed.
+///
+/// Note: The descriptor is stored as a `String` and re-parsed on each derivation
+/// to ensure `Send + Sync` compatibility (miniscript's `Descriptor<DescriptorPublicKey>`
+/// uses internal `RefCell` for taproot caching which is not thread-safe).
+pub struct XpubDerivator {
+    /// The wildcard descriptor string (e.g., "wpkh(xpub.../0/*)")
+    descriptor_str: String,
+
+    /// Current derivation index (atomic for thread safety)
+    current_index: AtomicU32,
+
+    /// Path to persist the current index
+    index_file: PathBuf,
+}
+
+impl XpubDerivator {
+    /// Creates a new `XpubDerivator` from a wildcard descriptor.
+    ///
+    /// If the index file exists, loads the persisted index. Otherwise, uses
+    /// `start_index` as the initial index.
+    ///
+    /// Creates parent directories for the index file if they don't exist.
+    ///
+    /// # Arguments
+    ///
+    /// * `descriptor_str` - A wildcard descriptor string (must have `*` in derivation path)
+    /// * `start_index` - Initial derivation index if no persisted index exists
+    /// * `index_file` - Path to store the current index
+    ///
+    /// # Errors
+    ///
+    /// Returns `XpubDerivationError::ParseError` if the descriptor string is invalid.
+    /// Returns `XpubDerivationError::NoWildcard` if the descriptor doesn't have a wildcard.
+    /// Returns `XpubDerivationError::CreateDirectoryError` if parent directories can't be created.
+    pub fn new(
+        descriptor_str: &str,
+        start_index: u32,
+        index_file: PathBuf,
+    ) -> Result<Self, XpubDerivationError> {
+        // Parse the descriptor to validate it
+        let descriptor: Descriptor<DescriptorPublicKey> = descriptor_str
+            .parse()
+            .map_err(|e: miniscript::Error| XpubDerivationError::ParseError(e.to_string()))?;
+
+        // Verify the descriptor has a wildcard
+        if !descriptor.has_wildcard() {
+            return Err(XpubDerivationError::NoWildcard);
+        }
+
+        // Create parent directories if they don't exist
+        if let Some(parent) = index_file.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent).map_err(XpubDerivationError::CreateDirectoryError)?;
+            }
+        }
+
+        // Load persisted index or use start_index
+        let current_index = Self::load_index(&index_file, start_index);
+
+        Ok(Self {
+            descriptor_str: descriptor_str.to_string(),
+            current_index: AtomicU32::new(current_index),
+            index_file,
+        })
+    }
+
+    /// Returns the current derivation index without incrementing.
+    pub fn current_index(&self) -> u32 {
+        self.current_index.load(Ordering::SeqCst)
+    }
+
+    /// Derives the script pubkey at the current index without incrementing.
+    ///
+    /// This is useful for getting the current coinbase address without rotating.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if derivation fails (e.g., index out of range).
+    pub fn current_script_pubkey(&self) -> Result<ScriptBuf, XpubDerivationError> {
+        let index = self.current_index.load(Ordering::SeqCst);
+        self.derive_at_index(index)
+    }
+
+    /// Increments the index and derives the script pubkey at the new index.
+    ///
+    /// This is the main method for coinbase rotation. Call this AFTER a block is
+    /// found to rotate to the next address.
+    ///
+    /// The new index is persisted to disk. If persistence fails, a warning is
+    /// logged but the operation still succeeds (the index is still incremented
+    /// in memory).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if derivation fails.
+    pub fn next_script_pubkey(&self) -> Result<ScriptBuf, XpubDerivationError> {
+        // Atomically increment and get the NEW index
+        // fetch_add returns the old value, so add 1 to get the new value
+        let new_index = self.current_index.fetch_add(1, Ordering::SeqCst) + 1;
+
+        // Derive at the NEW index
+        let script = self.derive_at_index(new_index)?;
+
+        // Persist the new index
+        // Don't fail if persistence fails - just log a warning
+        if let Err(e) = self.persist_index() {
+            tracing::warn!(
+                "Failed to persist coinbase rotation index to {:?}: {}",
+                self.index_file,
+                e
+            );
+        }
+
+        Ok(script)
+    }
+
+    /// Derives the script pubkey at a specific index.
+    fn derive_at_index(&self, index: u32) -> Result<ScriptBuf, XpubDerivationError> {
+        // Re-parse descriptor each time for thread safety
+        // (miniscript's Descriptor<DescriptorPublicKey> is not Send + Sync due to RefCell)
+        let descriptor: Descriptor<DescriptorPublicKey> = self
+            .descriptor_str
+            .parse()
+            .map_err(|e: miniscript::Error| XpubDerivationError::ParseError(e.to_string()))?;
+
+        let definite = descriptor
+            .at_derivation_index(index)
+            .map_err(|e| XpubDerivationError::DerivationFailed(e.to_string()))?;
+
+        Ok(definite.script_pubkey())
+    }
+
+    /// Persists the current index to disk.
+    fn persist_index(&self) -> Result<(), XpubDerivationError> {
+        let index = self.current_index.load(Ordering::SeqCst);
+        fs::write(&self.index_file, index.to_string())
+            .map_err(XpubDerivationError::PersistenceError)
+    }
+
+    /// Loads the index from disk, or returns the default if the file doesn't exist
+    /// or can't be parsed.
+    fn load_index(path: &Path, default: u32) -> u32 {
+        match fs::read_to_string(path) {
+            Ok(contents) => contents.trim().parse().unwrap_or(default),
+            Err(_) => default,
+        }
+    }
+}
+
+impl fmt::Debug for XpubDerivator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("XpubDerivator")
+            .field("descriptor", &self.descriptor_str)
+            .field("current_index", &self.current_index.load(Ordering::SeqCst))
+            .field("index_file", &self.index_file)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    // Test tpub from BIP84 test vectors
+    const TEST_TPUB: &str = "wpkh(tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp/0/*)";
+
+    #[test]
+    fn test_new_with_wildcard() {
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("index.dat");
+
+        let derivator = XpubDerivator::new(TEST_TPUB, 0, index_file).unwrap();
+
+        assert_eq!(derivator.current_index(), 0);
+    }
+
+    #[test]
+    fn test_new_without_wildcard_fails() {
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("index.dat");
+
+        // Descriptor without wildcard
+        let desc_str = "wpkh(tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp/0/0)";
+
+        let result = XpubDerivator::new(desc_str, 0, index_file);
+        assert!(matches!(result, Err(XpubDerivationError::NoWildcard)));
+    }
+
+    #[test]
+    fn test_new_with_invalid_descriptor_fails() {
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("index.dat");
+
+        let result = XpubDerivator::new("invalid_descriptor", 0, index_file);
+        assert!(matches!(result, Err(XpubDerivationError::ParseError(_))));
+    }
+
+    #[test]
+    fn test_current_script_pubkey_does_not_increment() {
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("index.dat");
+
+        let derivator = XpubDerivator::new(TEST_TPUB, 0, index_file).unwrap();
+
+        // Call current_script_pubkey multiple times
+        let script1 = derivator.current_script_pubkey().unwrap();
+        let script2 = derivator.current_script_pubkey().unwrap();
+        let script3 = derivator.current_script_pubkey().unwrap();
+
+        // All should be the same
+        assert_eq!(script1, script2);
+        assert_eq!(script2, script3);
+
+        // Index should still be 0
+        assert_eq!(derivator.current_index(), 0);
+    }
+
+    #[test]
+    fn test_next_script_pubkey_increments() {
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("index.dat");
+
+        let derivator = XpubDerivator::new(TEST_TPUB, 0, index_file).unwrap();
+
+        // Get first address
+        let script0 = derivator.next_script_pubkey().unwrap();
+        assert_eq!(derivator.current_index(), 1);
+
+        // Get second address
+        let script1 = derivator.next_script_pubkey().unwrap();
+        assert_eq!(derivator.current_index(), 2);
+
+        // Get third address
+        let script2 = derivator.next_script_pubkey().unwrap();
+        assert_eq!(derivator.current_index(), 3);
+
+        // All should be different
+        assert_ne!(script0, script1);
+        assert_ne!(script1, script2);
+        assert_ne!(script0, script2);
+    }
+
+    #[test]
+    fn test_index_persistence() {
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("subdir/index.dat");
+
+        // Create derivator and advance index
+        {
+            let derivator = XpubDerivator::new(TEST_TPUB, 0, index_file.clone()).unwrap();
+
+            // Advance to index 5
+            for _ in 0..5 {
+                derivator.next_script_pubkey().unwrap();
+            }
+            assert_eq!(derivator.current_index(), 5);
+        }
+
+        // Create new derivator with same index file - should resume at 5
+        {
+            let derivator = XpubDerivator::new(TEST_TPUB, 0, index_file).unwrap();
+
+            assert_eq!(derivator.current_index(), 5);
+        }
+    }
+
+    #[test]
+    fn test_start_index() {
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("index.dat");
+
+        let derivator = XpubDerivator::new(TEST_TPUB, 100, index_file).unwrap();
+
+        assert_eq!(derivator.current_index(), 100);
+
+        let script = derivator.next_script_pubkey().unwrap();
+        assert_eq!(derivator.current_index(), 101);
+
+        // Should be different from index 0
+        let dir2 = tempdir().unwrap();
+        let derivator2 = XpubDerivator::new(TEST_TPUB, 0, dir2.path().join("index.dat")).unwrap();
+        let script0 = derivator2.next_script_pubkey().unwrap();
+
+        assert_ne!(script, script0);
+    }
+
+    #[test]
+    fn test_creates_parent_directories() {
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("a/b/c/index.dat");
+
+        let derivator = XpubDerivator::new(TEST_TPUB, 0, index_file.clone()).unwrap();
+
+        // Should be able to persist
+        derivator.next_script_pubkey().unwrap();
+
+        // File should exist
+        assert!(index_file.exists());
+    }
+
+    #[test]
+    fn test_mainnet_xpub() {
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("index.dat");
+
+        // Mainnet xpub
+        let desc_str = "wpkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/0/*)";
+
+        let derivator = XpubDerivator::new(desc_str, 0, index_file).unwrap();
+
+        // Should work fine
+        let script = derivator.next_script_pubkey().unwrap();
+        assert!(!script.is_empty());
+    }
+
+    #[test]
+    fn test_taproot_descriptor() {
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("index.dat");
+
+        // Taproot descriptor with wildcard
+        let desc_str = "tr(tpubD6NzVbkrYhZ4XgiXtGrdW5XDAPFCL9h7we1vwNCpn8tGbBcgfVYjXyhWo4E1xkh56hjod1RhGjxbaTLV3X4FyWuejifB9jusQ46QzG87VKp/0/*)";
+
+        let derivator = XpubDerivator::new(desc_str, 0, index_file).unwrap();
+
+        let script0 = derivator.next_script_pubkey().unwrap();
+        let script1 = derivator.next_script_pubkey().unwrap();
+
+        assert_ne!(script0, script1);
+        // Taproot scripts start with 0x5120
+        assert!(script0.to_hex_string().starts_with("5120"));
+    }
+
+    /// Validates derivation against known test vectors.
+    ///
+    /// This test uses a specific tpub and validates that the derived scripts
+    /// match the expected values computed from the known public keys.
+    ///
+    /// Descriptor: wpkh(tpubDDHYkDsJ8XB1LLjMNrk5gXsmze87LRkWoNqprdXPud9Yx3ZfsjZZJEqscUgSRLJ1EG77KSKygC9uNAeDtgHsLtvH93MnPF2M9Vq5WvGvcLw/0/*)
+    ///
+    /// Expected derived scripts at each index (P2WPKH format: 0014<20-byte-hash>):
+    /// Index 0: 0014798fb52bc77ba8e028dfad1b522505223c7e7ca0
+    /// Index 1: 00143acc8d6d349a24a198fb9eec0e27b822c589d407
+    /// Index 2: 0014dd4da77967b0a8c59ee3026af582de496abad124
+    /// Index 3: 001401b85a64c3c8d8dcf46f49230d938ec1245fcd8e
+    /// Index 4: 0014a72ae2dddcc84c99a0abe43f4fbef1a46d153b8e
+    #[test]
+    fn test_known_derivation_vectors() {
+        const KNOWN_TPUB: &str = "wpkh(tpubDDHYkDsJ8XB1LLjMNrk5gXsmze87LRkWoNqprdXPud9Yx3ZfsjZZJEqscUgSRLJ1EG77KSKygC9uNAeDtgHsLtvH93MnPF2M9Vq5WvGvcLw/0/*)";
+
+        // Expected scripts at each index (P2WPKH format: 0014<20-byte-hash>)
+        let expected_scripts = [
+            "0014798fb52bc77ba8e028dfad1b522505223c7e7ca0", // Index 0
+            "00143acc8d6d349a24a198fb9eec0e27b822c589d407", // Index 1
+            "0014dd4da77967b0a8c59ee3026af582de496abad124", // Index 2
+            "001401b85a64c3c8d8dcf46f49230d938ec1245fcd8e", // Index 3
+            "0014a72ae2dddcc84c99a0abe43f4fbef1a46d153b8e", // Index 4
+        ];
+
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("index.dat");
+
+        let derivator = XpubDerivator::new(KNOWN_TPUB, 0, index_file).unwrap();
+
+        // Verify index 0 via current_script_pubkey
+        let script0 = derivator.current_script_pubkey().unwrap();
+        assert_eq!(
+            script0.to_hex_string(),
+            expected_scripts[0],
+            "Script mismatch at index 0"
+        );
+
+        // Verify indices 1-4 via next_script_pubkey (which increments then derives)
+        for (i, expected_script) in expected_scripts.iter().enumerate().skip(1) {
+            let script = derivator.next_script_pubkey().unwrap();
+            assert_eq!(
+                script.to_hex_string(),
+                *expected_script,
+                "Script mismatch at index {}: expected {}, got {}",
+                i,
+                expected_script,
+                script.to_hex_string()
+            );
+        }
+    }
+
+    /// Test the complete rotation flow simulating pool behavior.
+    ///
+    /// This simulates:
+    /// 1. Start at index 2 (from persisted file)
+    /// 2. Verify current_script_pubkey() returns index 2's script
+    /// 3. After block found, next_script_pubkey() returns index 3's script
+    /// 4. After another block, next_script_pubkey() returns index 4's script
+    /// 5. Restart and verify resumption at index 4
+    #[test]
+    fn test_rotation_flow_with_known_vectors() {
+        const KNOWN_TPUB: &str = "wpkh(tpubDDHYkDsJ8XB1LLjMNrk5gXsmze87LRkWoNqprdXPud9Yx3ZfsjZZJEqscUgSRLJ1EG77KSKygC9uNAeDtgHsLtvH93MnPF2M9Vq5WvGvcLw/0/*)";
+
+        let expected_scripts = [
+            "0014798fb52bc77ba8e028dfad1b522505223c7e7ca0", // Index 0
+            "00143acc8d6d349a24a198fb9eec0e27b822c589d407", // Index 1
+            "0014dd4da77967b0a8c59ee3026af582de496abad124", // Index 2
+            "001401b85a64c3c8d8dcf46f49230d938ec1245fcd8e", // Index 3
+            "0014a72ae2dddcc84c99a0abe43f4fbef1a46d153b8e", // Index 4
+        ];
+
+        let dir = tempdir().unwrap();
+        let index_file = dir.path().join("index.dat");
+
+        // Simulate: index file contains "2" (pool was at index 2)
+        fs::write(&index_file, "2").unwrap();
+
+        let derivator = XpubDerivator::new(KNOWN_TPUB, 0, index_file.clone()).unwrap();
+
+        // Step 1: Should load index 2 from file
+        assert_eq!(derivator.current_index(), 2);
+
+        // Step 2: current_script_pubkey() should return index 2's script
+        let initial_script = derivator.current_script_pubkey().unwrap();
+        assert_eq!(
+            initial_script.to_hex_string(),
+            expected_scripts[2],
+            "Initial script should be at index 2"
+        );
+
+        // Step 3: First block found - rotate to index 3
+        let script_after_first_block = derivator.next_script_pubkey().unwrap();
+        assert_eq!(derivator.current_index(), 3);
+        assert_eq!(
+            script_after_first_block.to_hex_string(),
+            expected_scripts[3],
+            "After first rotation, script should be at index 3"
+        );
+
+        // Step 4: Second block found - rotate to index 4
+        let script_after_second_block = derivator.next_script_pubkey().unwrap();
+        assert_eq!(derivator.current_index(), 4);
+        assert_eq!(
+            script_after_second_block.to_hex_string(),
+            expected_scripts[4],
+            "After second rotation, script should be at index 4"
+        );
+
+        // Verify file was updated
+        let contents = fs::read_to_string(&index_file).unwrap();
+        assert_eq!(contents, "4");
+
+        // Step 5: Simulate restart - create new derivator from same file
+        let derivator2 = XpubDerivator::new(KNOWN_TPUB, 0, index_file).unwrap();
+        assert_eq!(derivator2.current_index(), 4);
+        assert_eq!(
+            derivator2.current_script_pubkey().unwrap().to_hex_string(),
+            expected_scripts[4],
+            "After restart, should resume at index 4"
+        );
+    }
+}


### PR DESCRIPTION
Adds deterministic address derivation for coinbase outputs using HD wallet descriptors via miniscript crate. Each block found gets a fresh address derived from an extended public key.

This is ideal for privacy and QC resistance.

The code checks for /* in the descriptor via `has_wildcard()`. No wildcard = no rotation

## New Config Options
```toml
# Only needed if using wildcard descriptor
coinbase_index_file = "/var/lib/pool/coinbase_index.dat"  # Required with wildcard
coinbase_start_index = 0  # Optional, defaults to 0
```

Existing configs work unchanged. Defaults preserve current behavior and coinbase_index_file = None means no rotation.

## Testnet4 Validation
Two blocks mined on testnet4 (Jan 28, 2026):
- Index 4: tb1q5u4w9hwuepxfng9tusl5l0h353k32wuwv56s5x (block (https://mempool.space/testnet4/block/0000000000000000b2d658e434cb1383eb41853a1b8bb23df1993a6c9036f2f7))
- Index 5: tb1qlqym3pzn76qz5ecj7y36rwrgxrr83pnwxtc5rp (block (https://mempool.space/testnet4/block/00000000000000005a65b2d963bc3117c3b0f92d5674483e7ab6af1e03d51267))

Many more blocks have been found using this code. Any TN4 block with signature `whirly-pool` is a result of this rotation feature.

Blog: https://average-gary.github.io/sv2-apps/