### PR TITLE
fix(channels): Update channel nominal hashrate from downstream vardiff estimate

### DIFF
--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -277,7 +277,7 @@ name = "binary_codec_sv2"
 version = "3.0.0"
 source = "git+https://github.com/stratum-mining/stratum?rev=v1.5.0#30405fab90ae02a08ec05abade993610dc9d68f6"
 dependencies = [
- "buffer_sv2 2.0.0 (git+https://github.com/stratum-mining/stratum?rev=v1.5.0)",
+ "buffer_sv2 2.0.0",
 ]
 
 [[package]]
@@ -291,10 +291,10 @@ dependencies = [
 
 [[package]]
 name = "binary_sv2"
-version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "5.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "buffer_sv2 2.0.0 (git+https://github.com/stratum-mining/stratum?branch=main)",
+ "buffer_sv2 3.0.1",
  "derive_codec_sv2 1.1.2",
 ]
 
@@ -454,16 +454,15 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "2.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?rev=v1.5.0#30405fab90ae02a08ec05abade993610dc9d68f6"
 dependencies = [
  "aes-gcm",
- "generic-array",
 ]
 
 [[package]]
 name = "buffer_sv2"
-version = "2.0.0"
-source = "git+https://github.com/stratum-mining/stratum?rev=v1.5.0#30405fab90ae02a08ec05abade993610dc9d68f6"
+version = "3.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "aes-gcm",
 ]
@@ -589,15 +588,14 @@ dependencies = [
 
 [[package]]
 name = "channels_sv2"
-version = "3.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "3.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
+ "binary_sv2 5.0.1",
  "bitcoin",
- "common_messages_sv2 6.0.2",
  "mining_sv2 7.0.0",
  "primitive-types",
- "template_distribution_sv2 4.0.2",
+ "template_distribution_sv2 5.0.0",
  "tracing",
 ]
 
@@ -658,7 +656,7 @@ version = "3.0.1"
 source = "git+https://github.com/stratum-mining/stratum?rev=v1.5.0#30405fab90ae02a08ec05abade993610dc9d68f6"
 dependencies = [
  "binary_sv2 4.0.0",
- "buffer_sv2 2.0.0 (git+https://github.com/stratum-mining/stratum?rev=v1.5.0)",
+ "buffer_sv2 2.0.0",
  "framing_sv2 5.0.1",
  "noise_sv2 1.4.0",
  "rand",
@@ -667,13 +665,13 @@ dependencies = [
 
 [[package]]
 name = "codec_sv2"
-version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "4.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
- "buffer_sv2 2.0.0 (git+https://github.com/stratum-mining/stratum?branch=main)",
- "framing_sv2 6.0.0",
- "noise_sv2 1.4.1",
+ "binary_sv2 5.0.1",
+ "buffer_sv2 3.0.1",
+ "framing_sv2 6.0.1",
+ "noise_sv2 1.4.2",
  "rand",
  "tracing",
 ]
@@ -694,10 +692,10 @@ dependencies = [
 
 [[package]]
 name = "common_messages_sv2"
-version = "6.0.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "7.0.0"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
+ "binary_sv2 5.0.1",
 ]
 
 [[package]]
@@ -929,7 +927,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 
 [[package]]
 name = "digest"
@@ -1036,9 +1034,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
+ "binary_sv2 5.0.1",
 ]
 
 [[package]]
@@ -1097,18 +1095,18 @@ version = "5.0.1"
 source = "git+https://github.com/stratum-mining/stratum?rev=v1.5.0#30405fab90ae02a08ec05abade993610dc9d68f6"
 dependencies = [
  "binary_sv2 4.0.0",
- "buffer_sv2 2.0.0 (git+https://github.com/stratum-mining/stratum?rev=v1.5.0)",
+ "buffer_sv2 2.0.0",
  "noise_sv2 1.4.0",
 ]
 
 [[package]]
 name = "framing_sv2"
-version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "6.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
- "buffer_sv2 2.0.0 (git+https://github.com/stratum-mining/stratum?branch=main)",
- "noise_sv2 1.4.1",
+ "binary_sv2 5.0.1",
+ "buffer_sv2 3.0.1",
+ "noise_sv2 1.4.2",
 ]
 
 [[package]]
