### PR TITLE
add `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Rust build output
+target/
+**/target/
+
+# Git
+.git
+.gitignore
+
+# Docker
+Dockerfile
+.dockerignore
+
+# OS junk
+.DS_Store
+Thumbs.db
+
+# Editors / IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+*.log


### PR DESCRIPTION
closes #249 

much better now:
<img width="1370" height="378" alt="image" src="https://github.com/user-attachments/assets/f75df234-dcf2-4583-a5be-ed8089275e9d" />


This will only affects local builds, because in the CI the build always occurs in a fresh context