### PR TITLE
JDC asks for token when none is available for `RequestTransactionData.Success` handler

### DIFF
--- a/miner-apps/jd-client/src/lib/channel_manager/template_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/template_message_handler.rs
@@ -300,6 +300,7 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
                 "No token available, discarding template id: {}",
                 msg.template_id
             );
+            _ = self.allocate_tokens(1).await;
             return Ok(());
         };
         _ = self.allocate_tokens(1).await;


### PR DESCRIPTION
close #362