@@ -1272,17 +1270,17 @@ dependencies = [
 
 [[package]]
 name = "handlers_sv2"
-version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "0.2.2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
- "common_messages_sv2 6.0.2",
+ "binary_sv2 5.0.1",
+ "common_messages_sv2 7.0.0",
  "extensions_sv2",
- "framing_sv2 6.0.0",
+ "framing_sv2 6.0.1",
  "job_declaration_sv2 6.0.0",
  "mining_sv2 7.0.0",
- "parsers_sv2 0.2.1",
- "template_distribution_sv2 4.0.2",
+ "parsers_sv2 0.2.2",
+ "template_distribution_sv2 5.0.0",
  "trait-variant",
 ]
 
@@ -1709,9 +1707,9 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
+ "binary_sv2 5.0.1",
 ]
 
 [[package]]
@@ -1869,9 +1867,9 @@ dependencies = [
 [[package]]
 name = "mining_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
+ "binary_sv2 5.0.1",
 ]
 
 [[package]]
@@ -1961,14 +1959,12 @@ dependencies = [
 
 [[package]]
 name = "noise_sv2"
-version = "1.4.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "1.4.2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
- "generic-array",
  "rand",
- "rand_chacha",
  "secp256k1 0.28.2",
 ]
 
@@ -2101,16 +2097,16 @@ dependencies = [
 
 [[package]]
 name = "parsers_sv2"
-version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "0.2.2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
- "common_messages_sv2 6.0.2",
+ "binary_sv2 5.0.1",
+ "common_messages_sv2 7.0.0",
  "extensions_sv2",
- "framing_sv2 6.0.0",
+ "framing_sv2 6.0.1",
  "job_declaration_sv2 6.0.0",
  "mining_sv2 7.0.0",
- "template_distribution_sv2 4.0.2",
+ "template_distribution_sv2 5.0.0",
 ]
 
 [[package]]
@@ -2826,35 +2822,35 @@ dependencies = [
 
 [[package]]
 name = "stratum-core"
-version = "0.2.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "0.2.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
+ "binary_sv2 5.0.1",
  "bitcoin",
- "buffer_sv2 2.0.0 (git+https://github.com/stratum-mining/stratum?branch=main)",
- "channels_sv2 3.0.0",
- "codec_sv2 4.0.0",
- "common_messages_sv2 6.0.2",
+ "buffer_sv2 3.0.1",
+ "channels_sv2 3.0.1",
+ "codec_sv2 4.0.1",
+ "common_messages_sv2 7.0.0",
  "extensions_sv2",
- "framing_sv2 6.0.0",
- "handlers_sv2 0.2.1",
+ "framing_sv2 6.0.1",
+ "handlers_sv2 0.2.2",
  "job_declaration_sv2 6.0.0",
  "mining_sv2 7.0.0",
- "noise_sv2 1.4.1",
- "parsers_sv2 0.2.1",
+ "noise_sv2 1.4.2",
+ "parsers_sv2 0.2.2",
  "stratum_translation",
  "sv1_api",
- "template_distribution_sv2 4.0.2",
+ "template_distribution_sv2 5.0.0",
 ]
 
 [[package]]
 name = "stratum_translation"
 version = "0.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
+ "binary_sv2 5.0.1",
  "bitcoin",
- "channels_sv2 3.0.0",
+ "channels_sv2 3.0.1",
  "mining_sv2 7.0.0",
  "sv1_api",
  "tracing",
@@ -2874,13 +2870,12 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sv1_api"
-version = "2.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "2.1.3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
+ "binary_sv2 5.0.1",
  "bitcoin_hashes 0.3.2",
  "byteorder",
- "hex",
  "serde",
  "serde_json",
  "tracing",
@@ -2963,10 +2958,10 @@ dependencies = [
 
 [[package]]
 name = "template_distribution_sv2"
-version = "4.0.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "5.0.0"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
- "binary_sv2 5.0.0",
+ "binary_sv2 5.0.1",
 ]
 
 [[package]]

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -272,8 +272,8 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "binary_sv2"
-version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "5.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -427,11 +427,10 @@ dependencies = [
 
 [[package]]
 name = "buffer_sv2"
-version = "2.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "3.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "aes-gcm",
- "generic-array",
 ]
 
 [[package]]
@@ -540,12 +539,11 @@ dependencies = [
 
 [[package]]
 name = "channels_sv2"
-version = "3.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "3.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "bitcoin",
- "common_messages_sv2",
  "mining_sv2",
  "primitive-types",
  "template_distribution_sv2",
@@ -611,8 +609,8 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codec_sv2"
-version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "4.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -639,8 +637,8 @@ dependencies = [
 
 [[package]]
 name = "common_messages_sv2"
-version = "6.0.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "7.0.0"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
 ]
