### PR TITLE
Fix: JDC sends bad SetupConnection.Success.flags (#266)

### DIFF
--- a/miner-apps/jd-client/src/lib/downstream/common_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/downstream/common_message_handler.rs
@@ -103,7 +103,7 @@ impl HandleCommonMessagesFromClientAsync for Downstream {
         }
         let response = SetupConnectionSuccess {
             used_version: 2,
-            flags: msg.flags,
+            flags: 0, // !REQUIRES_FIXED_VERSION, !REQUIRES_EXTENDED_CHANNELS
         };
         let frame: Sv2Frame = AnyMessage::Common(response.into_static().into())
             .try_into()


### PR DESCRIPTION
Fixes #266

### Description
The `jd-client` was incorrectly echoing the `SetupConnection` flags received from the client back into the `SetupConnection.Success` response.

According to the Stratum V2 specification, the flags in the `Success` message have different semantic meanings than the request flags:
- **Bit 0:** `REQUIRES_FIXED_VERSION` (Must not be set if `REQUIRES_VERSION_ROLLING` was set in request)
- **Bit 1:** `REQUIRES_EXTENDED_CHANNELS`

Simply echoing the request flags caused a protocol violation.

### Fix
I updated `handle_setup_connection` in `miner-apps/jd-client/src/lib/downstream/common_message_handler.rs` to set `flags: 0`. This correctly indicates that the JDC has no special requirements (no fixed version, no extended channels required), which is the safe default.
