### PR TITLE
feat(monitoring): expose blocks_found metric via Prometheus

### DIFF
--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -292,7 +292,7 @@ dependencies = [
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "buffer_sv2 3.0.1",
  "derive_codec_sv2 1.1.2",
@@ -462,7 +462,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "aes-gcm",
 ]
@@ -589,7 +589,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
  "bitcoin",
@@ -666,7 +666,7 @@ dependencies = [
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
  "buffer_sv2 3.0.1",
@@ -693,7 +693,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
 ]
@@ -927,7 +927,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 
 [[package]]
 name = "digest"
@@ -1034,7 +1034,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
 ]
@@ -1101,7 +1101,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
  "buffer_sv2 3.0.1",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
  "common_messages_sv2 7.0.0",
@@ -1704,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
 ]
@@ -1864,7 +1864,7 @@ dependencies = [
 [[package]]
 name = "mining_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
 ]
@@ -1957,7 +1957,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2095,7 +2095,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
  "common_messages_sv2 7.0.0",
@@ -2820,7 +2820,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
  "bitcoin",
@@ -2843,7 +2843,7 @@ dependencies = [
 [[package]]
 name = "stratum_translation"
 version = "0.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
  "bitcoin",
@@ -2868,7 +2868,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sv1_api"
 version = "2.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
  "bitcoin_hashes 0.3.2",
@@ -2956,7 +2956,7 @@ dependencies = [
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2 5.0.1",
 ]

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "aes-gcm",
 ]
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -610,7 +610,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
 ]
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 
 [[package]]
 name = "digest"
@@ -935,7 +935,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
 ]
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1535,7 +1535,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
 ]
@@ -1656,7 +1656,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
 ]
@@ -1696,7 +1696,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1820,7 +1820,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2462,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2485,7 +2485,7 @@ dependencies = [
 [[package]]
 name = "stratum_translation"
 version = "0.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2510,7 +2510,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sv1_api"
 version = "2.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",
@@ -2557,7 +2557,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
 ]

--- a/miner-apps/jd-client/src/lib/monitoring.rs
+++ b/miner-apps/jd-client/src/lib/monitoring.rs
@@ -47,6 +47,7 @@ impl ServerMonitoring for ChannelManager {
                         share_work_sum: share_accounting.get_share_work_sum(),
                         shares_submitted,
                         best_diff: share_accounting.get_best_diff(),
+                        blocks_found: share_accounting.get_blocks_found(),
                     });
                 }
 
@@ -95,6 +96,7 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                     last_batch_accepted: share_accounting.get_last_batch_accepted(),
                     last_batch_work_sum: share_accounting.get_last_batch_work_sum(),
                     share_batch_size: share_accounting.get_share_batch_size(),
+                    blocks_found: share_accounting.get_blocks_found(),
                 });
             }
 
@@ -120,6 +122,7 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                     last_batch_accepted: share_accounting.get_last_batch_accepted(),
                     last_batch_work_sum: share_accounting.get_last_batch_work_sum(),
                     share_batch_size: share_accounting.get_share_batch_size(),
+                    blocks_found: share_accounting.get_blocks_found(),
                 });
             }
 

--- a/miner-apps/translator/src/lib/mod.rs
+++ b/miner-apps/translator/src/lib/mod.rs
@@ -310,7 +310,7 @@ impl TranslatorSv2 {
                                         monitoring_addr,
                                         Some(channel_manager.clone()),
                                         None,
-                                        std::time::Duration::from_secs(self.config.monitoring_cache_refresh_secs())
+                                        std::time::Duration::from_secs(self.config.monitoring_cache_refresh_secs()),
                                     )
                                     .expect("Failed to initialize monitoring server")
                                     .with_sv1_monitoring(sv1_server.clone())

--- a/miner-apps/translator/src/lib/monitoring.rs
+++ b/miner-apps/translator/src/lib/monitoring.rs
@@ -57,6 +57,7 @@ impl ServerMonitoring for ChannelManager {
                         share_work_sum: share_accounting.get_share_work_sum(),
                         shares_submitted,
                         best_diff: share_accounting.get_best_diff(),
+                        blocks_found: share_accounting.get_blocks_found(),
                     });
                 }
             }
@@ -97,6 +98,7 @@ impl ServerMonitoring for ChannelManager {
                         share_work_sum: share_accounting.get_share_work_sum(),
                         shares_submitted,
                         best_diff: share_accounting.get_best_diff(),
+                        blocks_found: share_accounting.get_blocks_found(),
                     });
                 }
             }

