### PR TITLE
fix `shares_submitted` tracking in server monitoring for tProxy and JDC

### DIFF
--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -122,7 +122,7 @@ pub struct ChannelManagerData {
     downstream_id_factory: AtomicUsize,
     // Factory that assigns a unique **sequence number** to each share
     // submitted from the JDC to the upstream.
-    sequence_number_factory: AtomicU32,
+    pub sequence_number_factory: AtomicU32,
     // The last **future template** received from the upstream.
     last_future_template: Option<NewTemplate<'static>>,
     // The last **new prevhash** received from the upstream.
@@ -298,7 +298,7 @@ impl ChannelManager {
             extranonce_prefix_factory_standard,
             downstream_id_factory: AtomicUsize::new(0),
             request_id_factory: AtomicU32::new(0),
-            sequence_number_factory: AtomicU32::new(0),
+            sequence_number_factory: AtomicU32::new(1),
             last_future_template: None,
             last_new_prev_hash: None,
             allocate_tokens: None,

--- a/miner-apps/jd-client/src/lib/monitoring.rs
+++ b/miner-apps/jd-client/src/lib/monitoring.rs
@@ -27,6 +27,13 @@ impl ServerMonitoring for ChannelManager {
                     let user_identity = upstream_channel.get_user_identity();
                     let share_accounting = upstream_channel.get_share_accounting();
 
+                    // Get the count of shares submitted to the upstream.
+                    // Counter starts at 1, so subtract 1 to get shares submitted.
+                    let shares_submitted = d
+                        .sequence_number_factory
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                        .saturating_sub(1);
+
                     extended_channels.push(ServerExtendedChannelInfo {
                         channel_id,
                         user_identity: user_identity.clone(),
@@ -38,8 +45,7 @@ impl ServerMonitoring for ChannelManager {
                         version_rolling: upstream_channel.is_version_rolling(),
                         shares_accepted: share_accounting.get_shares_accepted(),
                         share_work_sum: share_accounting.get_share_work_sum(),
-                        last_share_sequence_number: share_accounting
-                            .get_last_share_sequence_number(),
+                        shares_submitted,
                         best_diff: share_accounting.get_best_diff(),
                     });
                 }

--- a/miner-apps/translator/src/lib/monitoring.rs
+++ b/miner-apps/translator/src/lib/monitoring.rs
@@ -28,6 +28,14 @@ impl ServerMonitoring for ChannelManager {
                     let user_identity = aggregated_extended_channel.get_user_identity();
                     let share_accounting = aggregated_extended_channel.get_share_accounting();
 
+                    // Get the actual upstream sequence counter (shares submitted upstream)
+                    // In aggregated mode, we use the upstream channel_id as the counter key
+                    let shares_submitted = self
+                        .share_sequence_counters
+                        .get(&channel_id)
+                        .map(|v| *v)
+                        .unwrap_or(0);
+
                     extended_channels.push(ServerExtendedChannelInfo {
                         channel_id,
                         user_identity: user_identity.clone(),
@@ -41,8 +49,7 @@ impl ServerMonitoring for ChannelManager {
                         version_rolling: aggregated_extended_channel.is_version_rolling(),
                         shares_accepted: share_accounting.get_shares_accepted(),
                         share_work_sum: share_accounting.get_share_work_sum(),
-                        last_share_sequence_number: share_accounting
-                            .get_last_share_sequence_number(),
+                        shares_submitted,
                         best_diff: share_accounting.get_best_diff(),
                     });
                 }
@@ -59,6 +66,14 @@ impl ServerMonitoring for ChannelManager {
                     let user_identity = extended_channel.get_user_identity();
                     let share_accounting = extended_channel.get_share_accounting();
 
+                    // Get the actual upstream sequence counter (shares submitted upstream)
+                    // In non-aggregated mode, each channel has its own counter
+                    let shares_submitted = self
+                        .share_sequence_counters
+                        .get(&channel_id)
+                        .map(|v| *v)
+                        .unwrap_or(0);
+
                     extended_channels.push(ServerExtendedChannelInfo {
                         channel_id,
                         user_identity: user_identity.clone(),
@@ -70,8 +85,7 @@ impl ServerMonitoring for ChannelManager {
                         version_rolling: extended_channel.is_version_rolling(),
                         shares_accepted: share_accounting.get_shares_accepted(),
                         share_work_sum: share_accounting.get_share_work_sum(),
-                        last_share_sequence_number: share_accounting
-                            .get_last_share_sequence_number(),
+                        shares_submitted,
                         best_diff: share_accounting.get_best_diff(),
                     });
                 }

--- a/miner-apps/translator/src/lib/sv2/channel_manager/channel_manager.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/channel_manager.rs
@@ -724,12 +724,11 @@ impl ChannelManager {
     /// - In aggregated mode: use upstream channel ID (single counter for all shares)
     /// - In non-aggregated mode: use downstream channel ID (one counter per channel)
     pub fn next_share_sequence_number(&self, counter_key: u32) -> u32 {
-        let mut counter = self.share_sequence_counters.entry(counter_key).or_insert(1);
+        let mut counter = self.share_sequence_counters.entry(counter_key).or_insert(0);
         let counter = counter.value_mut();
 
-        let current = *counter;
         *counter += 1;
-        current
+        *counter
     }
 }
 

--- a/stratum-apps/src/monitoring/server.rs
+++ b/stratum-apps/src/monitoring/server.rs
@@ -19,7 +19,7 @@ pub struct ServerExtendedChannelInfo {
     pub version_rolling: bool,
     pub shares_accepted: u32,
     pub share_work_sum: f64,
-    pub last_share_sequence_number: u32,
+    pub shares_submitted: u32,
     pub best_diff: f64,
 }
 
@@ -33,7 +33,7 @@ pub struct ServerStandardChannelInfo {
     pub extranonce_prefix_hex: String,
     pub shares_accepted: u32,
     pub share_work_sum: f64,
-    pub last_share_sequence_number: u32,
+    pub shares_submitted: u32,
     pub best_diff: f64,
 }
 


### PR DESCRIPTION
This PR changes the way we are monitoring the `shares_submitted` to the server.

It now uses the counters used to track shares submitted to the server in both JDC and tProxy, instead of using the data from `ShareAccounting`.