### PR TITLE
fix(translator): make worker identity TLV optional and fix unwrap panic

### DIFF
--- a/miner-apps/translator/config-examples/mainnet/tproxy-config-hosted-pool-example.toml
+++ b/miner-apps/translator/config-examples/mainnet/tproxy-config-hosted-pool-example.toml
@@ -19,6 +19,11 @@ user_identity = "your_username_here"
 # Aggregate channels: if true, all miners share one upstream channel; if false, each miner gets its own channel
 aggregate_channels = true
 
+# Attach worker identity TLV to share submissions for per-worker hashrate tracking
+# (extension 0x0002). Disable when using Bitcoin addresses as user_identity, since
+# addresses exceed the 32-byte TLV limit.
+enable_worker_identity_tlv = true
+
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.
 # The CLI option --log-file (or -f) will override this setting if provided.

--- a/miner-apps/translator/config-examples/mainnet/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/mainnet/tproxy-config-local-jdc-example.toml
@@ -19,6 +19,11 @@ user_identity = "your_username_here"
 # Aggregate channels: if true, all miners share one upstream channel; if false, each miner gets its own channel
 aggregate_channels = false
 
+# Attach worker identity TLV to share submissions for per-worker hashrate tracking
+# (extension 0x0002). Disable when using Bitcoin addresses as user_identity, since
+# addresses exceed the 32-byte TLV limit.
+enable_worker_identity_tlv = true
+
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.
 # The CLI option --log-file (or -f) will override this setting if provided.

--- a/miner-apps/translator/config-examples/mainnet/tproxy-config-local-pool-example.toml
+++ b/miner-apps/translator/config-examples/mainnet/tproxy-config-local-pool-example.toml
@@ -19,6 +19,11 @@ user_identity = "your_username_here"
 # Aggregate channels: if true, all miners share one upstream channel; if false, each miner gets its own channel
 aggregate_channels = true
 
+# Attach worker identity TLV to share submissions for per-worker hashrate tracking
+# (extension 0x0002). Disable when using Bitcoin addresses as user_identity, since
+# addresses exceed the 32-byte TLV limit.
+enable_worker_identity_tlv = true
+
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.
 # The CLI option --log-file (or -f) will override this setting if provided.

--- a/miner-apps/translator/config-examples/signet/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/signet/tproxy-config-local-jdc-example.toml
@@ -19,6 +19,11 @@ user_identity = "your_username_here"
 # Aggregate channels: if true, all miners share one upstream channel; if false, each miner gets its own channel
 aggregate_channels = false
 
+# Attach worker identity TLV to share submissions for per-worker hashrate tracking
+# (extension 0x0002). Disable when using Bitcoin addresses as user_identity, since
+# addresses exceed the 32-byte TLV limit.
+enable_worker_identity_tlv = true
+
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.
 # The CLI option --log-file (or -f) will override this setting if provided.

--- a/miner-apps/translator/config-examples/signet/tproxy-config-local-pool-example.toml
+++ b/miner-apps/translator/config-examples/signet/tproxy-config-local-pool-example.toml
@@ -19,6 +19,11 @@ user_identity = "your_username_here"
 # Aggregate channels: if true, all miners share one upstream channel; if false, each miner gets its own channel
 aggregate_channels = true
 
+# Attach worker identity TLV to share submissions for per-worker hashrate tracking
+# (extension 0x0002). Disable when using Bitcoin addresses as user_identity, since
+# addresses exceed the 32-byte TLV limit.
+enable_worker_identity_tlv = true
+
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.
 # The CLI option --log-file (or -f) will override this setting if provided.

--- a/miner-apps/translator/config-examples/testnet4/tproxy-config-hosted-pool-example.toml
+++ b/miner-apps/translator/config-examples/testnet4/tproxy-config-hosted-pool-example.toml
@@ -19,6 +19,11 @@ user_identity = "your_username_here"
 # Aggregate channels: if true, all miners share one upstream channel; if false, each miner gets its own channel
 aggregate_channels = true
 
+# Attach worker identity TLV to share submissions for per-worker hashrate tracking
+# (extension 0x0002). Disable when using Bitcoin addresses as user_identity, since
+# addresses exceed the 32-byte TLV limit.
+enable_worker_identity_tlv = true
+
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.
 # The CLI option --log-file (or -f) will override this setting if provided.

--- a/miner-apps/translator/config-examples/testnet4/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/testnet4/tproxy-config-local-jdc-example.toml
@@ -19,6 +19,11 @@ user_identity = "your_username_here"
 # Aggregate channels: if true, all miners share one upstream channel; if false, each miner gets its own channel
 aggregate_channels = false
 
+# Attach worker identity TLV to share submissions for per-worker hashrate tracking
+# (extension 0x0002). Disable when using Bitcoin addresses as user_identity, since
+# addresses exceed the 32-byte TLV limit.
+enable_worker_identity_tlv = true
+
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.
 # The CLI option --log-file (or -f) will override this setting if provided.

