### PR TITLE
remove time sensitive assertion from `snapshot_cache::tests::test_snapshot_refresh`

### DIFF
--- a/stratum-apps/src/monitoring/snapshot_cache.rs
+++ b/stratum-apps/src/monitoring/snapshot_cache.rs
@@ -62,21 +62,6 @@ pub struct MonitoringSnapshot {
     pub sv1_clients_summary: Option<Sv1ClientsSummary>,
 }
 
-impl MonitoringSnapshot {
-    /// Check if this snapshot is stale (older than the given duration)
-    pub fn is_stale(&self, max_age: Duration) -> bool {
-        match self.timestamp {
-            None => true,
-            Some(ts) => ts.elapsed() > max_age,
-        }
-    }
-
-    /// Get the age of this snapshot
-    pub fn age(&self) -> Option<Duration> {
-        self.timestamp.map(|ts| ts.elapsed())
-    }
-}
-
 /// A cache that holds monitoring snapshots and refreshes them periodically.
 pub struct SnapshotCache {
     snapshot: RwLock<MonitoringSnapshot>,


### PR DESCRIPTION
hopefully fix the code coverage CI.

closes #301 


Also took the chance to remove unused API from `MonitoringSnapshot`. 
see: https://github.com/stratum-mining/sv2-apps/pull/302#discussion_r2870138431