--- a/pool-apps/Cargo.lock
+++ b/pool-apps/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -419,16 +419,16 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "aes-gcm",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6f81257d10a0f602a294ae4182251151ff97dbb504ef9afcdda4a64b24d9b4"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byte-slice-cast"
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5caf74d17c3aec5495110c34cc3f78644bfa89af6c8993ed4de2790e49b6499"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.59"
+version = "4.5.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "370daa45065b80218950227371916a1633217ae42b2715b2287b606dcd618e24"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
 dependencies = [
  "anstream",
  "anstyle",
@@ -601,7 +601,7 @@ checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
 ]
@@ -783,7 +783,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 
 [[package]]
 name = "digest"
@@ -912,7 +912,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
 ]
@@ -973,7 +973,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1108,7 +1108,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1496,7 +1496,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "job_declaration_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
 ]
@@ -1617,7 +1617,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
 ]
@@ -1657,7 +1657,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1781,7 +1781,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2439,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2471,9 +2471,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.116"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df424c70518695237746f84cede799c9c58fcb37450d7b23716568cc8bc69cb"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2506,7 +2506,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#dda2a476882876b20c075c2b0a4457e853f8c7e9"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#ece2b035697ec35a8d1506ee1a321bccc9707b09"
 dependencies = [
  "binary_sv2",
 ]

--- a/pool-apps/pool/src/lib/monitoring.rs
+++ b/pool-apps/pool/src/lib/monitoring.rs
@@ -42,6 +42,7 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                     last_batch_accepted: share_accounting.get_last_batch_accepted(),
                     last_batch_work_sum: share_accounting.get_last_batch_work_sum(),
                     share_batch_size: share_accounting.get_share_batch_size(),
+                    blocks_found: share_accounting.get_blocks_found(),
                 });
             }
 
@@ -67,6 +68,7 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                     last_batch_accepted: share_accounting.get_last_batch_accepted(),
                     last_batch_work_sum: share_accounting.get_last_batch_work_sum(),
                     share_batch_size: share_accounting.get_share_batch_size(),
+                    blocks_found: share_accounting.get_blocks_found(),
                 });
             }
 

