### PR TITLE
Add assertions to fix inconsistency

### DIFF
--- a/pool-apps/jd-server/src/lib/config.rs
+++ b/pool-apps/jd-server/src/lib/config.rs
@@ -52,6 +52,7 @@ impl JobDeclaratorServerConfig {
         core_rpc: CoreRpc,
         mempool_update_interval: Duration,
     ) -> Self {
+        assert!(!coinbase_reward_script.script_pubkey().is_empty());
         Self {
             full_template_mode_required: true,
             listen_jd_address,

--- a/pool-apps/pool/src/lib/config.rs
+++ b/pool-apps/pool/src/lib/config.rs
@@ -66,6 +66,7 @@ impl PoolConfig {
         supported_extensions: Vec<u16>,
         required_extensions: Vec<u16>,
     ) -> Self {
+        assert!(!coinbase_reward_script.script_pubkey().is_empty());
         Self {
             listen_address: pool_connection.listen_address,
             template_provider_type,


### PR DESCRIPTION
These 2 function's comment indicate they will panic when coinbase_reward_script is empty, while the code don't apply any check. So the 2 assertions should be appended.