### PR TITLE
fix(tproxy): report SV1 downstream hashrate when vardiff is disabled

### DIFF
--- a/miner-apps/translator/config-examples/mainnet/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/mainnet/tproxy-config-local-jdc-example.toml
@@ -47,8 +47,8 @@ monitoring_cache_refresh_secs = 15
 min_individual_miner_hashrate=10_000_000_000_000.0
 # target number of shares per minute the miner should be sending
 shares_per_minute = 6.0
-# disable variable difficulty adjustment when using with JDC (JDC handles vardiff)
-enable_vardiff = false
+# enable variable difficulty for per-miner difficulty tuning
+enable_vardiff = true
 
 # Interval in seconds for sending keepalive jobs to downstream miners.
 job_keepalive_interval_secs = 60

--- a/miner-apps/translator/config-examples/signet/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/signet/tproxy-config-local-jdc-example.toml
@@ -47,8 +47,8 @@ monitoring_cache_refresh_secs = 15
 min_individual_miner_hashrate=10_000_000_000_000.0
 # target number of shares per minute the miner should be sending
 shares_per_minute = 6.0
-# disable variable difficulty adjustment when using with JDC (JDC handles vardiff)
-enable_vardiff = false
+# enable variable difficulty for per-miner difficulty tuning
+enable_vardiff = true
 
 # Interval in seconds for sending keepalive jobs to downstream miners.
 job_keepalive_interval_secs = 60

--- a/miner-apps/translator/config-examples/testnet4/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/testnet4/tproxy-config-local-jdc-example.toml
@@ -47,8 +47,8 @@ monitoring_cache_refresh_secs = 15
 min_individual_miner_hashrate=10_000_000_000_000.0
 # target number of shares per minute the miner should be sending
 shares_per_minute = 6.0
-# disable variable difficulty adjustment when using with JDC (JDC handles vardiff)
-enable_vardiff = false
+# enable variable difficulty for per-miner difficulty tuning
+enable_vardiff = true
 
 # Interval in seconds for sending keepalive jobs to downstream miners.
 job_keepalive_interval_secs = 60

--- a/miner-apps/translator/src/lib/sv1_monitoring.rs
+++ b/miner-apps/translator/src/lib/sv1_monitoring.rs
@@ -3,14 +3,10 @@
 //! This module implements the Sv1ClientsMonitoring trait on `Sv1Server`.
 use stratum_apps::monitoring::sv1::{Sv1ClientInfo, Sv1ClientsMonitoring};
 
-use crate::{
-    sv1::{downstream::downstream::Downstream, sv1_server::sv1_server::Sv1Server},
-    vardiff_enabled,
-};
+use crate::sv1::{downstream::downstream::Downstream, sv1_server::sv1_server::Sv1Server};
 
 /// Helper to convert a Downstream to Sv1ClientInfo
 fn downstream_to_sv1_client_info(downstream: &Downstream) -> Option<Sv1ClientInfo> {
-    let report_hashrate = vardiff_enabled();
     downstream
         .downstream_data
         .safe_lock(|dd| Sv1ClientInfo {
@@ -19,7 +15,7 @@ fn downstream_to_sv1_client_info(downstream: &Downstream) -> Option<Sv1ClientInf
             authorized_worker_name: dd.authorized_worker_name.clone(),
             user_identity: dd.user_identity.clone(),
             target_hex: hex::encode(dd.target.to_be_bytes()),
-            hashrate: if report_hashrate { dd.hashrate } else { None },
+            hashrate: dd.hashrate,
             extranonce1_hex: hex::encode(&dd.extranonce1),
             extranonce2_len: dd.extranonce2_len,
             version_rolling_mask: dd


### PR DESCRIPTION
When vardiff is disabled, the tproxy was reporting zero hashrate for all SV1 downstream miners because the monitoring code in sv1_monitoring.rs gated hashrate reporting on vardiff_enabled(), and handle_set_target_without_vardiff never derived or stored hashrate from upstream SetTarget messages.

This fix:
- Removes the vardiff_enabled() gate from sv1_monitoring.rs so per-miner hashrate is always reported when available
- Derives hashrate from upstream SetTarget via hash_rate_from_target() and stores it as pending_hashrate on each affected downstream, so it becomes available when the next mining.notify flushes the pending state

Server-facing hashrate metrics (sv2_server_hashrate_total, sv2_server_channel_hashrate) intentionally remain suppressed when vardiff is disabled, since the JDC is the source of truth for those.

Closes #289