### PR TITLE
add IT for JD mining mode negotiation

### DIFF
--- a/integration-tests/tests/jd_integration.rs
+++ b/integration-tests/tests/jd_integration.rs
@@ -259,6 +259,48 @@ async fn jds_reject_setup_connection_without_declare_tx_data_flag() {
     shutdown_all!(pool);
 }
 
+#[tokio::test]
+async fn jdc_coinbase_only_mode_rejected_by_jds() {
+    start_tracing();
+    let (tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
+    let (pool, pool_addr, jds_addr, _) =
+        start_pool_with_jds(tp.bitcoin_core(), vec![], vec![], false).await;
+    let (sniffer, sniffer_addr) = start_sniffer("jdc-jds", jds_addr, false, vec![], None);
+    let (jdc, _jdc_addr, _) = start_jdc(
+        &[(pool_addr, sniffer_addr)],
+        sv2_tp_config(tp_addr),
+        vec![],
+        vec![],
+        false,
+        Some(jd_client_sv2::config::ConfigJDCMode::CoinbaseOnly),
+    );
+
+    sniffer
+        .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+        .await;
+    sniffer
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
+        )
+        .await;
+
+    let setup_connection_error = sniffer.next_message_from_upstream();
+    let setup_connection_error = match setup_connection_error {
+        Some((_, AnyMessage::Common(parsers_sv2::CommonMessages::SetupConnectionError(msg)))) => {
+            msg
+        }
+        msg => panic!("Expected SetupConnectionError message, found: {:?}", msg),
+    };
+    assert_eq!(
+        setup_connection_error.error_code.as_utf8_or_hex(),
+        ERROR_CODE_SETUP_CONNECTION_MISSING_DECLARE_TX_DATA_FLAG,
+        "SetupConnectionError message error code should be missing-declare-tx-data-flag"
+    );
+
+    shutdown_all!(jdc, pool);
+}
+
 // This test verifies that JDS rejects DeclareMiningJob when mining_job_token is invalid.
 #[tokio::test]
 async fn jds_reject_declare_mining_job_with_invalid_mining_job_token() {


### PR DESCRIPTION
Add an integration test verifying JDS rejects a JDC running in CoinbaseOnly mode during `SetupConnection` (`DECLARE_TX_DATA` flag absent → `SetupConnectionError: missing-declare-tx-data-flag`).

  Closes #21