--- a/miner-apps/translator/config-examples/testnet4/tproxy-config-local-pool-example.toml
+++ b/miner-apps/translator/config-examples/testnet4/tproxy-config-local-pool-example.toml
@@ -19,6 +19,11 @@ user_identity = "your_username_here"
 # Aggregate channels: if true, all miners share one upstream channel; if false, each miner gets its own channel
 aggregate_channels = true
 
+# Attach worker identity TLV to share submissions for per-worker hashrate tracking
+# (extension 0x0002). Disable when using Bitcoin addresses as user_identity, since
+# addresses exceed the 32-byte TLV limit.
+enable_worker_identity_tlv = true
+
 # Enable this option to set a predefined log file path.
 # When enabled, logs will always be written to this file.
 # The CLI option --log-file (or -f) will override this setting if provided.

--- a/miner-apps/translator/src/lib/config.rs
+++ b/miner-apps/translator/src/lib/config.rs
@@ -49,6 +49,12 @@ pub struct TranslatorConfig {
     /// If the upstream server doesn't support these, the translator will fail over to another
     /// upstream.
     pub required_extensions: Vec<u16>,
+    /// Whether to attach a UserIdentity TLV to SubmitSharesExtended messages for per-worker
+    /// hashrate tracking (extension 0x0002). When enabled, the user_identity must fit within
+    /// the 32-byte TLV limit. Disable this when using Bitcoin addresses as user_identity,
+    /// since addresses exceed 32 bytes.
+    #[serde(default = "default_enable_worker_identity_tlv")]
+    pub enable_worker_identity_tlv: bool,
     /// The path to the log file for the Translator.
     #[serde(default, deserialize_with = "opt_path_from_toml")]
     log_file: Option<PathBuf>,
@@ -61,6 +67,10 @@ pub struct TranslatorConfig {
 
 fn default_monitoring_cache_refresh_secs() -> u64 {
     15
+}
+
+fn default_enable_worker_identity_tlv() -> bool {
+    true
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -100,6 +110,7 @@ impl TranslatorConfig {
         aggregate_channels: bool,
         supported_extensions: Vec<u16>,
         required_extensions: Vec<u16>,
+        enable_worker_identity_tlv: bool,
     ) -> Self {
         Self {
             upstreams,
@@ -113,6 +124,7 @@ impl TranslatorConfig {
             aggregate_channels,
             supported_extensions,
             required_extensions,
+            enable_worker_identity_tlv,
             log_file: None,
             monitoring_address: None,
             monitoring_cache_refresh_secs: 15,
@@ -222,6 +234,7 @@ mod tests {
             true,
             vec![],
             vec![],
+            true,
         );
 
         assert_eq!(config.upstreams.len(), 1);
@@ -254,6 +267,7 @@ mod tests {
             false,
             vec![],
             vec![],
+            true,
         );
 
         assert!(config.log_dir().is_none());
@@ -288,6 +302,7 @@ mod tests {
             true,
             vec![],
             vec![],
+            true,
         );
 
         assert_eq!(config.upstreams.len(), 2);
@@ -315,6 +330,7 @@ mod tests {
             false,
             vec![],
             vec![],
+            true,
         );
 
         assert!(!config.downstream_difficulty_config.enable_vardiff);


### PR DESCRIPTION
## Summary

- Add `enable_worker_identity_tlv` config option (default: `true`) to control whether the `UserIdentity` TLV is attached to `SubmitSharesExtended` messages
- Replace `.unwrap()` with `.ok()` on `UserIdentity::new()` to prevent panics when `user_identity` exceeds the 32-byte TLV limit
- When disabled, the translator skips TLV encoding, matching current JD-client behavior

### Context

The translator panics when `user_identity` is a Bitcoin address (42-64 bytes) because the `UserIdentity` TLV has a hard 32-byte limit in `extensions-sv2`. This is relevant for solo mining setups where the SV2 server parses the `user_identity` from `OpenExtendedMiningChannel` to substitute the coinbase payout address. The address is correctly passed via `Str0255` (up to 255 bytes) in `OpenExtendedMiningChannel`, but the TLV encoding on share submissions crashes due to the 32-byte constraint.

Setting `enable_worker_identity_tlv = false` allows using Bitcoin addresses as `user_identity` without crashing, at the cost of losing per-worker hashrate attribution in the TLV. The JD-client already behaves this way (it does not attach `UserIdentity` TLV to shares).

Closes #295

## Test plan

- [x] `cargo check` passes
- [x] All 20 unit tests pass (`cargo test -p translator_sv2`)
- [ ] Manual test: connect SV1 miner with Bitcoin address as `user_identity` and `enable_worker_identity_tlv = false` — no crash
- [ ] Manual test: connect SV1 miner with short username as `user_identity` and `enable_worker_identity_tlv = true` — TLV attached as before
- [ ] Verify existing configs without the new field still work (serde default = true)