### PR TITLE
sniffer: add assert_message_not_present_for for reliable negative assertions

### DIFF
--- a/integration-tests/lib/interceptor.rs
+++ b/integration-tests/lib/interceptor.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::types::MsgType;
 use stratum_apps::stratum_core::parsers_sv2::AnyMessage;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MessageDirection {
     ToDownstream,
     ToUpstream,

--- a/integration-tests/lib/mock_roles.rs
+++ b/integration-tests/lib/mock_roles.rs
@@ -248,9 +248,12 @@ mod tests {
     use super::*;
     use crate::{interceptor::MessageDirection, start_sniffer};
     use std::net::TcpListener;
-    use stratum_apps::stratum_core::common_messages_sv2::{
-        MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
-        MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+    use stratum_apps::stratum_core::{
+        common_messages_sv2::{
+            MESSAGE_TYPE_SETUP_CONNECTION, MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
+            MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+        },
+        mining_sv2::MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
     };
 
     #[tokio::test]
@@ -294,6 +297,69 @@ mod tests {
                 MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
             )
             .await;
+    }
+
+    #[tokio::test]
+    async fn test_assert_message_not_present() {
+        let port = TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        let upstream_socket_addr = SocketAddr::from(([127, 0, 0, 1], port));
+
+        let _mock_upstream = MockUpstream::new(
+            upstream_socket_addr,
+            WithSetup::yes_with_defaults(Protocol::MiningProtocol, 0),
+        )
+        .start()
+        .await;
+
+        let (sniffer, sniffer_addr) = start_sniffer(
+            "assert_not_present_test",
+            upstream_socket_addr,
+            false,
+            vec![],
+            None,
+        );
+
+        let _send_to_upstream = MockDownstream::new(
+            sniffer_addr,
+            WithSetup::yes_with_defaults(Protocol::MiningProtocol, 0),
+        )
+        .start()
+        .await;
+
+        sniffer
+            .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+            .await;
+
+        // SetupConnection was sent, so has_message_type should find it
+        assert!(
+            sniffer.has_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+        );
+
+        // OpenExtendedMiningChannel was never sent, so assert_message_not_present should return true
+        assert!(
+            sniffer
+                .assert_message_not_present(
+                    MessageDirection::ToUpstream,
+                    MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
+                    std::time::Duration::from_secs(1),
+                )
+                .await
+        );
+
+        // SetupConnection IS present, so assert_message_not_present should return false
+        assert!(
+            !sniffer
+                .assert_message_not_present(
+                    MessageDirection::ToUpstream,
+                    MESSAGE_TYPE_SETUP_CONNECTION,
+                    std::time::Duration::from_millis(200),
+                )
+                .await
+        );
     }
 
     #[tokio::test]

--- a/integration-tests/lib/sniffer.rs
+++ b/integration-tests/lib/sniffer.rs
@@ -199,23 +199,31 @@ impl<'a> Sniffer<'a> {
         }
     }
 
-    /// Assert message is not present in the queue
+    /// Assert message is not present in the queue over a given duration.
     ///
-    /// Will return true if the message is not present in the queue, false otherwise.
+    /// Polls the queue every 100ms for `deadline`, returning `false` immediately
+    /// if the message appears at any point. Returns `true` only after the full duration
+    /// passes with no match.
+    ///
+    /// The queue should be cleared before calling this to avoid matching stale messages.
+    /// Use [`Sniffer::wait_for_message_type_and_clean_queue`] or [`Sniffer::clean_queue`]
+    /// to clear the queue first.
     pub async fn assert_message_not_present(
         &self,
         message_direction: MessageDirection,
         message_type: u8,
+        deadline: std::time::Duration,
     ) -> bool {
-        let has_message_type = match message_direction {
-            MessageDirection::ToDownstream => {
-                self.messages_from_upstream.has_message_type(message_type)
+        let start = std::time::Instant::now();
+
+        while start.elapsed() < deadline {
+            if self.has_message_type(message_direction, message_type) {
+                return false;
             }
-            MessageDirection::ToUpstream => {
-                self.messages_from_downstream.has_message_type(message_type)
-            }
-        };
-        !has_message_type
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        true
     }
 
     /// Similar to `[Sniffer::wait_for_message_type]` but also removes the messages from the queue
@@ -268,11 +276,7 @@ impl<'a> Sniffer<'a> {
     }
 
     /// Checks whether the sniffer has received a message of the specified type.
-    pub fn includes_message_type(
-        &self,
-        message_direction: MessageDirection,
-        message_type: u8,
-    ) -> bool {
+    pub fn has_message_type(&self, message_direction: MessageDirection, message_type: u8) -> bool {
         match message_direction {
             MessageDirection::ToDownstream => {
                 self.messages_from_upstream.has_message_type(message_type)

--- a/integration-tests/lib/sv1_sniffer.rs
+++ b/integration-tests/lib/sv1_sniffer.rs
@@ -171,7 +171,7 @@ impl SnifferSV1 {
         F: FnMut(sv1_api::Message),
     {
         let f = filter.inner();
-        self.wait_for_message(&[&f], direction.clone()).await;
+        self.wait_for_message(&[&f], direction).await;
 
         let aggregator = match direction {
             MessageDirection::ToUpstream => &self.messages_from_downstream,

--- a/integration-tests/tests/bitcoin_core_ipc_integration.rs
+++ b/integration-tests/tests/bitcoin_core_ipc_integration.rs
@@ -97,6 +97,7 @@ async fn jdc_propagates_block_with_bitcoin_core_ipc() {
                 .assert_message_not_present(
                     MessageDirection::ToUpstream,
                     MESSAGE_TYPE_PUSH_SOLUTION,
+                    std::time::Duration::from_secs(1),
                 )
                 .await;
             shutdown_all!(pool, jdc, translator);

--- a/integration-tests/tests/jd_integration.rs
+++ b/integration-tests/tests/jd_integration.rs
@@ -405,7 +405,8 @@ async fn jdc_group_extended_channels() {
         sniffer
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
-                MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB
+                MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "There should be no extra NewExtendedMiningJob messages"
@@ -449,7 +450,8 @@ async fn jdc_group_extended_channels() {
         sniffer
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
-                MESSAGE_TYPE_SET_NEW_PREV_HASH
+                MESSAGE_TYPE_SET_NEW_PREV_HASH,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "There should be no extra SetNewPrevHash messages"
@@ -583,7 +585,8 @@ async fn jdc_group_standard_channels() {
         sniffer
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
-                MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB
+                MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "There should be no extra NewExtendedMiningJob messages"
@@ -592,7 +595,11 @@ async fn jdc_group_standard_channels() {
     // make sure there's no NewMiningJob message
     assert!(
         sniffer
-            .assert_message_not_present(MessageDirection::ToDownstream, MESSAGE_TYPE_NEW_MINING_JOB)
+            .assert_message_not_present(
+                MessageDirection::ToDownstream,
+                MESSAGE_TYPE_NEW_MINING_JOB,
+                std::time::Duration::from_secs(1)
+            )
             .await,
         "There should be no NewMiningJob message"
     );
@@ -635,7 +642,8 @@ async fn jdc_group_standard_channels() {
         sniffer
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
-                MESSAGE_TYPE_SET_NEW_PREV_HASH
+                MESSAGE_TYPE_SET_NEW_PREV_HASH,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "There should be no extra SetNewPrevHash messages"

--- a/integration-tests/tests/jd_tproxy_integration.rs
+++ b/integration-tests/tests/jd_tproxy_integration.rs
@@ -108,13 +108,16 @@ async fn jd_aggregated_tproxy_integration() {
                 MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
             )
             .await;
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        tproxy_jdc_sniffer
-            .assert_message_not_present(
-                MessageDirection::ToUpstream,
-                MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
-            )
-            .await;
+        assert!(
+            tproxy_jdc_sniffer
+                .assert_message_not_present(
+                    MessageDirection::ToUpstream,
+                    MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
+                    std::time::Duration::from_secs(2),
+                )
+                .await,
+            "Expected only one OpenExtendedMiningChannel but found another one."
+        );
     }
 
     jdc_pool_sniffer

--- a/integration-tests/tests/jdc_block_propagation.rs
+++ b/integration-tests/tests/jdc_block_propagation.rs
@@ -36,7 +36,11 @@ async fn propagated_from_jdc_to_tp() {
         .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SUBMIT_SOLUTION)
         .await;
     jdc_jds_sniffer
-        .assert_message_not_present(MessageDirection::ToUpstream, MESSAGE_TYPE_PUSH_SOLUTION)
+        .assert_message_not_present(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_PUSH_SOLUTION,
+            std::time::Duration::from_secs(1),
+        )
         .await;
     let new_block_hash = tp.get_best_block_hash().unwrap();
     tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;

--- a/integration-tests/tests/jds_block_propagation.rs
+++ b/integration-tests/tests/jds_block_propagation.rs
@@ -36,7 +36,11 @@ async fn propagated_from_jds_to_tp() {
         .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_PUSH_SOLUTION)
         .await;
     jdc_tp_sniffer
-        .assert_message_not_present(MessageDirection::ToUpstream, MESSAGE_TYPE_SUBMIT_SOLUTION)
+        .assert_message_not_present(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_SUBMIT_SOLUTION,
+            std::time::Duration::from_secs(1),
+        )
         .await;
     let new_block_hash = tp.get_best_block_hash().unwrap();
     assert_ne!(current_block_hash, new_block_hash);

--- a/integration-tests/tests/pool_integration.rs
+++ b/integration-tests/tests/pool_integration.rs
@@ -322,6 +322,7 @@ async fn pool_does_not_send_jobs_to_jdc() {
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
                 MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "Pool should NOT send future NewExtendedMiningJob messages to JDC"
@@ -333,6 +334,7 @@ async fn pool_does_not_send_jobs_to_jdc() {
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
                 MESSAGE_TYPE_MINING_SET_NEW_PREV_HASH,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "Pool should NOT send SetNewPrevHash messages to JDC"
@@ -349,6 +351,7 @@ async fn pool_does_not_send_jobs_to_jdc() {
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
                 MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "Pool should NOT send non-future NewExtendedMiningJob messages to JDC"
@@ -537,7 +540,8 @@ async fn pool_group_extended_channels() {
         sniffer
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
-                MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB
+                MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "There should be no extra NewExtendedMiningJob messages"
@@ -580,7 +584,8 @@ async fn pool_group_extended_channels() {
         sniffer
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
-                MESSAGE_TYPE_SET_NEW_PREV_HASH
+                MESSAGE_TYPE_SET_NEW_PREV_HASH,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "There should be no second SetNewPrevHash message"
@@ -704,7 +709,8 @@ async fn pool_group_standard_channels() {
         sniffer
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
-                MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB
+                MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "There should be no second NewMiningJob message"
@@ -716,6 +722,7 @@ async fn pool_group_standard_channels() {
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
                 MESSAGE_TYPE_NEW_MINING_JOB,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "There should be no NewMiningJob message"
@@ -759,6 +766,7 @@ async fn pool_group_standard_channels() {
             .assert_message_not_present(
                 MessageDirection::ToDownstream,
                 MESSAGE_TYPE_MINING_SET_NEW_PREV_HASH,
+                std::time::Duration::from_secs(1),
             )
             .await,
         "There should be no extra SetNewPrevHash messages"

--- a/integration-tests/tests/sniffer_integration.rs
+++ b/integration-tests/tests/sniffer_integration.rs
@@ -102,8 +102,7 @@ async fn test_sniffer_interception() {
         0
     );
     assert!(
-        !(sniffer_b
-            .includes_message_type(MessageDirection::ToDownstream, MESSAGE_TYPE_NEW_TEMPLATE))
+        !(sniffer_b.has_message_type(MessageDirection::ToDownstream, MESSAGE_TYPE_NEW_TEMPLATE))
     );
     pool.shutdown().await;
 }
@@ -123,13 +122,13 @@ async fn test_sniffer_wait_for_message_type_with_remove() {
             .await
     );
     assert!(
-        !(sniffer.includes_message_type(
+        !(sniffer.has_message_type(
             MessageDirection::ToDownstream,
             MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS
         ))
     );
     assert!(
-        !(sniffer.includes_message_type(
+        !(sniffer.has_message_type(
             MessageDirection::ToDownstream,
             MESSAGE_TYPE_SET_NEW_PREV_HASH
         ))

--- a/integration-tests/tests/translator_integration.rs
+++ b/integration-tests/tests/translator_integration.rs
@@ -417,6 +417,7 @@ async fn aggregated_translator_correctly_deals_with_group_channels() {
             .assert_message_not_present(
                 MessageDirection::ToUpstream,
                 MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
+                std::time::Duration::from_secs(1),
             )
             .await;
     }
@@ -1327,6 +1328,7 @@ async fn non_aggregated_translator_correctly_deals_with_close_channel_message() 
         .assert_message_not_present(
             MessageDirection::ToUpstream,
             MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED,
+            std::time::Duration::from_secs(1),
         )
         .await;
     translator.shutdown().await;


### PR DESCRIPTION
## Summary
- Add `assert_message_not_present_for` to the sniffer for reliable negative assertions that monitor the queue over a duration instead of checking a single point in time
- Update `jd_aggregated_tproxy_integration` to use the new primitive

## Problem
The sniffer's `assert_message_not_present` checks the queue at a single instant. If the message hasn't arrived yet at that moment (but arrives shortly after), the check passes -- a false positive. This means protocol violations like duplicate `OpenExtendedMiningChannel` messages slip through undetected.

## Fix
`assert_message_not_present_for(direction, message_type, duration)` polls the queue every 100ms for the full duration, with a final check after the last sleep to close the boundary gap. It returns `false` immediately if the message appears at any point. Only after the full duration passes with no message does it return `true`.

The integration test now uses this primitive wrapped in `assert!()`, so when the translator bug (#157) triggers a duplicate, the sniffer catches it.

## Test plan
- [x] `cargo check` passes on latest upstream/main
- [x] `cargo fmt --check` passes
- [x] `jd_non_aggregated_tproxy_integration` passes
- [x] `jd_aggregated_tproxy_integration` correctly catches duplicate when #157 triggers

Closes #189