@@ -808,7 +806,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 
 [[package]]
 name = "digest"
@@ -937,7 +935,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
 ]
@@ -998,8 +996,8 @@ dependencies = [
 
 [[package]]
 name = "framing_sv2"
-version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "6.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1134,8 +1132,8 @@ dependencies = [
 
 [[package]]
 name = "handlers_sv2"
-version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "0.2.2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1540,7 +1538,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
 ]
@@ -1661,7 +1659,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
 ]
@@ -1700,14 +1698,12 @@ dependencies = [
 
 [[package]]
 name = "noise_sv2"
-version = "1.4.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "1.4.2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
- "generic-array",
  "rand",
- "rand_chacha",
  "secp256k1 0.28.2",
 ]
 
@@ -1826,8 +1822,8 @@ dependencies = [
 
 [[package]]
 name = "parsers_sv2"
-version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "0.2.2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2468,8 +2464,8 @@ dependencies = [
 
 [[package]]
 name = "stratum-core"
-version = "0.2.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "0.2.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2492,7 +2488,7 @@ dependencies = [
 [[package]]
 name = "stratum_translation"
 version = "0.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2516,13 +2512,12 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sv1_api"
-version = "2.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "2.1.3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",
  "byteorder",
- "hex",
  "serde",
  "serde_json",
  "tracing",
@@ -2564,8 +2559,8 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "template_distribution_sv2"
-version = "4.0.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "5.0.0"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
 ]

--- a/pool-apps/Cargo.lock
+++ b/pool-apps/Cargo.lock
@@ -272,8 +272,8 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 
 [[package]]
 name = "binary_sv2"
-version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "5.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -418,11 +418,10 @@ dependencies = [
 
 [[package]]
 name = "buffer_sv2"
-version = "2.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "3.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "aes-gcm",
- "generic-array",
 ]
 
 [[package]]
@@ -531,12 +530,11 @@ dependencies = [
 
 [[package]]
 name = "channels_sv2"
-version = "3.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "3.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "bitcoin",
- "common_messages_sv2",
  "mining_sv2",
  "primitive-types",
  "template_distribution_sv2",
@@ -602,8 +600,8 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "codec_sv2"
-version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "4.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -630,8 +628,8 @@ dependencies = [
 
 [[package]]
 name = "common_messages_sv2"
-version = "6.0.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "7.0.0"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
 ]
@@ -785,7 +783,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 
 [[package]]
 name = "digest"
@@ -914,7 +912,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
 ]
@@ -975,8 +973,8 @@ dependencies = [
 
 [[package]]
 name = "framing_sv2"
-version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "6.0.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1111,8 +1109,8 @@ dependencies = [
 
 [[package]]
 name = "handlers_sv2"
-version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "0.2.2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1501,7 +1499,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "job_declaration_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
 ]
@@ -1622,7 +1620,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
 ]
@@ -1661,14 +1659,12 @@ dependencies = [
 
 [[package]]
 name = "noise_sv2"
-version = "1.4.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "1.4.2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
- "generic-array",
  "rand",
- "rand_chacha",
  "secp256k1 0.28.2",
 ]
 
@@ -1787,8 +1783,8 @@ dependencies = [
 
 [[package]]
 name = "parsers_sv2"
-version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "0.2.2"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2445,8 +2441,8 @@ dependencies = [
 
 [[package]]
 name = "stratum-core"
-version = "0.2.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "0.2.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2512,8 +2508,8 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "template_distribution_sv2"
-version = "4.0.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#855ed9fe7c8aad1160043fecd365ed5c3c2429c2"
+version = "5.0.0"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#c05fd9966b7a66ea8016b7463c859e8e35a5c77a"
 dependencies = [
  "binary_sv2",
 ]


### PR DESCRIPTION
In aggregated mode, update the upstream extended channel's nominal hashrate to match the downstream vardiff estimate before forwarding UpdateChannel. In non-aggregated mode, update the specific extended channel's nominal hashrate. This ensures monitoring reports values consistent with downstream vardiff estimates.

See [stratum-mining/sv2-apps#242](https://github.com/stratum-mining/sv2-apps/issues/242)
