### PR TITLE
feat(monitoring): track all share response outcomes per channel

### DIFF
--- a/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
@@ -29,6 +29,8 @@ use stratum_apps::{
 };
 use tracing::{debug, error, info, warn};
 
+use stratum_apps::monitoring::client::ShareResponseCounts;
+
 use crate::{
     channel_manager::{
         ChannelManager, ChannelManagerChannel, SharesOrderedByDiff, FULL_EXTRANONCE_SIZE,
@@ -435,9 +437,12 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         let vardiff =
                             VardiffState::new().expect("Vardiff state should instantiate.");
 
+                        let key = (downstream_id, standard_channel_id).into();
+                        channel_manager_data.vardiff.insert(key, vardiff);
                         channel_manager_data
-                            .vardiff
-                            .insert((downstream_id, standard_channel_id).into(), vardiff);
+                            .share_response_counts
+                            .entry((downstream_id, standard_channel_id).into())
+                            .or_default();
                         data.standard_channels
                             .insert(standard_channel_id, standard_channel);
 
@@ -711,6 +716,10 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         channel_manager_data
                             .vardiff
                             .insert((downstream_id, extended_channel_id).into(), vardiff);
+                        channel_manager_data
+                            .share_response_counts
+                            .entry((downstream_id, extended_channel_id).into())
+                            .or_default();
 
                         data.group_channel
                             .add_channel_id(extended_channel_id, full_extranonce_size)
@@ -969,20 +978,27 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             downstream.downstream_data.super_safe_lock(|data| {
                 let mut messages: Vec<RouteMessageTo> = vec![];
 
+                let vardiff_key = (downstream_id, channel_id).into();
+
                 let Some(standard_channel) = data.standard_channels.get_mut(&channel_id) else {
                     error!("SubmitSharesError: channel_id: {channel_id}, sequence_number: {}, error_code: invalid-channel-id", msg.sequence_number);
+                    if let Some(counts) = channel_manager_data.share_response_counts.get_mut(&vardiff_key) {
+                        counts.invalid_channel_id += 1;
+                    }
                     return Ok(vec![(downstream_id, build_error("invalid-channel-id")).into()]);
                 };
 
-                let Some(vardiff) = channel_manager_data.vardiff.get_mut(&(downstream_id, channel_id).into()) else {
+                let Some(vardiff) = channel_manager_data.vardiff.get_mut(&vardiff_key) else {
                     return Ok(vec![(downstream_id, Mining::CloseChannel(create_close_channel_msg(channel_id, "invalid-channel-id"))).into()]);
                 };
                 vardiff.increment_shares_since_last_update();
                 let res = standard_channel.validate_share(msg.clone());
                 let mut is_downstream_share_valid = false;
                 let mut downstream_share_hash: Option<sha256d::Hash> = None;
+                let mut outcome = ShareResponseCounts::default();
                 match res {
                     Ok(ShareValidationResult::Valid(share_hash)) => {
+                        outcome.accepted = 1;
                         let share_accounting = standard_channel.get_share_accounting();
                         if share_accounting.should_acknowledge() {
                             let success = SubmitSharesSuccess {
@@ -1003,6 +1019,8 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         is_downstream_share_valid = true;
                     }
                     Ok(ShareValidationResult::BlockFound(share_hash, template_id, coinbase)) => {
+                        outcome.accepted = 1;
+                        outcome.blocks_found = 1;
                         info!("SubmitSharesStandard on downstream channel: 💰 Block Found!!! 💰{share_hash}");
                         downstream_share_hash = Some(share_hash);
                         is_downstream_share_valid = true;
@@ -1032,16 +1050,21 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                     }
                     Err(err) => {
                         let code = match err {
-                            ShareValidationError::Invalid => "invalid-share",
-                            ShareValidationError::Stale => "stale-share",
-                            ShareValidationError::InvalidJobId => "invalid-job-id",
-                            ShareValidationError::DoesNotMeetTarget => "difficulty-too-low",
-                            ShareValidationError::DuplicateShare => "duplicate-share",
+                            ShareValidationError::Invalid => { outcome.invalid = 1; "invalid-share" }
+                            ShareValidationError::Stale => { outcome.stale = 1; "stale-share" }
+                            ShareValidationError::InvalidJobId => { outcome.invalid_job_id = 1; "invalid-job-id" }
+                            ShareValidationError::DoesNotMeetTarget => { outcome.difficulty_too_low = 1; "difficulty-too-low" }
+                            ShareValidationError::DuplicateShare => { outcome.duplicate = 1; "duplicate-share" }
                             _ => unreachable!(),
                         };
                         error!("❌ SubmitSharesError: ch={}, seq={}, error={code}", channel_id, msg.sequence_number);
                         messages.push((downstream_id, build_error(code)).into());
                     }
+                }
+
+                // Accumulate share outcome into per-channel counters
+                if let Some(counts) = channel_manager_data.share_response_counts.get_mut(&vardiff_key) {
+                    counts.accumulate(&outcome);
                 }
 
                 if !is_downstream_share_valid {
@@ -1204,8 +1227,13 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             downstream.downstream_data.super_safe_lock(|data| {
                 let mut messages: Vec<RouteMessageTo> = vec![];
 
+                let vardiff_key = (downstream_id, channel_id).into();
+
                 let Some(extended_channel) = data.extended_channels.get_mut(&channel_id) else {
                     error!("SubmitSharesError: channel_id: {channel_id}, sequence_number: {}, error_code: invalid-channel-id", msg.sequence_number);
+                    if let Some(counts) = channel_manager_data.share_response_counts.get_mut(&vardiff_key) {
+                        counts.invalid_channel_id += 1;
+                    }
                     return Ok(vec![(downstream_id, build_error("invalid-channel-id")).into()]);
                 };
                 // here we extract and set the user_identity from the TLV fields if the extension is negotiated
@@ -1225,15 +1253,17 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                     // here we have the UserIdentity TLV, so we can use it to enhance monitoring of individual miners in the future
                 }
 
-                let Some(vardiff) = channel_manager_data.vardiff.get_mut(&(downstream_id, channel_id).into()) else {
+                let Some(vardiff) = channel_manager_data.vardiff.get_mut(&vardiff_key) else {
                     return Ok(vec![(downstream_id, Mining::CloseChannel(create_close_channel_msg(channel_id, "invalid-channel-id"))).into()]);
                 };
                 vardiff.increment_shares_since_last_update();
                 let res = extended_channel.validate_share(msg.clone());
                 let mut is_downstream_share_valid = false;
                 let mut downstream_share_hash: Option<sha256d::Hash> = None;
+                let mut outcome = ShareResponseCounts::default();
                 match res {
                     Ok(ShareValidationResult::Valid(share_hash)) => {
+                        outcome.accepted = 1;
                         let share_accounting = extended_channel.get_share_accounting();
                         if share_accounting.should_acknowledge() {
                             let success = SubmitSharesSuccess {
@@ -1254,6 +1284,8 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         is_downstream_share_valid = true;
                     }
                     Ok(ShareValidationResult::BlockFound(share_hash, template_id, coinbase)) => {
+                        outcome.accepted = 1;
+                        outcome.blocks_found = 1;
                         info!("SubmitSharesExtended on downstream channel: 💰 Block Found!!! 💰{share_hash}");
                         downstream_share_hash = Some(share_hash);
                         if let Some(template_id) = template_id {
@@ -1282,17 +1314,22 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                     }
                     Err(err) => {
                         let code = match err {
-                            ShareValidationError::Invalid => "invalid-share",
-                            ShareValidationError::Stale => "stale-share",
-                            ShareValidationError::InvalidJobId => "invalid-job-id",
-                            ShareValidationError::DoesNotMeetTarget => "difficulty-too-low",
-                            ShareValidationError::DuplicateShare => "duplicate-share",
-                            ShareValidationError::BadExtranonceSize => "bad-extranonce-size",
+                            ShareValidationError::Invalid => { outcome.invalid = 1; "invalid-share" }
+                            ShareValidationError::Stale => { outcome.stale = 1; "stale-share" }
+                            ShareValidationError::InvalidJobId => { outcome.invalid_job_id = 1; "invalid-job-id" }
+                            ShareValidationError::DoesNotMeetTarget => { outcome.difficulty_too_low = 1; "difficulty-too-low" }
+                            ShareValidationError::DuplicateShare => { outcome.duplicate = 1; "duplicate-share" }
+                            ShareValidationError::BadExtranonceSize => { outcome.bad_extranonce_size = 1; "bad-extranonce-size" }
                             _ => unreachable!(),
                         };
                         error!("❌ SubmitSharesError on downstream channel: ch={}, seq={}, error={code}", channel_id, msg.sequence_number);
                         messages.push((downstream_id, build_error(code)).into());
                     }
+                }
+
+                // Accumulate share outcome into per-channel counters
+                if let Some(counts) = channel_manager_data.share_response_counts.get_mut(&vardiff_key) {
+                    counts.accumulate(&outcome);
                 }
 
                 if !is_downstream_share_valid{

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -58,6 +58,8 @@ use stratum_apps::{
 use tokio::{net::TcpListener, select, sync::broadcast};
 use tracing::{debug, error, info, warn};
 
+use stratum_apps::monitoring::client::ShareResponseCounts;
+
 use crate::{
     channel_manager::downstream_message_handler::RouteMessageTo,
     config::JobDeclaratorClientConfig,
@@ -169,6 +171,13 @@ pub struct ChannelManagerData {
     required_extensions: Vec<u16>,
     /// Cached shares waiting for `SetCustomMiningJob.Success` to be propagated upstream
     cached_shares: HashMap<TemplateId, BinaryHeap<SharesOrderedByDiff>>,
+    /// Per-channel counters for all share submission outcomes.
+    /// Tracks every share response the JDC sends back to a downstream channel,
+    /// enabling monitoring of rejection rates and root-cause analysis.
+    pub share_response_counts: HashMap<VardiffKey, ShareResponseCounts>,
+    /// Counters for share rejections received from the upstream server.
+    /// Keyed by channel_id. Populated from SubmitSharesError messages.
+    pub server_share_response_counts: HashMap<ChannelId, ShareResponseCounts>,
 }
 
 impl ChannelManagerData {
@@ -206,6 +215,8 @@ impl ChannelManagerData {
         self.allocate_tokens = None;
         self.upstream_channel = None;
         self.pool_tag_string = None;
+        self.share_response_counts.clear();
+        self.server_share_response_counts.clear();
 
         self.coinbase_outputs = coinbase_outputs;
     }
@@ -327,6 +338,8 @@ impl ChannelManager {
             supported_extensions,
             required_extensions,
             cached_shares: HashMap::new(),
+            share_response_counts: HashMap::new(),
+            server_share_response_counts: HashMap::new(),
         }));
 
         let channel_manager_channel = ChannelManagerChannel {
@@ -684,6 +697,9 @@ impl ChannelManager {
                 .retain(|key, _| key.downstream_id != downstream_id);
             cm_data
                 .vardiff
+                .retain(|key, _| key.downstream_id != downstream_id);
+            cm_data
+                .share_response_counts
                 .retain(|key, _| key.downstream_id != downstream_id);
         });
         Ok(())

--- a/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
@@ -511,6 +511,27 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
         warn!("Received: {} ❌", msg);
+
+        let error_code = msg.error_code.as_utf8_or_hex();
+        self.channel_manager_data.super_safe_lock(|data| {
+            let counts = data
+                .server_share_response_counts
+                .entry(msg.channel_id)
+                .or_default();
+            match error_code.as_str() {
+                "invalid-share" => counts.invalid += 1,
+                "stale-share" => counts.stale += 1,
+                "invalid-job-id" => counts.invalid_job_id += 1,
+                "difficulty-too-low" => counts.difficulty_too_low += 1,
+                "duplicate-share" => counts.duplicate += 1,
+                "bad-extranonce-size" => counts.bad_extranonce_size += 1,
+                "invalid-channel-id" => counts.invalid_channel_id += 1,
+                _ => {
+                    warn!("Unknown SubmitSharesError error_code: {}", error_code);
+                }
+            }
+        });
+
         Ok(())
     }
 

--- a/miner-apps/jd-client/src/lib/monitoring.rs
+++ b/miner-apps/jd-client/src/lib/monitoring.rs
@@ -5,10 +5,18 @@
 //! - Server channels (upstream to pool)
 //! - Client channels (downstream miners connecting to JDC)
 
+use std::collections::HashMap;
+
 use hex;
-use stratum_apps::monitoring::{
-    client::{ExtendedChannelInfo, StandardChannelInfo, Sv2ClientInfo, Sv2ClientsMonitoring},
-    server::{ServerExtendedChannelInfo, ServerInfo, ServerMonitoring},
+use stratum_apps::{
+    monitoring::{
+        client::{
+            ExtendedChannelInfo, ShareResponseCounts, StandardChannelInfo, Sv2ClientInfo,
+            Sv2ClientsMonitoring,
+        },
+        server::{ServerExtendedChannelInfo, ServerInfo, ServerMonitoring},
+    },
+    utils::types::VardiffKey,
 };
 
 use crate::{channel_manager::ChannelManager, downstream::Downstream};
@@ -34,6 +42,8 @@ impl ServerMonitoring for ChannelManager {
                         .load(std::sync::atomic::Ordering::Relaxed)
                         .saturating_sub(1);
 
+                    let share_responses = d.server_share_response_counts.get(&channel_id).cloned();
+
                     extended_channels.push(ServerExtendedChannelInfo {
                         channel_id,
                         user_identity: user_identity.clone(),
@@ -48,6 +58,7 @@ impl ServerMonitoring for ChannelManager {
                         shares_submitted,
                         best_diff: share_accounting.get_best_diff(),
                         blocks_found: share_accounting.get_blocks_found(),
+                        share_responses,
                     });
                 }
 
@@ -65,7 +76,11 @@ impl ServerMonitoring for ChannelManager {
 
 /// Helper to convert a Downstream to Sv2ClientInfo.
 /// Returns None if the lock cannot be acquired (graceful degradation for monitoring).
-fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
+fn downstream_to_sv2_client_info(
+    client: &Downstream,
+    share_response_counts: &HashMap<VardiffKey, ShareResponseCounts>,
+) -> Option<Sv2ClientInfo> {
+    let downstream_id = client.downstream_id;
     client
         .downstream_data
         .safe_lock(|dd| {
@@ -78,6 +93,9 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                 let requested_max_target = extended_channel.get_requested_max_target();
                 let user_identity = extended_channel.get_user_identity();
                 let share_accounting = extended_channel.get_share_accounting();
+
+                let key: VardiffKey = (downstream_id, channel_id).into();
+                let share_responses = share_response_counts.get(&key).cloned();
 
                 extended_channels.push(ExtendedChannelInfo {
                     channel_id,
@@ -97,6 +115,7 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                     last_batch_work_sum: share_accounting.get_last_batch_work_sum(),
                     share_batch_size: share_accounting.get_share_batch_size(),
                     blocks_found: share_accounting.get_blocks_found(),
+                    share_responses,
                 });
             }
 
@@ -106,6 +125,9 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                 let requested_max_target = standard_channel.get_requested_max_target();
                 let user_identity = standard_channel.get_user_identity();
                 let share_accounting = standard_channel.get_share_accounting();
+
+                let key: VardiffKey = (downstream_id, channel_id).into();
+                let share_responses = share_response_counts.get(&key).cloned();
 
                 standard_channels.push(StandardChannelInfo {
                     channel_id,
@@ -123,11 +145,12 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                     last_batch_work_sum: share_accounting.get_last_batch_work_sum(),
                     share_batch_size: share_accounting.get_share_batch_size(),
                     blocks_found: share_accounting.get_blocks_found(),
+                    share_responses,
                 });
             }
 
             Sv2ClientInfo {
-                client_id: client.downstream_id,
+                client_id: downstream_id,
                 extended_channels,
                 standard_channels,
             }
@@ -137,25 +160,34 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
 
 impl Sv2ClientsMonitoring for ChannelManager {
     fn get_sv2_clients(&self) -> Vec<Sv2ClientInfo> {
-        // Clone Downstream references and release lock immediately to avoid contention
-        // with template distribution and message handling
-        let downstream_refs: Vec<Downstream> = self
+        // Clone Downstream references and share_response_counts, then release lock
+        // immediately to avoid contention with template distribution and message handling
+        let (downstream_refs, share_response_counts): (
+            Vec<Downstream>,
+            HashMap<VardiffKey, ShareResponseCounts>,
+        ) = self
             .channel_manager_data
-            .safe_lock(|data| data.downstream.values().cloned().collect())
+            .safe_lock(|data| {
+                (
+                    data.downstream.values().cloned().collect(),
+                    data.share_response_counts.clone(),
+                )
+            })
             .unwrap_or_default();
 
         downstream_refs
             .iter()
-            .filter_map(downstream_to_sv2_client_info)
+            .filter_map(|d| downstream_to_sv2_client_info(d, &share_response_counts))
             .collect()
     }
 
     fn get_sv2_client_by_id(&self, client_id: usize) -> Option<Sv2ClientInfo> {
         self.channel_manager_data
             .safe_lock(|d| {
+                let share_response_counts = &d.share_response_counts;
                 d.downstream
                     .get(&client_id)
-                    .and_then(downstream_to_sv2_client_info)
+                    .and_then(|ds| downstream_to_sv2_client_info(ds, share_response_counts))
             })
             .unwrap_or(None)
     }

--- a/miner-apps/translator/src/lib/monitoring.rs
+++ b/miner-apps/translator/src/lib/monitoring.rs
@@ -4,7 +4,10 @@
 //! tProxy has server channels (upstream to pool) but no SV2 clients
 //! (SV1 clients are handled separately in sv1_monitoring.rs).
 
-use stratum_apps::monitoring::server::{ServerExtendedChannelInfo, ServerInfo, ServerMonitoring};
+use stratum_apps::monitoring::{
+    client::ShareResponseCounts,
+    server::{ServerExtendedChannelInfo, ServerInfo, ServerMonitoring},
+};
 
 use crate::{
     sv2::channel_manager::ChannelManager, tproxy_mode, utils::AGGREGATED_CHANNEL_ID,
@@ -38,6 +41,12 @@ impl ServerMonitoring for ChannelManager {
                         .map(|v| *v)
                         .unwrap_or(0);
 
+                    // In aggregated mode, rejections are keyed by AGGREGATED_CHANNEL_ID
+                    let share_responses: Option<ShareResponseCounts> = self
+                        .server_share_response_counts
+                        .get(&AGGREGATED_CHANNEL_ID)
+                        .map(|r| r.clone());
+
                     extended_channels.push(ServerExtendedChannelInfo {
                         channel_id,
                         user_identity: user_identity.clone(),
@@ -58,6 +67,7 @@ impl ServerMonitoring for ChannelManager {
                         shares_submitted,
                         best_diff: share_accounting.get_best_diff(),
                         blocks_found: share_accounting.get_blocks_found(),
+                        share_responses,
                     });
                 }
             }
@@ -81,6 +91,11 @@ impl ServerMonitoring for ChannelManager {
                         .map(|v| *v)
                         .unwrap_or(0);
 
+                    let share_responses: Option<ShareResponseCounts> = self
+                        .server_share_response_counts
+                        .get(&channel_id)
+                        .map(|r| r.clone());
+
                     extended_channels.push(ServerExtendedChannelInfo {
                         channel_id,
                         user_identity: user_identity.clone(),
@@ -99,6 +114,7 @@ impl ServerMonitoring for ChannelManager {
                         shares_submitted,
                         best_diff: share_accounting.get_best_diff(),
                         blocks_found: share_accounting.get_blocks_found(),
+                        share_responses,
                     });
                 }
             }

--- a/miner-apps/translator/src/lib/sv1/downstream/data.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream/data.rs
@@ -13,6 +13,23 @@ use tracing::debug;
 
 use super::SubmitShareWithChannelId;
 
+/// Per-downstream counters for SV1 share submission outcomes.
+///
+/// Tracks every share response the tProxy sends back to an SV1 miner,
+/// enabling monitoring of rejection rates and root-cause analysis.
+/// Counters are monotonically increasing over the lifetime of the connection.
+#[derive(Debug, Clone, Default)]
+pub struct Sv1ShareCounts {
+    /// Shares that passed local validation and were forwarded upstream.
+    pub accepted: u32,
+    /// Share referenced an unknown job_id.
+    pub job_not_found: u32,
+    /// Share submitted before channel was open.
+    pub channel_not_open: u32,
+    /// Share failed PoW validation against the downstream target.
+    pub failed_validation: u32,
+}
+
 #[derive(Debug)]
 pub struct DownstreamData {
     pub channel_id: Option<ChannelId>,
@@ -37,6 +54,8 @@ pub struct DownstreamData {
     pub upstream_target: Option<Target>,
     // Timestamp of when the last job was received by this downstream, used for keepalive check
     pub last_job_received_time: Option<Instant>,
+    /// Per-outcome share response counters for local SV1 validation.
+    pub share_counts: Sv1ShareCounts,
 }
 
 impl DownstreamData {
@@ -62,6 +81,7 @@ impl DownstreamData {
             pending_share: None,
             upstream_target: None,
             last_job_received_time: None,
+            share_counts: Sv1ShareCounts::default(),
         }
     }
 

--- a/miner-apps/translator/src/lib/sv1/sv1_server/downstream_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/downstream_message_handler.rs
@@ -110,6 +110,9 @@ impl IsServer<'static> for Sv1Server {
             .downstream_data
             .super_safe_lock(|data| data.channel_id)
         else {
+            downstream
+                .downstream_data
+                .super_safe_lock(|data| data.share_counts.channel_not_open += 1);
             return false;
         };
 
@@ -128,6 +131,9 @@ impl IsServer<'static> for Sv1Server {
             .and_then(|jobs| find_job(jobs.as_ref()));
 
         let Some(job) = job else {
+            downstream
+                .downstream_data
+                .super_safe_lock(|data| data.share_counts.job_not_found += 1);
             return false;
         };
 
@@ -139,6 +145,7 @@ impl IsServer<'static> for Sv1Server {
                         "Cannot submit share: channel_id is None \
                          (waiting for OpenExtendedMiningChannelSuccess)"
                     );
+                    data.share_counts.channel_not_open += 1;
                     return false;
                 }
             };
@@ -159,8 +166,11 @@ impl IsServer<'static> for Sv1Server {
 
             if !is_valid {
                 error!("Invalid share for channel id: {}", channel_id);
+                data.share_counts.failed_validation += 1;
                 return false;
             }
+
+            data.share_counts.accepted += 1;
 
             data.pending_share = Some(SubmitShareWithChannelId {
                 channel_id,

--- a/miner-apps/translator/src/lib/sv1_monitoring.rs
+++ b/miner-apps/translator/src/lib/sv1_monitoring.rs
@@ -1,7 +1,10 @@
 //! SV1 client monitoring integration for Sv1Server
 //!
 //! This module implements the Sv1ClientsMonitoring trait on `Sv1Server`.
-use stratum_apps::monitoring::sv1::{Sv1ClientInfo, Sv1ClientsMonitoring};
+use stratum_apps::monitoring::{
+    client::ShareResponseCounts,
+    sv1::{Sv1ClientInfo, Sv1ClientsMonitoring},
+};
 
 use crate::sv1::{downstream::downstream::Downstream, sv1_server::sv1_server::Sv1Server};
 
@@ -9,23 +12,39 @@ use crate::sv1::{downstream::downstream::Downstream, sv1_server::sv1_server::Sv1
 fn downstream_to_sv1_client_info(downstream: &Downstream) -> Option<Sv1ClientInfo> {
     downstream
         .downstream_data
-        .safe_lock(|dd| Sv1ClientInfo {
-            client_id: downstream.downstream_id,
-            channel_id: dd.channel_id,
-            authorized_worker_name: dd.authorized_worker_name.clone(),
-            user_identity: dd.user_identity.clone(),
-            target_hex: hex::encode(dd.target.to_be_bytes()),
-            hashrate: dd.hashrate,
-            extranonce1_hex: hex::encode(&dd.extranonce1),
-            extranonce2_len: dd.extranonce2_len,
-            version_rolling_mask: dd
-                .version_rolling_mask
-                .as_ref()
-                .map(|mask| format!("{:08x}", mask.0)),
-            version_rolling_min_bit: dd
-                .version_rolling_min_bit
-                .as_ref()
-                .map(|bit| format!("{:08x}", bit.0)),
+        .safe_lock(|dd| {
+            let sc = &dd.share_counts;
+            let share_responses = ShareResponseCounts {
+                accepted: sc.accepted,
+                blocks_found: 0,
+                invalid: sc.failed_validation,
+                stale: 0,
+                invalid_job_id: sc.job_not_found,
+                difficulty_too_low: 0,
+                duplicate: 0,
+                bad_extranonce_size: 0,
+                invalid_channel_id: sc.channel_not_open,
+            };
+
+            Sv1ClientInfo {
+                client_id: downstream.downstream_id,
+                channel_id: dd.channel_id,
+                authorized_worker_name: dd.authorized_worker_name.clone(),
+                user_identity: dd.user_identity.clone(),
+                target_hex: hex::encode(dd.target.to_be_bytes()),
+                hashrate: dd.hashrate,
+                extranonce1_hex: hex::encode(&dd.extranonce1),
+                extranonce2_len: dd.extranonce2_len,
+                version_rolling_mask: dd
+                    .version_rolling_mask
+                    .as_ref()
+                    .map(|mask| format!("{:08x}", mask.0)),
+                version_rolling_min_bit: dd
+                    .version_rolling_min_bit
+                    .as_ref()
+                    .map(|bit| format!("{:08x}", bit.0)),
+                share_responses: Some(share_responses),
+            }
         })
         .ok()
 }

--- a/miner-apps/translator/src/lib/sv2/channel_manager/channel_manager.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/channel_manager.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use stratum_apps::{
     custom_mutex::Mutex,
     fallback_coordinator::FallbackCoordinator,
+    monitoring::client::ShareResponseCounts,
     stratum_core::{
         channels_sv2::client::{extended::ExtendedChannel, group::GroupChannel},
         codec_sv2::StandardSv2Frame,
@@ -75,6 +76,9 @@ pub struct ChannelManager {
     pub negotiated_extensions: Arc<Mutex<Vec<u16>>>,
     /// Extranonce factories containing per channel extranonces
     pub extranonce_factories: Arc<DashMap<ChannelId, ExtendedExtranonce>>,
+    /// Per-channel share response counts received from the upstream server.
+    /// Keyed by channel_id. Tracks rejections reported via SubmitSharesError.
+    pub server_share_response_counts: Arc<DashMap<ChannelId, ShareResponseCounts>>,
 }
 
 #[cfg_attr(not(test), hotpath::measure_all)]
@@ -122,6 +126,7 @@ impl ChannelManager {
             share_sequence_counters: Arc::new(DashMap::new()),
             negotiated_extensions: Arc::new(Mutex::new(Vec::new())),
             extranonce_factories: Arc::new(DashMap::new()),
+            server_share_response_counts: Arc::new(DashMap::new()),
         }
     }
 

--- a/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
@@ -383,6 +383,30 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
         warn!("Received: {} ❌", m);
+
+        // In aggregated mode the pool responds with the upstream channel ID;
+        // map it back to AGGREGATED_CHANNEL_ID so the counter key is consistent.
+        let key = if is_aggregated() {
+            AGGREGATED_CHANNEL_ID
+        } else {
+            m.channel_id
+        };
+
+        let error_code = m.error_code.as_utf8_or_hex();
+        let mut counts = self.server_share_response_counts.entry(key).or_default();
+        match error_code.as_str() {
+            "invalid-share" => counts.invalid += 1,
+            "stale-share" => counts.stale += 1,
+            "invalid-job-id" => counts.invalid_job_id += 1,
+            "difficulty-too-low" => counts.difficulty_too_low += 1,
+            "duplicate-share" => counts.duplicate += 1,
+            "bad-extranonce-size" => counts.bad_extranonce_size += 1,
+            "invalid-channel-id" => counts.invalid_channel_id += 1,
+            _ => {
+                warn!("Unknown SubmitSharesError error_code: {}", error_code);
+            }
+        }
+
         Ok(())
     }
 

--- a/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
@@ -23,6 +23,8 @@ use stratum_apps::stratum_core::{
 };
 use tracing::{error, info};
 
+use stratum_apps::monitoring::client::ShareResponseCounts;
+
 use crate::{
     channel_manager::{ChannelManager, RouteMessageTo, CLIENT_SEARCH_SPACE_BYTES},
     error::{self, PoolError, PoolErrorKind},
@@ -241,6 +243,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 }
                 let vardiff = VardiffState::new().map_err(PoolError::shutdown)?;
                 channel_manager_data.vardiff.insert((downstream_id, channel_id).into(), vardiff);
+                channel_manager_data.share_response_counts.insert((downstream_id, channel_id).into(), ShareResponseCounts::default());
 
                 Ok(messages)
             })
@@ -504,6 +507,9 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         channel_manager_data
                             .vardiff
                             .insert((downstream_id, channel_id).into(), vardiff);
+                        channel_manager_data
+                            .share_response_counts
+                            .insert((downstream_id, channel_id).into(), ShareResponseCounts::default());
 
                         Ok(messages)
                     })
@@ -545,6 +551,10 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                             .expect("error code must be valid string"),
                     };
                     error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: invalid-channel-id ❌", downstream_id, channel_id, msg.sequence_number);
+                    channel_manager_data.share_response_counts
+                        .entry((downstream_id, channel_id).into())
+                        .or_default()
+                        .invalid_channel_id += 1;
                     return Ok(vec![(downstream_id, Mining::SubmitSharesError(submit_shares_error)).into()]);
                 };
 
@@ -555,9 +565,13 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 let res = standard_channel.validate_share(msg.clone());
                 vardiff.increment_shares_since_last_update();
 
+                // Track the share outcome so we can update share_response_counts
+                // after the vardiff borrow is released (avoids overlapping mutable borrows).
+                let mut outcome = ShareResponseCounts::default();
 
                 match res {
                     Ok(ShareValidationResult::Valid(share_hash)) => {
+                        outcome.accepted = 1;
                         let share_accounting = standard_channel.get_share_accounting();
                         if share_accounting.should_acknowledge() {
                             let success = SubmitSharesSuccess {
@@ -578,6 +592,8 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
 
                     }
                     Ok(ShareValidationResult::BlockFound(share_hash, template_id, coinbase)) => {
+                        outcome.accepted = 1;
+                        outcome.blocks_found = 1;
                         info!("SubmitSharesStandard: 💰 Block Found!!! 💰{share_hash}");
                         // if we have a template id (i.e.: this was not a custom job)
                         // we can propagate the solution to the TP
@@ -602,6 +618,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesSuccess(success)).into());
                     }
                     Err(ShareValidationError::Invalid) => {
+                        outcome.invalid = 1;
                         error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: invalid-share ❌", downstream_id, channel_id, msg.sequence_number);
                         let error = SubmitSharesError {
                             channel_id: msg.channel_id,
@@ -615,6 +632,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(ShareValidationError::Stale) => {
+                        outcome.stale = 1;
                         error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: stale-share ❌", downstream_id, channel_id, msg.sequence_number);
                         let error = SubmitSharesError {
                             channel_id: msg.channel_id,
@@ -627,6 +645,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(ShareValidationError::InvalidJobId) => {
+                        outcome.invalid_job_id = 1;
                         error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: invalid-job-id ❌", downstream_id, channel_id, msg.sequence_number);
                         let error = SubmitSharesError {
                             channel_id: msg.channel_id,
@@ -639,6 +658,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(ShareValidationError::DoesNotMeetTarget) => {
+                        outcome.difficulty_too_low = 1;
                         error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: difficulty-too-low ❌", downstream_id, channel_id, msg.sequence_number);
                         let error = SubmitSharesError {
                             channel_id: msg.channel_id,
@@ -651,6 +671,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(ShareValidationError::DuplicateShare) => {
+                        outcome.duplicate = 1;
                         error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: duplicate-share ❌", downstream_id, channel_id, msg.sequence_number);
                         let error = SubmitSharesError {
                             channel_id: msg.channel_id,
@@ -666,6 +687,12 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         return Err(PoolError::disconnect(e, downstream_id))?;
                     }
                 }
+
+                // Update share response counts (after vardiff borrow is released)
+                channel_manager_data.share_response_counts
+                    .entry((downstream_id, channel_id).into())
+                    .or_default()
+                    .accumulate(&outcome);
 
                 Ok(messages)
             })
@@ -724,6 +751,10 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                             .expect("error code must be valid string"),
                     };
                     error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: invalid-channel-id ❌", downstream_id, channel_id, msg.sequence_number);
+                    channel_manager_data.share_response_counts
+                        .entry((downstream_id, channel_id).into())
+                        .or_default()
+                        .invalid_channel_id += 1;
                     return Ok(vec![(downstream_id, Mining::SubmitSharesError(error)).into()]);
                 };
 
@@ -738,8 +769,13 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 let res = extended_channel.validate_share(msg.clone());
                 vardiff.increment_shares_since_last_update();
 
+                // Track the share outcome so we can update share_response_counts
+                // after the vardiff borrow is released (avoids overlapping mutable borrows).
+                let mut outcome = ShareResponseCounts::default();
+
                 match res {
                     Ok(ShareValidationResult::Valid(share_hash)) => {
+                        outcome.accepted = 1;
                         let share_accounting = extended_channel.get_share_accounting();
                         if share_accounting.should_acknowledge() {
                             let success = SubmitSharesSuccess {
@@ -759,6 +795,8 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         }
                     }
                     Ok(ShareValidationResult::BlockFound(share_hash, template_id, coinbase)) => {
+                        outcome.accepted = 1;
+                        outcome.blocks_found = 1;
                         info!("SubmitSharesExtended: 💰 Block Found!!! 💰{share_hash}");
                         // if we have a template id (i.e.: this was not a custom job)
                         // we can propagate the solution to the TP
@@ -783,6 +821,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesSuccess(success)).into());
                     }
                     Err(ShareValidationError::Invalid) => {
+                        outcome.invalid = 1;
                         error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: invalid-share ❌", downstream_id, channel_id, msg.sequence_number);
                         let error = SubmitSharesError {
                             channel_id: msg.channel_id,
@@ -795,6 +834,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(ShareValidationError::Stale) => {
+                        outcome.stale = 1;
                         error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: stale-share ❌", downstream_id, channel_id, msg.sequence_number);
                         let error = SubmitSharesError {
                             channel_id: msg.channel_id,
@@ -807,6 +847,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(ShareValidationError::InvalidJobId) => {
+                        outcome.invalid_job_id = 1;
                         error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: invalid-job-id ❌", downstream_id, channel_id, msg.sequence_number);
                         let error = SubmitSharesError {
                             channel_id: msg.channel_id,
@@ -819,6 +860,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(ShareValidationError::DoesNotMeetTarget) => {
+                        outcome.difficulty_too_low = 1;
                         error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: difficulty-too-low ❌", downstream_id, channel_id, msg.sequence_number);
                         let error = SubmitSharesError {
                             channel_id: msg.channel_id,
@@ -831,6 +873,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(ShareValidationError::DuplicateShare) => {
+                        outcome.duplicate = 1;
                         error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: duplicate-share ❌", downstream_id, channel_id, msg.sequence_number);
                         let error = SubmitSharesError {
                             channel_id: msg.channel_id,
@@ -843,6 +886,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         messages.push((downstream_id, Mining::SubmitSharesError(error)).into());
                     }
                     Err(ShareValidationError::BadExtranonceSize) => {
+                        outcome.bad_extranonce_size = 1;
                         error!("SubmitSharesError: downstream_id: {}, channel_id: {}, sequence_number: {}, error_code: bad-extranonce-size ❌", downstream_id, channel_id, msg.sequence_number);
                         let error = SubmitSharesError {
                             channel_id: msg.channel_id,
@@ -858,6 +902,12 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                         return Err(PoolError::disconnect(e, downstream_id))?;
                     }
                 }
+
+                // Update share response counts (after vardiff borrow is released)
+                channel_manager_data.share_response_counts
+                    .entry((downstream_id, channel_id).into())
+                    .or_default()
+                    .accumulate(&outcome);
 
                 Ok(messages)
             })

--- a/pool-apps/pool/src/lib/channel_manager/mod.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mod.rs
@@ -15,6 +15,7 @@ use stratum_apps::{
     config_helpers::CoinbaseRewardScript,
     custom_mutex::Mutex,
     key_utils::{Secp256k1PublicKey, Secp256k1SecretKey},
+    monitoring::client::ShareResponseCounts,
     network_helpers::accept_noise_connection,
     stratum_core::{
         bitcoin::{Amount, TxOut},
@@ -69,6 +70,9 @@ pub struct ChannelManagerData {
     // Mapping of `(downstream_id, channel_id)` → vardiff controller.
     // Each entry manages variable difficulty for a specific downstream channel.
     vardiff: HashMap<VardiffKey, VardiffState>,
+    // Mapping of `(downstream_id, channel_id)` → share response counters.
+    // Tracks all share submission outcomes per channel for monitoring.
+    pub(crate) share_response_counts: HashMap<VardiffKey, ShareResponseCounts>,
     // Coinbase outputs
     coinbase_outputs: Vec<u8>,
     // Last new prevhash
@@ -142,6 +146,7 @@ impl ChannelManager {
             extranonce_prefix_factory_standard,
             downstream_id_factory: AtomicUsize::new(1),
             vardiff: HashMap::new(),
+            share_response_counts: HashMap::new(),
             coinbase_outputs,
             last_future_template: None,
             last_new_prev_hash: None,
@@ -429,6 +434,9 @@ impl ChannelManager {
             cm_data.downstream.remove(&downstream_id);
             cm_data
                 .vardiff
+                .retain(|key, _| key.downstream_id != downstream_id);
+            cm_data
+                .share_response_counts
                 .retain(|key, _| key.downstream_id != downstream_id);
         });
         Ok(())

--- a/pool-apps/pool/src/lib/monitoring.rs
+++ b/pool-apps/pool/src/lib/monitoring.rs
@@ -3,15 +3,24 @@
 //! This module implements the Sv2ClientsMonitoring trait on `ChannelManager`.
 //! Pool only has clients (miners connecting to it), no upstream server.
 
+use std::collections::HashMap;
+
 use stratum_apps::monitoring::client::{
-    ExtendedChannelInfo, StandardChannelInfo, Sv2ClientInfo, Sv2ClientsMonitoring,
+    ExtendedChannelInfo, ShareResponseCounts, StandardChannelInfo, Sv2ClientInfo,
+    Sv2ClientsMonitoring,
 };
 
 use crate::{channel_manager::ChannelManager, downstream::Downstream};
+use stratum_apps::utils::types::VardiffKey;
 
 /// Helper to convert a Downstream to Sv2ClientInfo.
+/// Takes the share_response_counts map so we can populate per-channel rejection metrics.
 /// Returns None if the lock cannot be acquired (graceful degradation for monitoring).
-fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
+fn downstream_to_sv2_client_info(
+    client: &Downstream,
+    share_response_counts: &HashMap<VardiffKey, ShareResponseCounts>,
+) -> Option<Sv2ClientInfo> {
+    let downstream_id = client.downstream_id;
     client
         .downstream_data
         .safe_lock(|dd| {
@@ -24,6 +33,12 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                 let requested_max_target = extended_channel.get_requested_max_target();
                 let user_identity = extended_channel.get_user_identity();
                 let share_accounting = extended_channel.get_share_accounting();
+
+                let key = VardiffKey {
+                    downstream_id,
+                    channel_id,
+                };
+                let share_responses = share_response_counts.get(&key).cloned();
 
                 extended_channels.push(ExtendedChannelInfo {
                     channel_id,
@@ -43,6 +58,7 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                     last_batch_work_sum: share_accounting.get_last_batch_work_sum(),
                     share_batch_size: share_accounting.get_share_batch_size(),
                     blocks_found: share_accounting.get_blocks_found(),
+                    share_responses,
                 });
             }
 
@@ -52,6 +68,12 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                 let requested_max_target = standard_channel.get_requested_max_target();
                 let user_identity = standard_channel.get_user_identity();
                 let share_accounting = standard_channel.get_share_accounting();
+
+                let key = VardiffKey {
+                    downstream_id,
+                    channel_id,
+                };
+                let share_responses = share_response_counts.get(&key).cloned();
 
                 standard_channels.push(StandardChannelInfo {
                     channel_id,
@@ -69,11 +91,12 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
                     last_batch_work_sum: share_accounting.get_last_batch_work_sum(),
                     share_batch_size: share_accounting.get_share_batch_size(),
                     blocks_found: share_accounting.get_blocks_found(),
+                    share_responses,
                 });
             }
 
             Sv2ClientInfo {
-                client_id: client.downstream_id,
+                client_id: downstream_id,
                 extended_channels,
                 standard_channels,
             }
@@ -83,25 +106,35 @@ fn downstream_to_sv2_client_info(client: &Downstream) -> Option<Sv2ClientInfo> {
 
 impl Sv2ClientsMonitoring for ChannelManager {
     fn get_sv2_clients(&self) -> Vec<Sv2ClientInfo> {
-        // Clone Downstream references and release lock immediately to avoid contention
-        // with template distribution and message handling
-        let downstream_refs: Vec<Downstream> = self
+        // Extract both downstream references and share_response_counts in a single lock
+        // acquisition, then release immediately to avoid contention with template
+        // distribution and message handling.
+        let (downstream_refs, share_response_counts): (
+            Vec<Downstream>,
+            HashMap<VardiffKey, ShareResponseCounts>,
+        ) = self
             .channel_manager_data
-            .safe_lock(|data| data.downstream.values().cloned().collect())
+            .safe_lock(|data| {
+                (
+                    data.downstream.values().cloned().collect(),
+                    data.share_response_counts.clone(),
+                )
+            })
             .unwrap_or_default();
 
         downstream_refs
             .iter()
-            .filter_map(downstream_to_sv2_client_info)
+            .filter_map(|d| downstream_to_sv2_client_info(d, &share_response_counts))
             .collect()
     }
 
     fn get_sv2_client_by_id(&self, client_id: usize) -> Option<Sv2ClientInfo> {
         self.channel_manager_data
             .safe_lock(|d| {
-                d.downstream
-                    .get(&client_id)
-                    .and_then(downstream_to_sv2_client_info)
+                let share_response_counts = &d.share_response_counts;
+                d.downstream.get(&client_id).and_then(|downstream| {
+                    downstream_to_sv2_client_info(downstream, share_response_counts)
+                })
             })
             .unwrap_or(None)
     }

--- a/stratum-apps/src/monitoring/README.md
+++ b/stratum-apps/src/monitoring/README.md
@@ -81,9 +81,17 @@ tokio::spawn(async move {
 - `sv2_client_channels{channel_type}` - Client channels by type (extended/standard)
 - `sv2_client_hashrate_total` - Total client hashrate
 - `sv2_client_channel_hashrate{client_id, channel_id, user_identity}` - Per-channel hashrate
-- `sv2_client_shares_accepted_total{client_id, channel_id, user_identity}` - Per-channel shares
+- `sv2_client_shares_accepted_total{client_id, channel_id, user_identity}` - Per-channel shares accepted
+- `sv2_client_shares_rejected_total{client_id, channel_id, user_identity, reason}` - Per-channel shares rejected, by reason (`invalid-share`, `stale-share`, `invalid-job-id`, `difficulty-too-low`, `duplicate-share`, `bad-extranonce-size`, `invalid-channel-id`). Only populated by the pool.
 - `sv2_client_blocks_found_total` - Total blocks found across all current client channels
 
 **Sv1 (Translator Proxy only):**
 - `sv1_clients_total` - Sv1 client count
 - `sv1_hashrate_total` - Sv1 total hashrate
+- `sv1_client_shares_accepted_total{client_id, user_identity}` - Per-client shares accepted (local tProxy validation)
+- `sv1_client_shares_rejected_total{client_id, user_identity, reason}` - Per-client shares rejected, by reason (`invalid-share`, `invalid-job-id`, `invalid-channel-id`). Tracks local tProxy validation outcomes that determine the SV1 `result: true/false` response.
+
+**Note on share response tracking:**
+- **Pool**: `sv2_client_shares_accepted/rejected_total` tracks per-channel share validation outcomes.
+- **JDC**: Same `sv2_client_shares_accepted/rejected_total` metrics are now populated by JDC's local share validation (both pool-connected and solo mining modes).
+- **tProxy**: `sv1_client_shares_accepted/rejected_total` tracks per-SV1-miner share validation outcomes at the tProxy's local validation layer.

--- a/stratum-apps/src/monitoring/client.rs
+++ b/stratum-apps/src/monitoring/client.rs
@@ -6,6 +6,50 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+/// Per-channel breakdown of all share submission outcomes.
+///
+/// Enables monitoring of rejection rates and root-cause analysis:
+/// a high `stale` count may indicate slow job distribution, a high
+/// `invalid_job_id` count may signal template propagation issues, etc.
+///
+/// All counters are monotonically increasing over the lifetime of the channel.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct ShareResponseCounts {
+    /// Shares that passed validation (includes block-found shares).
+    pub accepted: u32,
+    /// Blocks found (subset of accepted).
+    pub blocks_found: u32,
+    /// `invalid-share` — share failed hash validation.
+    pub invalid: u32,
+    /// `stale-share` — share references an outdated prev_hash / job.
+    pub stale: u32,
+    /// `invalid-job-id` — job_id in the share does not match any known job.
+    pub invalid_job_id: u32,
+    /// `difficulty-too-low` — share hash does not meet the channel's target.
+    pub difficulty_too_low: u32,
+    /// `duplicate-share` — share was already submitted.
+    pub duplicate: u32,
+    /// `bad-extranonce-size` — extranonce size mismatch (extended channels only).
+    pub bad_extranonce_size: u32,
+    /// `invalid-channel-id` — the channel_id in the share message was not found.
+    pub invalid_channel_id: u32,
+}
+
+impl ShareResponseCounts {
+    /// Merge a single-share outcome delta into the running totals.
+    pub fn accumulate(&mut self, delta: &ShareResponseCounts) {
+        self.accepted += delta.accepted;
+        self.blocks_found += delta.blocks_found;
+        self.invalid += delta.invalid;
+        self.stale += delta.stale;
+        self.invalid_job_id += delta.invalid_job_id;
+        self.difficulty_too_low += delta.difficulty_too_low;
+        self.duplicate += delta.duplicate;
+        self.bad_extranonce_size += delta.bad_extranonce_size;
+        self.invalid_channel_id += delta.invalid_channel_id;
+    }
+}
+
 /// Information about an extended channel
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ExtendedChannelInfo {
@@ -26,6 +70,9 @@ pub struct ExtendedChannelInfo {
     pub last_batch_work_sum: f64,
     pub share_batch_size: usize,
     pub blocks_found: u32,
+    /// Per-outcome share response counters (only populated by the pool).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub share_responses: Option<ShareResponseCounts>,
 }
 
 /// Information about a standard channel
@@ -46,6 +93,9 @@ pub struct StandardChannelInfo {
     pub last_batch_work_sum: f64,
     pub share_batch_size: usize,
     pub blocks_found: u32,
+    /// Per-outcome share response counters (only populated by the pool).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub share_responses: Option<ShareResponseCounts>,
 }
 
 /// Full information about a single Sv2 client including all channels

--- a/stratum-apps/src/monitoring/http_server.rs
+++ b/stratum-apps/src/monitoring/http_server.rs
@@ -61,6 +61,7 @@ use utoipa_swagger_ui::SwaggerUi;
         Sv2ClientMetadata,
         ExtendedChannelInfo,
         StandardChannelInfo,
+        super::client::ShareResponseCounts,
         Sv1ClientInfo,
         Sv1ClientsSummary,
         HealthResponse,
@@ -733,6 +734,89 @@ async fn handle_sv1_client_by_id(
     }
 }
 
+/// Sets per-reason rejection gauge values for a single channel.
+fn set_rejection_metrics(
+    metric: &prometheus::GaugeVec,
+    client_id: &str,
+    channel_id: &str,
+    user: &str,
+    sr: &super::client::ShareResponseCounts,
+) {
+    let reasons: &[(&str, u32)] = &[
+        ("invalid-share", sr.invalid),
+        ("stale-share", sr.stale),
+        ("invalid-job-id", sr.invalid_job_id),
+        ("difficulty-too-low", sr.difficulty_too_low),
+        ("duplicate-share", sr.duplicate),
+        ("bad-extranonce-size", sr.bad_extranonce_size),
+        ("invalid-channel-id", sr.invalid_channel_id),
+    ];
+    for (reason, count) in reasons {
+        if *count > 0 {
+            metric
+                .with_label_values(&[client_id, channel_id, user, reason])
+                .set(*count as f64);
+        }
+    }
+}
+
+/// Sets per-reason rejection gauge values for a single SV1 client.
+///
+/// Uses the same `ShareResponseCounts` struct as SV2, but the label set is
+/// `[client_id, user_identity, reason]` (no channel_id — SV1 clients don't have
+/// SV2 channels visible to the operator).
+fn set_sv1_rejection_metrics(
+    metric: &prometheus::GaugeVec,
+    client_id: &str,
+    user: &str,
+    sr: &super::client::ShareResponseCounts,
+) {
+    let reasons: &[(&str, u32)] = &[
+        ("invalid-share", sr.invalid),
+        ("stale-share", sr.stale),
+        ("invalid-job-id", sr.invalid_job_id),
+        ("difficulty-too-low", sr.difficulty_too_low),
+        ("duplicate-share", sr.duplicate),
+        ("bad-extranonce-size", sr.bad_extranonce_size),
+        ("invalid-channel-id", sr.invalid_channel_id),
+    ];
+    for (reason, count) in reasons {
+        if *count > 0 {
+            metric
+                .with_label_values(&[client_id, user, reason])
+                .set(*count as f64);
+        }
+    }
+}
+
+/// Sets per-reason rejection gauge values for a single server channel.
+///
+/// Uses the same `ShareResponseCounts` struct as clients, but the label set is
+/// `[channel_id, user_identity, reason]` (no client_id — the server is upstream).
+fn set_server_rejection_metrics(
+    metric: &prometheus::GaugeVec,
+    channel_id: &str,
+    user: &str,
+    sr: &super::client::ShareResponseCounts,
+) {
+    let reasons: &[(&str, u32)] = &[
+        ("invalid-share", sr.invalid),
+        ("stale-share", sr.stale),
+        ("invalid-job-id", sr.invalid_job_id),
+        ("difficulty-too-low", sr.difficulty_too_low),
+        ("duplicate-share", sr.duplicate),
+        ("bad-extranonce-size", sr.bad_extranonce_size),
+        ("invalid-channel-id", sr.invalid_channel_id),
+    ];
+    for (reason, count) in reasons {
+        if *count > 0 {
+            metric
+                .with_label_values(&[channel_id, user, reason])
+                .set(*count as f64);
+        }
+    }
+}
+
 /// Handler for Prometheus metrics endpoint
 async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response {
     let snapshot = state.cache.get_snapshot();
@@ -751,10 +835,16 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
     if let Some(ref metric) = state.metrics.sv2_client_shares_accepted_total {
         metric.reset();
     }
+    if let Some(ref metric) = state.metrics.sv2_client_shares_rejected_total {
+        metric.reset();
+    }
     if let Some(ref metric) = state.metrics.sv2_server_channel_hashrate {
         metric.reset();
     }
     if let Some(ref metric) = state.metrics.sv2_server_shares_accepted_total {
+        metric.reset();
+    }
+    if let Some(ref metric) = state.metrics.sv2_server_shares_rejected_total {
         metric.reset();
     }
 
@@ -791,6 +881,12 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
                     .with_label_values(&[&channel_id, user])
                     .set(hashrate as f64);
             }
+            if let (Some(ref metric), Some(ref sr)) = (
+                &state.metrics.sv2_server_shares_rejected_total,
+                &channel.share_responses,
+            ) {
+                set_server_rejection_metrics(metric, &channel_id, user, sr);
+            }
         }
 
         for channel in &server.standard_channels {
@@ -809,6 +905,12 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
                 metric
                     .with_label_values(&[&channel_id, user])
                     .set(hashrate as f64);
+            }
+            if let (Some(ref metric), Some(ref sr)) = (
+                &state.metrics.sv2_server_shares_rejected_total,
+                &channel.share_responses,
+            ) {
+                set_server_rejection_metrics(metric, &channel_id, user, sr);
             }
         }
 
@@ -864,6 +966,12 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
                         .with_label_values(&[&client_id, &channel_id, user])
                         .set(channel.nominal_hashrate as f64);
                 }
+                if let (Some(ref metric), Some(ref sr)) = (
+                    &state.metrics.sv2_client_shares_rejected_total,
+                    &channel.share_responses,
+                ) {
+                    set_rejection_metrics(metric, &client_id, &channel_id, user, sr);
+                }
                 client_blocks_total += channel.blocks_found as u64;
             }
 
@@ -881,6 +989,12 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
                         .with_label_values(&[&client_id, &channel_id, user])
                         .set(channel.nominal_hashrate as f64);
                 }
+                if let (Some(ref metric), Some(ref sr)) = (
+                    &state.metrics.sv2_client_shares_rejected_total,
+                    &channel.share_responses,
+                ) {
+                    set_rejection_metrics(metric, &client_id, &channel_id, user, sr);
+                }
                 client_blocks_total += channel.blocks_found as u64;
             }
         }
@@ -890,6 +1004,14 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
         }
     }
 
+    // Reset per-client SV1 metrics before repopulating
+    if let Some(ref metric) = state.metrics.sv1_client_shares_accepted_total {
+        metric.reset();
+    }
+    if let Some(ref metric) = state.metrics.sv1_client_shares_rejected_total {
+        metric.reset();
+    }
+
     // Collect SV1 client metrics
     if let Some(ref summary) = snapshot.sv1_clients_summary {
         if let Some(ref metric) = state.metrics.sv1_clients_total {
@@ -897,6 +1019,23 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
         }
         if let Some(ref metric) = state.metrics.sv1_hashrate_total {
             metric.set(summary.total_hashrate as f64);
+        }
+    }
+
+    // Collect per-SV1-client share response metrics
+    for client in snapshot.sv1_clients.as_deref().unwrap_or(&[]) {
+        if let Some(ref sr) = client.share_responses {
+            let client_id = client.client_id.to_string();
+            let user = &client.user_identity;
+
+            if let Some(ref metric) = state.metrics.sv1_client_shares_accepted_total {
+                metric
+                    .with_label_values(&[&client_id, user])
+                    .set(sr.accepted as f64);
+            }
+            if let Some(ref metric) = state.metrics.sv1_client_shares_rejected_total {
+                set_sv1_rejection_metrics(metric, &client_id, user, sr);
+            }
         }
     }
 

--- a/stratum-apps/src/monitoring/prometheus_metrics.rs
+++ b/stratum-apps/src/monitoring/prometheus_metrics.rs
@@ -14,6 +14,7 @@ pub struct PrometheusMetrics {
     pub sv2_server_hashrate_total: Option<Gauge>,
     pub sv2_server_channel_hashrate: Option<GaugeVec>,
     pub sv2_server_shares_accepted_total: Option<GaugeVec>,
+    pub sv2_server_shares_rejected_total: Option<GaugeVec>,
     pub sv2_server_blocks_found_total: Option<Gauge>,
     // Clients metrics (downstream connections)
     pub sv2_clients_total: Option<Gauge>,
@@ -21,10 +22,13 @@ pub struct PrometheusMetrics {
     pub sv2_client_hashrate_total: Option<Gauge>,
     pub sv2_client_channel_hashrate: Option<GaugeVec>,
     pub sv2_client_shares_accepted_total: Option<GaugeVec>,
+    pub sv2_client_shares_rejected_total: Option<GaugeVec>,
     pub sv2_client_blocks_found_total: Option<Gauge>,
     // SV1 metrics
     pub sv1_clients_total: Option<Gauge>,
     pub sv1_hashrate_total: Option<Gauge>,
+    pub sv1_client_shares_accepted_total: Option<GaugeVec>,
+    pub sv1_client_shares_rejected_total: Option<GaugeVec>,
 }
 
 impl PrometheusMetrics {
@@ -45,6 +49,7 @@ impl PrometheusMetrics {
             sv2_server_hashrate_total,
             sv2_server_channel_hashrate,
             sv2_server_shares_accepted_total,
+            sv2_server_shares_rejected_total,
             sv2_server_blocks_found_total,
         ) = if enable_server_metrics {
             let channels = GaugeVec::new(
@@ -77,6 +82,15 @@ impl PrometheusMetrics {
             )?;
             registry.register(Box::new(shares_accepted.clone()))?;
 
+            let shares_rejected = GaugeVec::new(
+                Opts::new(
+                    "sv2_server_shares_rejected_total",
+                    "Total shares rejected per server channel, broken down by rejection reason",
+                ),
+                &["channel_id", "user_identity", "reason"],
+            )?;
+            registry.register(Box::new(shares_rejected.clone()))?;
+
             let blocks_found = Gauge::new(
                 "sv2_server_blocks_found_total",
                 "Total blocks found across all current server channels",
@@ -88,10 +102,11 @@ impl PrometheusMetrics {
                 Some(hashrate),
                 Some(channel_hashrate),
                 Some(shares_accepted),
+                Some(shares_rejected),
                 Some(blocks_found),
             )
         } else {
-            (None, None, None, None, None)
+            (None, None, None, None, None, None)
         };
 
         // Clients metrics (downstream connections)
@@ -101,6 +116,7 @@ impl PrometheusMetrics {
             sv2_client_hashrate_total,
             sv2_client_channel_hashrate,
             sv2_client_shares_accepted_total,
+            sv2_client_shares_rejected_total,
             sv2_client_blocks_found_total,
         ) = if enable_clients_metrics {
             let clients_total =
@@ -137,6 +153,15 @@ impl PrometheusMetrics {
             )?;
             registry.register(Box::new(shares_accepted.clone()))?;
 
+            let shares_rejected = GaugeVec::new(
+                Opts::new(
+                    "sv2_client_shares_rejected_total",
+                    "Total shares rejected per client channel, broken down by rejection reason",
+                ),
+                &["client_id", "channel_id", "user_identity", "reason"],
+            )?;
+            registry.register(Box::new(shares_rejected.clone()))?;
+
             let blocks_found = Gauge::new(
                 "sv2_client_blocks_found_total",
                 "Total blocks found across all current client channels",
@@ -149,23 +174,52 @@ impl PrometheusMetrics {
                 Some(hashrate),
                 Some(channel_hashrate),
                 Some(shares_accepted),
+                Some(shares_rejected),
                 Some(blocks_found),
             )
         } else {
-            (None, None, None, None, None, None)
+            (None, None, None, None, None, None, None)
         };
 
         // SV1 metrics
-        let (sv1_clients_total, sv1_hashrate_total) = if enable_sv1_metrics {
+        let (
+            sv1_clients_total,
+            sv1_hashrate_total,
+            sv1_client_shares_accepted_total,
+            sv1_client_shares_rejected_total,
+        ) = if enable_sv1_metrics {
             let clients = Gauge::new("sv1_clients_total", "Total number of SV1 clients")?;
             registry.register(Box::new(clients.clone()))?;
 
             let hashrate = Gauge::new("sv1_hashrate_total", "Total hashrate from SV1 clients")?;
             registry.register(Box::new(hashrate.clone()))?;
 
-            (Some(clients), Some(hashrate))
+            let shares_accepted = GaugeVec::new(
+                Opts::new(
+                    "sv1_client_shares_accepted_total",
+                    "Total shares accepted per SV1 client",
+                ),
+                &["client_id", "user_identity"],
+            )?;
+            registry.register(Box::new(shares_accepted.clone()))?;
+
+            let shares_rejected = GaugeVec::new(
+                Opts::new(
+                    "sv1_client_shares_rejected_total",
+                    "Total shares rejected per SV1 client, broken down by rejection reason",
+                ),
+                &["client_id", "user_identity", "reason"],
+            )?;
+            registry.register(Box::new(shares_rejected.clone()))?;
+
+            (
+                Some(clients),
+                Some(hashrate),
+                Some(shares_accepted),
+                Some(shares_rejected),
+            )
         } else {
-            (None, None)
+            (None, None, None, None)
         };
 
         Ok(Self {
@@ -175,15 +229,19 @@ impl PrometheusMetrics {
             sv2_server_hashrate_total,
             sv2_server_channel_hashrate,
             sv2_server_shares_accepted_total,
+            sv2_server_shares_rejected_total,
             sv2_server_blocks_found_total,
             sv2_clients_total,
             sv2_client_channels,
             sv2_client_hashrate_total,
             sv2_client_channel_hashrate,
             sv2_client_shares_accepted_total,
+            sv2_client_shares_rejected_total,
             sv2_client_blocks_found_total,
             sv1_clients_total,
             sv1_hashrate_total,
+            sv1_client_shares_accepted_total,
+            sv1_client_shares_rejected_total,
         })
     }
 }

--- a/stratum-apps/src/monitoring/server.rs
+++ b/stratum-apps/src/monitoring/server.rs
@@ -6,6 +6,8 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use super::client::ShareResponseCounts;
+
 /// Information about an extended channel opened with the server
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ServerExtendedChannelInfo {
@@ -23,6 +25,9 @@ pub struct ServerExtendedChannelInfo {
     pub shares_submitted: u32,
     pub best_diff: f64,
     pub blocks_found: u32,
+    /// Per-outcome share response counters from the upstream server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub share_responses: Option<ShareResponseCounts>,
 }
 
 /// Information about a standard channel opened with the server
@@ -39,6 +44,9 @@ pub struct ServerStandardChannelInfo {
     pub shares_submitted: u32,
     pub best_diff: f64,
     pub blocks_found: u32,
+    /// Per-outcome share response counters from the upstream server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub share_responses: Option<ShareResponseCounts>,
 }
 
 /// Information about the server (upstream connection)

--- a/stratum-apps/src/monitoring/sv1.rs
+++ b/stratum-apps/src/monitoring/sv1.rs
@@ -6,6 +6,8 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use super::client::ShareResponseCounts;
+
 /// Information about a single SV1 client connection
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Sv1ClientInfo {
@@ -19,6 +21,15 @@ pub struct Sv1ClientInfo {
     pub extranonce2_len: usize,
     pub version_rolling_mask: Option<String>,
     pub version_rolling_min_bit: Option<String>,
+    /// Per-outcome share response counters for this SV1 client's local validation.
+    ///
+    /// Tracks shares accepted/rejected at the tProxy's local validation layer,
+    /// which is what the SV1 miner actually sees (`result: true/false`).
+    /// Only a subset of rejection reasons apply to SV1:
+    /// `accepted`, `invalid` (failed PoW), `invalid_job_id` (job not found),
+    /// `invalid_channel_id` (channel not open).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub share_responses: Option<ShareResponseCounts>,
 }
 
 /// Aggregate information about SV1 client connections

--- a/stratum-apps/src/utils/types.rs
+++ b/stratum-apps/src/utils/types.rs
@@ -17,7 +17,7 @@ pub type MessageType = u8;
 pub type Message = AnyMessage<'static>;
 pub type Sv2Frame = StandardSv2Frame<Message>;
 
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VardiffKey {
     pub downstream_id: DownstreamId,
     pub channel_id: ChannelId,


### PR DESCRIPTION
Previously, only accepted shares were tracked via ShareAccounting from stratum-core. When a share was rejected (stale, invalid job, difficulty too low, etc.) the pool logged an error and sent SubmitSharesError but no counters were incremented — meaning there was no way to assess the rate of share rejection or diagnose the root cause of revenue loss.

This adds per-channel ShareResponseCounts that track every share submission outcome the pool produces:

  - accepted (valid + block-found)
  - stale-share
  - invalid-job-id
  - invalid-share
  - difficulty-too-low
  - duplicate-share
  - bad-extranonce-size
  - invalid-channel-id

Counters are incremented inline in the pool's share validation handlers (handle_submit_shares_standard / handle_submit_shares_extended) and stored in ChannelManagerData alongside the existing vardiff state.

The monitoring pipeline is extended end-to-end:

  - ShareResponseCounts struct added to monitoring client types
  - Pool monitoring reads counts from ChannelManagerData and maps them into the channel info structs (ExtendedChannelInfo, StandardChannelInfo)
  - JSON API exposes share_responses per channel (omitted when absent)
  - New Prometheus GaugeVec sv2_client_shares_rejected_total with labels [client_id, channel_id, user_identity, reason] enables alerting on rejection spikes and dashboarding rejection rates by error type
  - OpenAPI schema updated to include ShareResponseCounts

This enables operators to:
  - Monitor share rejection rate as a fraction of total submissions
  - Identify whether rejections are dominated by stale shares (latency), invalid job IDs (template propagation), or other causes
  - Set alerts when rejection rates exceed acceptable thresholds
  - Correlate rejection patterns with infrastructure changes