### PR TITLE
improve `global/` API endpoint

### DIFF
--- a/stratum-apps/src/monitoring/README.md
+++ b/stratum-apps/src/monitoring/README.md
@@ -28,8 +28,8 @@ Server and client endpoints return metadata only (counts, hashrate). Use `/chann
 Applications implement these traits on their data structures:
 
 - `ServerMonitoring` - For upstream connection info
-- `ClientsMonitoring` - For downstream client info  
-- `Sv1ClientsMonitoring` - For Sv1 clients (Translator Proxy only)
+- `Sv2ClientsMonitoring` - For Sv2 downstream client info (Pool, JDC)
+- `Sv1ClientsMonitoring` - For Sv1 downstream client info (Translator Proxy only)
 
 ## Usage
 
@@ -40,7 +40,7 @@ use std::sync::Arc;
 let server = MonitoringServer::new(
     "127.0.0.1:9090".parse()?,
     Some(Arc::new(channel_manager.clone())), // server monitoring
-    Some(Arc::new(channel_manager.clone())), // clients monitoring
+    Some(Arc::new(channel_manager.clone())), // Sv2 clients monitoring
     std::time::Duration::from_secs(15),      // cache refresh interval
 )?;
 

--- a/stratum-apps/src/monitoring/client.rs
+++ b/stratum-apps/src/monitoring/client.rs
@@ -1,6 +1,6 @@
-//! Client monitoring types
+//! Sv2 client monitoring types
 //!
-//! These types are for monitoring **clients** (downstream connections).
+//! These types are for monitoring **Sv2 clients** (downstream connections).
 //! Each client can have multiple channels opened with the app.
 
 use serde::{Deserialize, Serialize};
@@ -46,15 +46,15 @@ pub struct StandardChannelInfo {
     pub share_batch_size: usize,
 }
 
-/// Full information about a single client including all channels
+/// Full information about a single Sv2 client including all channels
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct ClientInfo {
+pub struct Sv2ClientInfo {
     pub client_id: usize,
     pub extended_channels: Vec<ExtendedChannelInfo>,
     pub standard_channels: Vec<StandardChannelInfo>,
 }
 
-impl ClientInfo {
+impl Sv2ClientInfo {
     /// Get total number of channels for this client
     pub fn total_channels(&self) -> usize {
         self.extended_channels.len() + self.standard_channels.len()
@@ -74,8 +74,8 @@ impl ClientInfo {
     }
 
     /// Convert to metadata (without channel arrays)
-    pub fn to_metadata(&self) -> ClientMetadata {
-        ClientMetadata {
+    pub fn to_metadata(&self) -> Sv2ClientMetadata {
+        Sv2ClientMetadata {
             client_id: self.client_id,
             extended_channels_count: self.extended_channels.len(),
             standard_channels_count: self.standard_channels.len(),
@@ -84,18 +84,18 @@ impl ClientInfo {
     }
 }
 
-/// Client metadata without channel arrays (for listings)
+/// Sv2 client metadata without channel arrays (for listings)
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct ClientMetadata {
+pub struct Sv2ClientMetadata {
     pub client_id: usize,
     pub extended_channels_count: usize,
     pub standard_channels_count: usize,
     pub total_hashrate: f32,
 }
 
-/// Aggregate information about all clients
+/// Aggregate information about all Sv2 clients
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-pub struct ClientsSummary {
+pub struct Sv2ClientsSummary {
     pub total_clients: usize,
     pub total_channels: usize,
     pub extended_channels: usize,
@@ -103,28 +103,28 @@ pub struct ClientsSummary {
     pub total_hashrate: f32,
 }
 
-/// Trait for monitoring clients (downstream connections)
-pub trait ClientsMonitoring: Send + Sync {
-    /// Get all clients with their channels
-    fn get_clients(&self) -> Vec<ClientInfo>;
+/// Trait for monitoring Sv2 clients (downstream connections)
+pub trait Sv2ClientsMonitoring: Send + Sync {
+    /// Get all Sv2 clients with their channels
+    fn get_sv2_clients(&self) -> Vec<Sv2ClientInfo>;
 
-    /// Get a single client by client_id
+    /// Get a single Sv2 client by client_id
     ///
     /// Default implementation does O(n) scan. Override for O(1) lookup
     /// if your implementation uses a HashMap internally.
-    fn get_client_by_id(&self, client_id: usize) -> Option<ClientInfo> {
-        self.get_clients()
+    fn get_sv2_client_by_id(&self, client_id: usize) -> Option<Sv2ClientInfo> {
+        self.get_sv2_clients()
             .into_iter()
             .find(|c| c.client_id == client_id)
     }
 
-    /// Get summary of all clients
-    fn get_clients_summary(&self) -> ClientsSummary {
-        let clients = self.get_clients();
+    /// Get summary of all Sv2 clients
+    fn get_sv2_clients_summary(&self) -> Sv2ClientsSummary {
+        let clients = self.get_sv2_clients();
         let extended: usize = clients.iter().map(|c| c.extended_channels.len()).sum();
         let standard: usize = clients.iter().map(|c| c.standard_channels.len()).sum();
 
-        ClientsSummary {
+        Sv2ClientsSummary {
             total_clients: clients.len(),
             total_channels: extended + standard,
             extended_channels: extended,

--- a/stratum-apps/src/monitoring/http_server.rs
+++ b/stratum-apps/src/monitoring/http_server.rs
@@ -2,8 +2,8 @@
 
 use super::{
     client::{
-        ClientInfo, ClientMetadata, ClientsMonitoring, ClientsSummary, ExtendedChannelInfo,
-        StandardChannelInfo,
+        ExtendedChannelInfo, StandardChannelInfo, Sv2ClientInfo, Sv2ClientMetadata,
+        Sv2ClientsMonitoring, Sv2ClientsSummary,
     },
     prometheus_metrics::PrometheusMetrics,
     server::{
@@ -54,11 +54,11 @@ use utoipa_swagger_ui::SwaggerUi;
     components(schemas(
         GlobalInfo,
         ServerSummary,
-        ClientsSummary,
+        Sv2ClientsSummary,
         ServerExtendedChannelInfo,
         ServerStandardChannelInfo,
-        ClientInfo,
-        ClientMetadata,
+        Sv2ClientInfo,
+        Sv2ClientMetadata,
         ExtendedChannelInfo,
         StandardChannelInfo,
         Sv1ClientInfo,
@@ -67,9 +67,9 @@ use utoipa_swagger_ui::SwaggerUi;
         ErrorResponse,
         ServerResponse,
         ServerChannelsResponse,
-        ClientsResponse,
-        ClientResponse,
-        ClientChannelsResponse,
+        Sv2ClientsResponse,
+        Sv2ClientResponse,
+        Sv2ClientChannelsResponse,
         Sv1ClientsResponse,
     )),
     tags(
@@ -145,12 +145,12 @@ impl MonitoringServer {
     ///
     /// * `bind_address` - Address to bind the HTTP server to
     /// * `server_monitoring` - Optional server (upstream) monitoring trait object
-    /// * `clients_monitoring` - Optional clients (downstream) monitoring trait object
+    /// * `sv2_clients_monitoring` - Optional Sv2 clients (downstream) monitoring trait object
     /// * `refresh_interval` - How often to refresh the cache (e.g., Duration::from_secs(15))
     pub fn new(
         bind_address: SocketAddr,
         server_monitoring: Option<Arc<dyn ServerMonitoring + Send + Sync + 'static>>,
-        clients_monitoring: Option<Arc<dyn ClientsMonitoring + Send + Sync + 'static>>,
+        sv2_clients_monitoring: Option<Arc<dyn Sv2ClientsMonitoring + Send + Sync + 'static>>,
         refresh_interval: Duration,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let start_time = SystemTime::now()
@@ -159,19 +159,19 @@ impl MonitoringServer {
             .as_secs();
 
         let has_server = server_monitoring.is_some();
-        let has_clients = clients_monitoring.is_some();
+        let has_sv2_clients = sv2_clients_monitoring.is_some();
 
         // Create the snapshot cache
         let cache = Arc::new(SnapshotCache::new(
             refresh_interval,
             server_monitoring,
-            clients_monitoring,
+            sv2_clients_monitoring,
         ));
 
         // Do initial refresh
         cache.refresh();
 
-        let metrics = PrometheusMetrics::new(has_server, has_clients, false)?;
+        let metrics = PrometheusMetrics::new(has_server, has_sv2_clients, false)?;
 
         Ok(Self {
             bind_address,
@@ -194,7 +194,7 @@ impl MonitoringServer {
         // Determine what sources the cache already has
         let snapshot = self.state.cache.get_snapshot();
         let has_server = snapshot.server_info.is_some();
-        let has_clients = snapshot.clients_summary.is_some();
+        let has_sv2_clients = snapshot.sv2_clients_summary.is_some();
 
         // Add Sv1 clients source to the cache
         let cache = Arc::new(
@@ -207,7 +207,7 @@ impl MonitoringServer {
         cache.refresh();
 
         // Re-create metrics with SV1 enabled
-        self.state.metrics = PrometheusMetrics::new(has_server, has_clients, true)?;
+        self.state.metrics = PrometheusMetrics::new(has_server, has_sv2_clients, true)?;
         self.state.cache = cache;
 
         Ok(self)
@@ -317,15 +317,15 @@ struct ServerChannelsResponse {
 }
 
 #[derive(serde::Serialize, ToSchema)]
-struct ClientsResponse {
+struct Sv2ClientsResponse {
     offset: usize,
     limit: usize,
     total: usize,
-    items: Vec<ClientMetadata>,
+    items: Vec<Sv2ClientMetadata>,
 }
 
 #[derive(serde::Serialize, ToSchema)]
-struct ClientResponse {
+struct Sv2ClientResponse {
     client_id: usize,
     extended_channels_count: usize,
     standard_channels_count: usize,
@@ -333,7 +333,7 @@ struct ClientResponse {
 }
 
 #[derive(serde::Serialize, ToSchema)]
-struct ClientChannelsResponse {
+struct Sv2ClientChannelsResponse {
     client_id: usize,
     offset: usize,
     limit: usize,
@@ -420,8 +420,8 @@ async fn handle_global(State(state): State<ServerState>) -> Json<GlobalInfo> {
 
     Json(GlobalInfo {
         server: snapshot.server_summary,
-        clients: snapshot.clients_summary,
-        sv1_clients: snapshot.sv1_summary,
+        sv2_clients: snapshot.sv2_clients_summary,
+        sv1_clients: snapshot.sv1_clients_summary,
         uptime_secs,
     })
 }
@@ -498,15 +498,16 @@ async fn handle_server_channels(
     }
 }
 
-/// Get all clients (downstream) - returns metadata only, use /clients/{id}/channels for channels
+/// Get all Sv2 clients (downstream) - returns metadata only, use /clients/{id}/channels for
+/// channels
 #[utoipa::path(
     get,
     path = "/api/v1/clients",
     tag = "clients",
     params(Pagination),
     responses(
-        (status = 200, description = "List of clients (metadata only)", body = ClientsResponse),
-        (status = 404, description = "Clients monitoring not available", body = ErrorResponse)
+        (status = 200, description = "List of Sv2 clients (metadata only)", body = Sv2ClientsResponse),
+        (status = 404, description = "Sv2 clients monitoring not available", body = ErrorResponse)
     )
 )]
 async fn handle_clients(
@@ -515,12 +516,13 @@ async fn handle_clients(
 ) -> Response {
     let snapshot = state.cache.get_snapshot();
 
-    match snapshot.clients {
-        Some(ref clients) => {
-            let metadata: Vec<ClientMetadata> = clients.iter().map(|c| c.to_metadata()).collect();
+    match snapshot.sv2_clients {
+        Some(ref sv2_clients) => {
+            let metadata: Vec<Sv2ClientMetadata> =
+                sv2_clients.iter().map(|c| c.to_metadata()).collect();
             let (total, items) = paginate(&metadata, &params);
 
-            Json(ClientsResponse {
+            Json(Sv2ClientsResponse {
                 offset: params.offset,
                 limit: params.effective_limit(),
                 total,
@@ -531,24 +533,24 @@ async fn handle_clients(
         None => (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
-                error: "Clients monitoring not available".to_string(),
+                error: "Sv2 clients monitoring not available".to_string(),
             }),
         )
             .into_response(),
     }
 }
 
-/// Get a single client by ID - returns metadata only, use /clients/{id}/channels for channels
+/// Get a single Sv2 client by ID - returns metadata only, use /clients/{id}/channels for channels
 #[utoipa::path(
     get,
     path = "/api/v1/clients/{client_id}",
     tag = "clients",
     params(
-        ("client_id" = usize, Path, description = "Client ID")
+        ("client_id" = usize, Path, description = "Sv2 Client ID")
     ),
     responses(
-        (status = 200, description = "Client metadata", body = ClientResponse),
-        (status = 404, description = "Client not found", body = ErrorResponse)
+        (status = 200, description = "Sv2 client metadata", body = Sv2ClientResponse),
+        (status = 404, description = "Sv2 client not found", body = ErrorResponse)
     )
 )]
 async fn handle_client_by_id(
@@ -557,21 +559,21 @@ async fn handle_client_by_id(
 ) -> Response {
     let snapshot = state.cache.get_snapshot();
 
-    let clients = match snapshot.clients {
+    let sv2_clients = match snapshot.sv2_clients {
         Some(ref clients) => clients,
         None => {
             return (
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse {
-                    error: "Clients monitoring not available".to_string(),
+                    error: "Sv2 clients monitoring not available".to_string(),
                 }),
             )
                 .into_response();
         }
     };
 
-    match clients.iter().find(|c| c.client_id == client_id) {
-        Some(client) => Json(ClientResponse {
+    match sv2_clients.iter().find(|c| c.client_id == client_id) {
+        Some(client) => Json(Sv2ClientResponse {
             client_id,
             extended_channels_count: client.extended_channels.len(),
             standard_channels_count: client.standard_channels.len(),
@@ -581,25 +583,25 @@ async fn handle_client_by_id(
         None => (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
-                error: format!("Client {} not found", client_id),
+                error: format!("Sv2 client {} not found", client_id),
             }),
         )
             .into_response(),
     }
 }
 
-/// Get channels for a specific client (paginated)
+/// Get channels for a specific Sv2 client (paginated)
 #[utoipa::path(
     get,
     path = "/api/v1/clients/{client_id}/channels",
     tag = "clients",
     params(
-        ("client_id" = usize, Path, description = "Client ID"),
+        ("client_id" = usize, Path, description = "Sv2 Client ID"),
         Pagination
     ),
     responses(
-        (status = 200, description = "Client channels (paginated)", body = ClientChannelsResponse),
-        (status = 404, description = "Client not found", body = ErrorResponse)
+        (status = 200, description = "Sv2 client channels (paginated)", body = Sv2ClientChannelsResponse),
+        (status = 404, description = "Sv2 client not found", body = ErrorResponse)
     )
 )]
 async fn handle_client_channels(
@@ -609,25 +611,25 @@ async fn handle_client_channels(
 ) -> Response {
     let snapshot = state.cache.get_snapshot();
 
-    let clients = match snapshot.clients {
+    let sv2_clients = match snapshot.sv2_clients {
         Some(ref clients) => clients,
         None => {
             return (
                 StatusCode::NOT_FOUND,
                 Json(ErrorResponse {
-                    error: "Clients monitoring not available".to_string(),
+                    error: "Sv2 clients monitoring not available".to_string(),
                 }),
             )
                 .into_response();
         }
     };
 
-    match clients.iter().find(|c| c.client_id == client_id) {
+    match sv2_clients.iter().find(|c| c.client_id == client_id) {
         Some(client) => {
             let (total_extended, extended_channels) = paginate(&client.extended_channels, &params);
             let (total_standard, standard_channels) = paginate(&client.standard_channels, &params);
 
-            Json(ClientChannelsResponse {
+            Json(Sv2ClientChannelsResponse {
                 client_id,
                 offset: params.offset,
                 limit: params.effective_limit(),
@@ -641,7 +643,7 @@ async fn handle_client_channels(
         None => (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
-                error: format!("Client {} not found", client_id),
+                error: format!("Sv2 client {} not found", client_id),
             }),
         )
             .into_response(),
@@ -811,8 +813,8 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
         }
     }
 
-    // Collect clients metrics
-    if let Some(ref summary) = snapshot.clients_summary {
+    // Collect Sv2 clients metrics
+    if let Some(ref summary) = snapshot.sv2_clients_summary {
         if let Some(ref metric) = state.metrics.sv2_clients_total {
             metric.set(summary.total_clients as f64);
         }
@@ -828,7 +830,7 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
             metric.set(summary.total_hashrate as f64);
         }
 
-        for client in snapshot.clients.as_deref().unwrap_or(&[]) {
+        for client in snapshot.sv2_clients.as_deref().unwrap_or(&[]) {
             let client_id = client.client_id.to_string();
 
             for channel in &client.extended_channels {
@@ -866,7 +868,7 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
     }
 
     // Collect SV1 client metrics
-    if let Some(ref summary) = snapshot.sv1_summary {
+    if let Some(ref summary) = snapshot.sv1_clients_summary {
         if let Some(ref metric) = state.metrics.sv1_clients_total {
             metric.set(summary.total_clients as f64);
         }

--- a/stratum-apps/src/monitoring/mod.rs
+++ b/stratum-apps/src/monitoring/mod.rs
@@ -17,8 +17,8 @@ pub mod snapshot_cache;
 pub mod sv1;
 
 pub use client::{
-    ClientInfo, ClientMetadata, ClientsMonitoring, ClientsSummary, ExtendedChannelInfo,
-    StandardChannelInfo,
+    ExtendedChannelInfo, StandardChannelInfo, Sv2ClientInfo, Sv2ClientMetadata,
+    Sv2ClientsMonitoring, Sv2ClientsSummary,
 };
 pub use http_server::MonitoringServer;
 pub use server::{
@@ -36,15 +36,15 @@ use utoipa::ToSchema;
 /// with zeros).
 ///
 /// Typical configurations:
-/// - **Pool/JDC**: `server` and `clients` are `Some`, `sv1_clients` is `None`
-/// - **tProxy**: `server` and `sv1_clients` are `Some`, `clients` is `None`
+/// - **Pool/JDC**: `server` and `sv2_clients` are `Some`, `sv1_clients` is `None`
+/// - **tProxy**: `server` and `sv1_clients` are `Some`, `sv2_clients` is `None`
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, ToSchema)]
 pub struct GlobalInfo {
     /// Server (upstream) summary - `None` if server monitoring is not enabled
     pub server: Option<ServerSummary>,
     /// Sv2 clients (downstream) summary - `None` if Sv2 client monitoring is not enabled (e.g.,
     /// tProxy)
-    pub clients: Option<ClientsSummary>,
+    pub sv2_clients: Option<Sv2ClientsSummary>,
     /// Sv1 clients summary - `None` if Sv1 monitoring is not enabled (e.g., Pool/JDC)
     pub sv1_clients: Option<Sv1ClientsSummary>,
     /// Uptime in seconds since the application started

--- a/stratum-apps/src/monitoring/snapshot_cache.rs
+++ b/stratum-apps/src/monitoring/snapshot_cache.rs
@@ -42,7 +42,7 @@ use std::{
 };
 
 use super::{
-    client::{ClientInfo, ClientsMonitoring, ClientsSummary},
+    client::{Sv2ClientInfo, Sv2ClientsMonitoring, Sv2ClientsSummary},
     server::{ServerInfo, ServerMonitoring, ServerSummary},
     sv1::{Sv1ClientInfo, Sv1ClientsMonitoring, Sv1ClientsSummary},
 };
@@ -56,10 +56,10 @@ pub struct MonitoringSnapshot {
     pub timestamp: Option<Instant>,
     pub server_info: Option<ServerInfo>,
     pub server_summary: Option<ServerSummary>,
-    pub clients: Option<Vec<ClientInfo>>,
-    pub clients_summary: Option<ClientsSummary>,
+    pub sv2_clients: Option<Vec<Sv2ClientInfo>>,
+    pub sv2_clients_summary: Option<Sv2ClientsSummary>,
     pub sv1_clients: Option<Vec<Sv1ClientInfo>>,
-    pub sv1_summary: Option<Sv1ClientsSummary>,
+    pub sv1_clients_summary: Option<Sv1ClientsSummary>,
 }
 
 impl MonitoringSnapshot {
@@ -82,7 +82,7 @@ pub struct SnapshotCache {
     snapshot: RwLock<MonitoringSnapshot>,
     refresh_interval: Duration,
     server_source: Option<Arc<dyn ServerMonitoring + Send + Sync>>,
-    sv2_clients_source: Option<Arc<dyn ClientsMonitoring + Send + Sync>>,
+    sv2_clients_source: Option<Arc<dyn Sv2ClientsMonitoring + Send + Sync>>,
     sv1_clients_source: Option<Arc<dyn Sv1ClientsMonitoring + Send + Sync>>,
 }
 
@@ -107,17 +107,17 @@ impl SnapshotCache {
     ///
     /// * `refresh_interval` - How often to refresh the cache (e.g., 15 seconds)
     /// * `server_source` - Optional server monitoring trait object
-    /// * `clients_source` - Optional clients monitoring trait object
+    /// * `sv2_clients_source` - Optional Sv2 clients monitoring trait object
     pub fn new(
         refresh_interval: Duration,
         server_source: Option<Arc<dyn ServerMonitoring + Send + Sync>>,
-        clients_source: Option<Arc<dyn ClientsMonitoring + Send + Sync>>,
+        sv2_clients_source: Option<Arc<dyn Sv2ClientsMonitoring + Send + Sync>>,
     ) -> Self {
         Self {
             snapshot: RwLock::new(MonitoringSnapshot::default()),
             refresh_interval,
             server_source,
-            sv2_clients_source: clients_source,
+            sv2_clients_source,
             sv1_clients_source: None,
         }
     }
@@ -157,14 +157,14 @@ impl SnapshotCache {
 
         // Collect Sv2 clients data
         if let Some(ref source) = self.sv2_clients_source {
-            new_snapshot.clients = Some(source.get_clients());
-            new_snapshot.clients_summary = Some(source.get_clients_summary());
+            new_snapshot.sv2_clients = Some(source.get_sv2_clients());
+            new_snapshot.sv2_clients_summary = Some(source.get_sv2_clients_summary());
         }
 
         // Collect Sv1 clients data
         if let Some(ref source) = self.sv1_clients_source {
             new_snapshot.sv1_clients = Some(source.get_sv1_clients());
-            new_snapshot.sv1_summary = Some(source.get_sv1_clients_summary());
+            new_snapshot.sv1_clients_summary = Some(source.get_sv1_clients_summary());
         }
 
         // Update the cache
@@ -191,9 +191,9 @@ mod tests {
         }
     }
 
-    struct MockClientsMonitoring;
-    impl ClientsMonitoring for MockClientsMonitoring {
-        fn get_clients(&self) -> Vec<ClientInfo> {
+    struct MockSv2ClientsMonitoring;
+    impl Sv2ClientsMonitoring for MockSv2ClientsMonitoring {
+        fn get_sv2_clients(&self) -> Vec<Sv2ClientInfo> {
             vec![]
         }
     }
@@ -203,7 +203,7 @@ mod tests {
         let cache = SnapshotCache::new(
             Duration::from_secs(5),
             Some(Arc::new(MockServerMonitoring)),
-            Some(Arc::new(MockClientsMonitoring)),
+            Some(Arc::new(MockSv2ClientsMonitoring)),
         );
 
         // Before refresh, snapshot has no timestamp
@@ -217,7 +217,7 @@ mod tests {
         let cache = SnapshotCache::new(
             Duration::from_secs(5),
             Some(Arc::new(MockServerMonitoring)),
-            Some(Arc::new(MockClientsMonitoring)),
+            Some(Arc::new(MockSv2ClientsMonitoring)),
         );
 
         // Before refresh, snapshot has no data
@@ -231,8 +231,8 @@ mod tests {
         assert!(snapshot.timestamp.is_some());
         assert!(snapshot.age().unwrap() < Duration::from_millis(100));
         assert!(snapshot.server_info.is_some());
-        assert!(snapshot.clients.is_some());
-        assert!(snapshot.clients_summary.is_some());
+        assert!(snapshot.sv2_clients.is_some());
+        assert!(snapshot.sv2_clients_summary.is_some());
     }
 
     /// Mock monitoring that simulates lock contention with business logic.
@@ -265,8 +265,8 @@ mod tests {
         }
     }
 
-    impl ClientsMonitoring for ContendedMonitoring {
-        fn get_clients(&self) -> Vec<ClientInfo> {
+    impl Sv2ClientsMonitoring for ContendedMonitoring {
+        fn get_sv2_clients(&self) -> Vec<Sv2ClientInfo> {
             let _guard = self.business_lock.lock().unwrap();
             self.monitoring_lock_acquisitions
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
@@ -303,7 +303,7 @@ mod tests {
         let cache = Arc::new(SnapshotCache::new(
             Duration::from_secs(5),
             None,
-            Some(real_monitoring.clone() as Arc<dyn ClientsMonitoring + Send + Sync>),
+            Some(real_monitoring.clone() as Arc<dyn Sv2ClientsMonitoring + Send + Sync>),
         ));
 
         cache.refresh();


### PR DESCRIPTION
Closes #210.

It also renames `ClientInfo` and `ClientsMonitoring` into `Sv2ClientInfo` and `Sv2ClientsMonitoring` for better clarity.