### PR TITLE
fix(monitoring): make nominal_hashrate Optional and omit metrics when vardiff disabled

### DIFF
--- a/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
@@ -884,13 +884,17 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                     });
                 }
 
-                if let Some(ref upstream_channel) = channel_manager_data.upstream_channel {
+                if let Some(ref mut upstream_channel) = channel_manager_data.upstream_channel {
                     debug!(
                         "Checking upstream channel {} with hashrate {} and target {:?}",
                         upstream_channel.get_channel_id(),
                         upstream_channel.get_nominal_hashrate(),
                         upstream_channel.get_target()
                     );
+
+                    // Update the upstream channel's nominal hashrate to reflect
+                    // the aggregated downstream hashrate
+                    upstream_channel.set_nominal_hashrate(downstream_hashrate);
 
                     info!("Sending update channel message upstream");
                     messages.push(

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -1177,13 +1177,17 @@ impl ChannelManager {
                         });
                     }
 
-                    if let Some(ref upstream_channel) = channel_manager_data.upstream_channel {
+                    if let Some(ref mut upstream_channel) = channel_manager_data.upstream_channel {
                         debug!(
                             "Checking upstream channel {} with hashrate {} and target {:?}",
                             upstream_channel.get_channel_id(),
                             upstream_channel.get_nominal_hashrate(),
                             upstream_channel.get_target()
                         );
+
+                        // Update the upstream channel's nominal hashrate to reflect
+                        // the aggregated downstream hashrate
+                        upstream_channel.set_nominal_hashrate(downstream_hashrate);
 
                         info!("Sending update channel message upstream");
                         messages.push(

--- a/miner-apps/jd-client/src/lib/monitoring.rs
+++ b/miner-apps/jd-client/src/lib/monitoring.rs
@@ -37,7 +37,7 @@ impl ServerMonitoring for ChannelManager {
                     extended_channels.push(ServerExtendedChannelInfo {
                         channel_id,
                         user_identity: user_identity.clone(),
-                        nominal_hashrate: upstream_channel.get_nominal_hashrate(),
+                        nominal_hashrate: Some(upstream_channel.get_nominal_hashrate()),
                         target_hex: hex::encode(target.to_be_bytes()),
                         extranonce_prefix_hex: hex::encode(extranonce_prefix),
                         full_extranonce_size: upstream_channel.get_full_extranonce_size(),

--- a/miner-apps/translator/src/lib/mod.rs
+++ b/miner-apps/translator/src/lib/mod.rs
@@ -71,6 +71,9 @@ impl TranslatorSv2 {
         TPROXY_MODE
             .set(self.config.aggregate_channels.into())
             .expect("TPROXY_MODE initialized more than once");
+        VARDIFF_ENABLED
+            .set(self.config.downstream_difficulty_config.enable_vardiff)
+            .expect("VARDIFF_ENABLED initialized more than once");
 
         let (notify_shutdown, _) =
             broadcast::channel::<ShutdownMessage>(SHUTDOWN_BROADCAST_CAPACITY);
@@ -424,6 +427,7 @@ impl From<bool> for TproxyMode {
 }
 
 static TPROXY_MODE: OnceLock<TproxyMode> = OnceLock::new();
+static VARDIFF_ENABLED: OnceLock<bool> = OnceLock::new();
 
 #[cfg(not(test))]
 pub fn tproxy_mode() -> TproxyMode {
@@ -447,4 +451,14 @@ pub fn is_aggregated() -> bool {
 #[inline]
 pub fn is_non_aggregated() -> bool {
     matches!(tproxy_mode(), TproxyMode::NonAggregated)
+}
+
+#[cfg(not(test))]
+pub fn vardiff_enabled() -> bool {
+    *VARDIFF_ENABLED.get().expect("VARDIFF_ENABLED has to exist")
+}
+
+#[cfg(test)]
+pub fn vardiff_enabled() -> bool {
+    *VARDIFF_ENABLED.get_or_init(|| true)
 }

--- a/miner-apps/translator/src/lib/sv1_monitoring.rs
+++ b/miner-apps/translator/src/lib/sv1_monitoring.rs
@@ -3,10 +3,14 @@
 //! This module implements the Sv1ClientsMonitoring trait on `Sv1Server`.
 use stratum_apps::monitoring::sv1::{Sv1ClientInfo, Sv1ClientsMonitoring};
 
-use crate::sv1::{downstream::downstream::Downstream, sv1_server::sv1_server::Sv1Server};
+use crate::{
+    sv1::{downstream::downstream::Downstream, sv1_server::sv1_server::Sv1Server},
+    vardiff_enabled,
+};
 
 /// Helper to convert a Downstream to Sv1ClientInfo
 fn downstream_to_sv1_client_info(downstream: &Downstream) -> Option<Sv1ClientInfo> {
+    let report_hashrate = vardiff_enabled();
     downstream
         .downstream_data
         .safe_lock(|dd| Sv1ClientInfo {
@@ -15,7 +19,7 @@ fn downstream_to_sv1_client_info(downstream: &Downstream) -> Option<Sv1ClientInf
             authorized_worker_name: dd.authorized_worker_name.clone(),
             user_identity: dd.user_identity.clone(),
             target_hex: hex::encode(dd.target.to_be_bytes()),
-            hashrate: dd.hashrate,
+            hashrate: if report_hashrate { dd.hashrate } else { None },
             extranonce1_hex: hex::encode(&dd.extranonce1),
             extranonce2_len: dd.extranonce2_len,
             version_rolling_mask: dd

--- a/stratum-apps/src/monitoring/README.md
+++ b/stratum-apps/src/monitoring/README.md
@@ -41,6 +41,7 @@ let server = MonitoringServer::new(
     "127.0.0.1:9090".parse()?,
     Some(Arc::new(channel_manager.clone())), // server monitoring
     Some(Arc::new(channel_manager.clone())), // clients monitoring
+    std::time::Duration::from_secs(15),      // cache refresh interval
 )?;
 
 // For Translator, add SV1 monitoring

--- a/stratum-apps/src/monitoring/http_server.rs
+++ b/stratum-apps/src/monitoring/http_server.rs
@@ -788,10 +788,13 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
                     .with_label_values(&[&channel_id, user])
                     .set(channel.shares_accepted as f64);
             }
-            if let Some(ref metric) = state.metrics.sv2_server_channel_hashrate {
+            if let (Some(ref metric), Some(hashrate)) = (
+                &state.metrics.sv2_server_channel_hashrate,
+                channel.nominal_hashrate,
+            ) {
                 metric
                     .with_label_values(&[&channel_id, user])
-                    .set(channel.nominal_hashrate as f64);
+                    .set(hashrate as f64);
             }
         }
 
@@ -804,10 +807,13 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
                     .with_label_values(&[&channel_id, user])
                     .set(channel.shares_accepted as f64);
             }
-            if let Some(ref metric) = state.metrics.sv2_server_channel_hashrate {
+            if let (Some(ref metric), Some(hashrate)) = (
+                &state.metrics.sv2_server_channel_hashrate,
+                channel.nominal_hashrate,
+            ) {
                 metric
                     .with_label_values(&[&channel_id, user])
-                    .set(channel.nominal_hashrate as f64);
+                    .set(hashrate as f64);
             }
         }
     }

--- a/stratum-apps/src/monitoring/server.rs
+++ b/stratum-apps/src/monitoring/server.rs
@@ -11,7 +11,8 @@ use utoipa::ToSchema;
 pub struct ServerExtendedChannelInfo {
     pub channel_id: u32,
     pub user_identity: String,
-    pub nominal_hashrate: f32,
+    /// None when vardiff is disabled and hashrate cannot be reliably tracked
+    pub nominal_hashrate: Option<f32>,
     pub target_hex: String,
     pub extranonce_prefix_hex: String,
     pub full_extranonce_size: usize,
@@ -28,7 +29,8 @@ pub struct ServerExtendedChannelInfo {
 pub struct ServerStandardChannelInfo {
     pub channel_id: u32,
     pub user_identity: String,
-    pub nominal_hashrate: f32,
+    /// None when vardiff is disabled and hashrate cannot be reliably tracked
+    pub nominal_hashrate: Option<f32>,
     pub target_hex: String,
     pub extranonce_prefix_hex: String,
     pub shares_accepted: u32,
@@ -54,12 +56,12 @@ impl ServerInfo {
     pub fn total_hashrate(&self) -> f32 {
         self.extended_channels
             .iter()
-            .map(|c| c.nominal_hashrate)
+            .filter_map(|c| c.nominal_hashrate)
             .sum::<f32>()
             + self
                 .standard_channels
                 .iter()
-                .map(|c| c.nominal_hashrate)
+                .filter_map(|c| c.nominal_hashrate)
                 .sum::<f32>()
     }
 }


### PR DESCRIPTION
Closes [#262](https://github.com/stratum-mining/sv2-apps/issues/262)
 
When enable_vardiff = false, the tProxy and JDC never generate UpdateChannel messages, so difficulty adjustments arrive exclusively as SetTarget (tProxy) or are managed internally (JDC). The existing handlers updated targets but not nominal_hashrate, leaving hashrate metrics stuck at initial values.
    
Changes:
- Make nominal_hashrate Option<f32> in server monitoring types
- Update total_hashrate() to use filter_map for Option handling
- Omit hashrate metrics from HTTP endpoints when vardiff is disabled

This ensures hashrate metrics accurately reflect when they can be reliably tracked (vardiff enabled) vs when they cannot (vardiff disabled).