--- a/stratum-apps/src/monitoring/README.md
+++ b/stratum-apps/src/monitoring/README.md
@@ -74,6 +74,7 @@ tokio::spawn(async move {
 - `sv2_server_hashrate_total` - Total server hashrate
 - `sv2_server_channel_hashrate{channel_id, user_identity}` - Per-channel hashrate
 - `sv2_server_shares_accepted_total{channel_id, user_identity}` - Per-channel shares
+- `sv2_server_blocks_found_total` - Total blocks found across all current server channels
 
 **Clients:**
 - `sv2_clients_total` - Connected client count
@@ -81,6 +82,7 @@ tokio::spawn(async move {
 - `sv2_client_hashrate_total` - Total client hashrate
 - `sv2_client_channel_hashrate{client_id, channel_id, user_identity}` - Per-channel hashrate
 - `sv2_client_shares_accepted_total{client_id, channel_id, user_identity}` - Per-channel shares
+- `sv2_client_blocks_found_total` - Total blocks found across all current client channels
 
 **Sv1 (Translator Proxy only):**
 - `sv1_clients_total` - Sv1 client count

--- a/stratum-apps/src/monitoring/client.rs
+++ b/stratum-apps/src/monitoring/client.rs
@@ -25,6 +25,7 @@ pub struct ExtendedChannelInfo {
     pub last_batch_accepted: u32,
     pub last_batch_work_sum: f64,
     pub share_batch_size: usize,
+    pub blocks_found: u32,
 }
 
 /// Information about a standard channel
@@ -44,6 +45,7 @@ pub struct StandardChannelInfo {
     pub last_batch_accepted: u32,
     pub last_batch_work_sum: f64,
     pub share_batch_size: usize,
+    pub blocks_found: u32,
 }
 
 /// Full information about a single Sv2 client including all channels

--- a/stratum-apps/src/monitoring/prometheus_metrics.rs
+++ b/stratum-apps/src/monitoring/prometheus_metrics.rs
@@ -14,12 +14,14 @@ pub struct PrometheusMetrics {
     pub sv2_server_hashrate_total: Option<Gauge>,
     pub sv2_server_channel_hashrate: Option<GaugeVec>,
     pub sv2_server_shares_accepted_total: Option<GaugeVec>,
+    pub sv2_server_blocks_found_total: Option<Gauge>,
     // Clients metrics (downstream connections)
     pub sv2_clients_total: Option<Gauge>,
     pub sv2_client_channels: Option<GaugeVec>,
     pub sv2_client_hashrate_total: Option<Gauge>,
     pub sv2_client_channel_hashrate: Option<GaugeVec>,
     pub sv2_client_shares_accepted_total: Option<GaugeVec>,
+    pub sv2_client_blocks_found_total: Option<Gauge>,
     // SV1 metrics
     pub sv1_clients_total: Option<Gauge>,
     pub sv1_hashrate_total: Option<Gauge>,
@@ -43,6 +45,7 @@ impl PrometheusMetrics {
             sv2_server_hashrate_total,
             sv2_server_channel_hashrate,
             sv2_server_shares_accepted_total,
+            sv2_server_blocks_found_total,
         ) = if enable_server_metrics {
             let channels = GaugeVec::new(
                 Opts::new("sv2_server_channels", "Number of server channels by type"),
@@ -74,14 +77,21 @@ impl PrometheusMetrics {
             )?;
             registry.register(Box::new(shares_accepted.clone()))?;
 
+            let blocks_found = Gauge::new(
+                "sv2_server_blocks_found_total",
+                "Total blocks found across all current server channels",
+            )?;
+            registry.register(Box::new(blocks_found.clone()))?;
+
             (
                 Some(channels),
                 Some(hashrate),
                 Some(channel_hashrate),
                 Some(shares_accepted),
+                Some(blocks_found),
             )
         } else {
-            (None, None, None, None)
+            (None, None, None, None, None)
         };
 
         // Clients metrics (downstream connections)
@@ -91,6 +101,7 @@ impl PrometheusMetrics {
             sv2_client_hashrate_total,
             sv2_client_channel_hashrate,
             sv2_client_shares_accepted_total,
+            sv2_client_blocks_found_total,
         ) = if enable_clients_metrics {
             let clients_total =
                 Gauge::new("sv2_clients_total", "Total number of connected clients")?;
@@ -126,15 +137,22 @@ impl PrometheusMetrics {
             )?;
             registry.register(Box::new(shares_accepted.clone()))?;
 
+            let blocks_found = Gauge::new(
+                "sv2_client_blocks_found_total",
+                "Total blocks found across all current client channels",
+            )?;
+            registry.register(Box::new(blocks_found.clone()))?;
+
             (
                 Some(clients_total),
                 Some(channels),
                 Some(hashrate),
                 Some(channel_hashrate),
                 Some(shares_accepted),
+                Some(blocks_found),
             )
         } else {
-            (None, None, None, None, None)
+            (None, None, None, None, None, None)
         };
 
         // SV1 metrics
@@ -157,11 +175,13 @@ impl PrometheusMetrics {
             sv2_server_hashrate_total,
             sv2_server_channel_hashrate,
             sv2_server_shares_accepted_total,
+            sv2_server_blocks_found_total,
             sv2_clients_total,
             sv2_client_channels,
             sv2_client_hashrate_total,
             sv2_client_channel_hashrate,
             sv2_client_shares_accepted_total,
+            sv2_client_blocks_found_total,
             sv1_clients_total,
             sv1_hashrate_total,
         })

--- a/stratum-apps/src/monitoring/server.rs
+++ b/stratum-apps/src/monitoring/server.rs
@@ -22,6 +22,7 @@ pub struct ServerExtendedChannelInfo {
     pub share_work_sum: f64,
     pub shares_submitted: u32,
     pub best_diff: f64,
+    pub blocks_found: u32,
 }
 
 /// Information about a standard channel opened with the server
@@ -37,6 +38,7 @@ pub struct ServerStandardChannelInfo {
     pub share_work_sum: f64,
     pub shares_submitted: u32,
     pub best_diff: f64,
+    pub blocks_found: u32,
 }
 
 /// Information about the server (upstream connection)


### PR DESCRIPTION
Add sv2_server_blocks_found_total Prometheus gauge that aggregates blocks found across all server channels. Only server-side monitoring exposes this metric since only the pool and JDC (in solo mode) can find blocks.

Changes:
- Add blocks_found to ServerExtendedChannelInfo and ServerStandardChannelInfo
- Wire blocks_found in JDC server monitoring (from downstream channels)
- Set blocks_found=0 in translator (doesn't find blocks)
- Add sv2_server_blocks_found_total Prometheus gauge
- Aggregate and expose total blocks in HTTP metrics handler

Note: CI/CD will fail until the corresponding stratum changes are merged and Cargo.lock files are updated to reference the new stratum version.