### PR TITLE
remove verbose debug log from `bitcoin_core_sv2::job_declaration_protocol`

### DIFF
--- a/bitcoin-core-sv2/src/job_declaration_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/job_declaration_protocol/mod.rs
@@ -253,7 +253,6 @@ impl BitcoinCoreSv2JDP {
         tracing::debug!("Deserializing block ({} bytes)", block_bytes.len());
         let block: Block =
             deserialize(&block_bytes).map_err(BitcoinCoreSv2JDPError::FailedToDeserializeBlock)?;
-        tracing::debug!("Block deserialized: {:?}", block);
 
         self.mempool_mirror.borrow_mut().update(&block);
 


### PR DESCRIPTION
this polutes log files and makes them unreadable for humans