### PR TITLE
Move test suite to tests.yaml workflow (Fixes #235)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,69 +8,10 @@ on:
     branches:
       - main
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  test:
-    name: Test Suite
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install capnp dependencies (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install -y capnproto libcapnp-dev
-
-      - name: Install capnp dependencies (macOS)
-        if: matrix.os == 'macos-latest'
-        run: brew install capnp
-
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@1.85
-
-      - name: Test stratum-apps workspace
-        run: cargo test --manifest-path=stratum-apps/Cargo.toml --all-features
-
-      - name: Test pool
-        run: cargo test --manifest-path=pool-apps/pool/Cargo.toml
-
-      - name: Test jd-server (separate workspace)
-        run: cargo test --manifest-path=pool-apps/jd-server/Cargo.toml
-
-      - name: Test miner applications workspace
-        run: cargo test --manifest-path=miner-apps/Cargo.toml
-
-      - name: Test mining-device (separate workspace)
-        run: cargo test --manifest-path=miner-apps/mining-device/Cargo.toml
-        
-      - name: Test bitcoin-core-sv2 crate
-        run: cargo test --manifest-path=bitcoin-core-sv2/Cargo.toml
-
-      # We have a separate workflow to run integration tests (see integration-tests.yaml)
-
   clippy:
     name: Clippy Check
     runs-on: ubuntu-latest
@@ -122,15 +63,12 @@ jobs:
           cargo fmt --all --manifest-path=bitcoin-core-sv2/Cargo.toml -- --check
 
   machete:
-    name: Cargo Machete
+    name: Unused Dependencies (cargo machete)
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
-
       - name: Run cargo-machete
         uses: bnjbvr/cargo-machete@main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,56 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test Suite
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install capnp dependencies (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install -y capnproto libcapnp-dev
+      - name: Install capnp dependencies (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install capnp
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@1.85
+      - name: Test stratum-apps workspace
+        run: cargo test --manifest-path=stratum-apps/Cargo.toml --all-features
+      - name: Test pool
+        run: cargo test --manifest-path=pool-apps/pool/Cargo.toml
+      - name: Test jd-server (separate workspace)
+        run: cargo test --manifest-path=pool-apps/jd-server/Cargo.toml
+      - name: Test miner applications workspace
+        run: cargo test --manifest-path=miner-apps/Cargo.toml
+      - name: Test mining-device (separate workspace)
+        run: cargo test --manifest-path=miner-apps/mining-device/Cargo.toml
+      - name: Test bitcoin-core-sv2 crate
+        run: cargo test --manifest-path=bitcoin-core-sv2/Cargo.toml

--- a/stratum-apps/src/config_helpers/toml.rs
+++ b/stratum-apps/src/config_helpers/toml.rs
@@ -2,8 +2,7 @@ use serde::{
     de::{self, Deserializer},
     Deserialize,
 };
-use std::path::PathBuf;
-use std::time::Duration;
+use std::{path::PathBuf, time::Duration};
 
 /// Deserialize a duration from a TOML string.
 pub fn duration_from_toml<'de, D>(deserializer: D) -> Result<Duration, D::Error>
@@ -66,8 +65,7 @@ mod tests {
     use super::*;
     use ext_config::{Config, File, FileFormat};
     use serde::Deserialize;
-    use std::env;
-    use std::path::PathBuf;
+    use std::{env, path::PathBuf};
 
     #[derive(Debug, Deserialize)]
     struct TestConfig {

--- a/stratum-apps/src/tp_type.rs
+++ b/stratum-apps/src/tp_type.rs
@@ -1,5 +1,4 @@
-use crate::config_helpers::opt_path_from_toml;
-use crate::key_utils::Secp256k1PublicKey;
+use crate::{config_helpers::opt_path_from_toml, key_utils::Secp256k1PublicKey};
 use std::path::PathBuf;
 
 /// Bitcoin network for determining node.sock location


### PR DESCRIPTION
## Description
This PR moves the test suite execution from the main `ci.yaml` workflow to a dedicated `tests.yaml` workflow, resolving issue #235.

## Changes
- Created `.github/workflows/tests.yaml` to handle `cargo build` and `cargo test`.
- Updated `.github/workflows/ci.yaml` to remove test steps, keeping only `fmt`, `clippy`, and `machete` checks.
- Ensured `capnproto` dependencies are installed in both workflows so tests and linting pass on Ubuntu/macOS.

## Verification
- CI workflow should now only run linting and static analysis.
- Tests workflow should now run the build and test suite separately.