### PR TITLE
Add integration and unit tests for monitoring JSON API endpoints

### DIFF
--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -1771,6 +1771,8 @@ dependencies = [
  "pool_sv2",
  "primitive-types",
  "rand",
+ "serde",
+ "serde_json",
  "sha2 0.10.9",
  "stratum-apps",
  "tokio",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -28,6 +28,8 @@ tracing = { version = "0.1.41", default-features = false }
 tracing-subscriber = { version = "0.3.19", default-features = false }
 hex = "0.4.3"
 clap = { version = "^4.5.4", features = ["derive"] }
+serde_json = "1"
+serde = { version = "1", features = ["derive"] }
 
 # Direct dependencies kept only for the embedded `mining_device` module.
 # Remove this block when removing:

--- a/integration-tests/lib/prometheus_metrics_assertions.rs
+++ b/integration-tests/lib/prometheus_metrics_assertions.rs
@@ -1,7 +1,16 @@
 //! Helpers for querying and asserting on Prometheus metrics and JSON API endpoints
 //! exposed by SV2 components during integration tests.
 
-use std::{collections::HashMap, fmt, net::SocketAddr};
+use std::{collections::HashMap, fmt, net::SocketAddr, time::Duration};
+use stratum_apps::monitoring::{
+    GlobalInfo, HealthResponse, ServerResponse, Sv1ClientsResponse, Sv2ClientsResponse,
+};
+
+// All endpoints with a typed production struct in `stratum_apps::monitoring`
+// (`GlobalInfo`, `HealthResponse`, `ServerResponse`, `Sv2ClientsResponse`, ...)
+// are deserialized into the production type directly. The `/` root endpoint
+// is hand-rolled JSON in `handle_root` with no production struct; tests parse
+// it with `fetch_api_typed::<serde_json::Value>` and index by key.
 
 /// Fetch the raw Prometheus text-format metrics from a component's `/metrics` endpoint.
 /// Uses `spawn_blocking` to avoid blocking the tokio runtime with synchronous HTTP calls.
@@ -25,6 +34,218 @@ pub async fn fetch_api(monitoring_addr: SocketAddr, path: &str) -> String {
     })
     .await
     .expect("spawn_blocking for fetch_api panicked")
+}
+
+/// Fetch a JSON API endpoint and parse the response into a typed struct.
+pub async fn fetch_api_typed<T: serde::de::DeserializeOwned>(
+    monitoring_addr: SocketAddr,
+    path: &str,
+) -> T {
+    let body = fetch_api(monitoring_addr, path).await;
+    serde_json::from_str(&body).unwrap_or_else(|e| {
+        panic!(
+            "Failed to parse JSON from {} into {}: {}\nBody: {}",
+            path,
+            std::any::type_name::<T>(),
+            e,
+            body
+        )
+    })
+}
+
+/// Fetch a JSON API endpoint returning both the HTTP status code and parsed JSON body.
+/// Unlike `fetch_api_typed`, this does **not** panic on non-2xx responses, so it can be
+/// used to test error endpoints (e.g. 404).
+pub async fn fetch_api_with_status(
+    monitoring_addr: SocketAddr,
+    path: &str,
+) -> (i32, serde_json::Value) {
+    let url = format!("http://{}{}", monitoring_addr, path);
+    tokio::task::spawn_blocking(move || {
+        let (status, bytes) = crate::utils::http::make_get_request_with_status(&url, 5);
+        let body = String::from_utf8(bytes).expect("api response should be valid UTF-8");
+        let json: serde_json::Value = serde_json::from_str(&body).unwrap_or_else(|e| {
+            panic!(
+                "Failed to parse JSON from {} (status {}): {}\nBody: {}",
+                url, status, e, body
+            )
+        });
+        (status, json)
+    })
+    .await
+    .expect("spawn_blocking for fetch_api_with_status panicked")
+}
+
+/// Poll a JSON API endpoint until a numeric field at `json_pointer` (RFC 6901, e.g.
+/// `"/sv2_clients/total_clients"`) reaches `>= min`. Returns the full JSON value once
+/// satisfied. Panics if the condition is not met within `timeout`.
+///
+/// This is the JSON equivalent of `poll_until_metric_gte` — use it for endpoints whose
+/// data only appears after the monitoring snapshot cache has refreshed.
+pub async fn poll_until_api_field_gte(
+    monitoring_addr: SocketAddr,
+    path: &str,
+    json_pointer: &str,
+    min: f64,
+    timeout: Duration,
+) -> serde_json::Value {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        // Use fetch_api_with_status so that transient non-2xx responses (e.g. 404
+        // before the snapshot cache has populated) are retried instead of panicking.
+        let (status, json) = fetch_api_with_status(monitoring_addr, path).await;
+        if (200..300).contains(&status) {
+            if let Some(val) = json.pointer(json_pointer) {
+                let num = val.as_f64().unwrap_or(0.0);
+                if num >= min {
+                    return json;
+                }
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!(
+                "JSON field '{}' at {} never reached >= {} within {:?}. Last status: {}. Last response:\n{}",
+                json_pointer,
+                path,
+                min,
+                timeout,
+                status,
+                serde_json::to_string_pretty(&json).unwrap_or_default()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Internal: poll `path` until `condition` is met, returning the parsed `T`.
+/// Retries on non-2xx responses (endpoint may not be ready yet).
+async fn poll_until<T, F>(
+    monitoring_addr: SocketAddr,
+    path: &'static str,
+    timeout: Duration,
+    condition: F,
+    timeout_msg: &'static str,
+) -> T
+where
+    T: serde::de::DeserializeOwned,
+    F: Fn(&T) -> bool,
+{
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let (status, body) = {
+            let url = format!("http://{}{}", monitoring_addr, path);
+            tokio::task::spawn_blocking(move || {
+                crate::utils::http::make_get_request_with_status(&url, 5)
+            })
+            .await
+            .expect("spawn_blocking panicked")
+        };
+        if (200..300).contains(&status) {
+            let body_str = String::from_utf8(body).expect("response should be valid UTF-8");
+            if let Ok(resp) = serde_json::from_str::<T>(&body_str) {
+                if condition(&resp) {
+                    return resp;
+                }
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("{} within {:?}", timeout_msg, timeout);
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Poll `/api/v1/global` until `sv2_clients.total_clients >= min`.
+/// Returns the parsed `GlobalInfo` once satisfied.
+pub async fn poll_until_global_sv2_clients_gte(
+    monitoring_addr: SocketAddr,
+    min: usize,
+    timeout: Duration,
+) -> GlobalInfo {
+    poll_until(
+        monitoring_addr,
+        "/api/v1/global",
+        timeout,
+        move |r: &GlobalInfo| {
+            r.sv2_clients
+                .as_ref()
+                .is_some_and(|c| c.total_clients >= min)
+        },
+        "GlobalInfo sv2_clients.total_clients never reached >= expected",
+    )
+    .await
+}
+
+/// Poll `/api/v1/global` until `sv1_clients.total_clients >= min`.
+/// Returns the parsed `GlobalInfo` once satisfied.
+pub async fn poll_until_global_sv1_clients_gte(
+    monitoring_addr: SocketAddr,
+    min: usize,
+    timeout: Duration,
+) -> GlobalInfo {
+    poll_until(
+        monitoring_addr,
+        "/api/v1/global",
+        timeout,
+        move |r: &GlobalInfo| {
+            r.sv1_clients
+                .as_ref()
+                .is_some_and(|c| c.total_clients >= min)
+        },
+        "GlobalInfo sv1_clients.total_clients never reached >= expected",
+    )
+    .await
+}
+
+/// Poll `/api/v1/clients` until `total >= min`.
+/// Returns the parsed `Sv2ClientsResponse` once satisfied.
+pub async fn poll_until_clients_total_gte(
+    monitoring_addr: SocketAddr,
+    min: usize,
+    timeout: Duration,
+) -> Sv2ClientsResponse {
+    poll_until(
+        monitoring_addr,
+        "/api/v1/clients",
+        timeout,
+        move |r: &Sv2ClientsResponse| r.total >= min,
+        "Sv2ClientsResponse total never reached >= expected",
+    )
+    .await
+}
+
+/// Poll `/api/v1/sv1/clients` until `total >= min`.
+/// Returns the parsed `Sv1ClientsResponse` once satisfied.
+pub async fn poll_until_sv1_clients_total_gte(
+    monitoring_addr: SocketAddr,
+    min: usize,
+    timeout: Duration,
+) -> Sv1ClientsResponse {
+    poll_until(
+        monitoring_addr,
+        "/api/v1/sv1/clients",
+        timeout,
+        move |r: &Sv1ClientsResponse| r.total >= min,
+        "Sv1ClientsResponse total never reached >= expected",
+    )
+    .await
+}
+
+/// Poll `/api/v1/server` until `extended_channels_count >= min`.
+/// Returns the parsed `ServerResponse` once satisfied.
+pub async fn poll_until_server_channels_gte(
+    monitoring_addr: SocketAddr,
+    min: usize,
+    timeout: Duration,
+) -> ServerResponse {
+    poll_until(
+        monitoring_addr,
+        "/api/v1/server",
+        timeout,
+        move |r: &ServerResponse| r.extended_channels_count >= min,
+        "ServerResponse extended_channels_count never reached >= expected",
+    )
+    .await
 }
 
 /// A Prometheus metric selector: a metric name plus an optional set of label matchers.
@@ -158,6 +379,7 @@ pub(crate) fn parse_metric_value<'a, M: Into<Metric<'a>>>(
 }
 
 /// Assert that a metric is present and its value satisfies the given predicate.
+#[track_caller]
 pub(crate) fn assert_metric<'a, M, F>(
     metrics_text: &str,
     metric: M,
@@ -188,11 +410,13 @@ pub(crate) fn assert_metric<'a, M, F>(
 }
 
 /// Assert that a metric is present with a value >= the given minimum.
+#[track_caller]
 pub fn assert_metric_gte<'a, M: Into<Metric<'a>>>(metrics_text: &str, metric: M, min: f64) {
     assert_metric(metrics_text, metric, |v| v >= min, &format!(">= {}", min));
 }
 
 /// Assert that a metric is present with the exact given value.
+#[track_caller]
 pub fn assert_metric_eq<'a, M: Into<Metric<'a>>>(metrics_text: &str, metric: M, expected: f64) {
     assert_metric(
         metrics_text,
@@ -207,6 +431,7 @@ pub fn assert_metric_eq<'a, M: Into<Metric<'a>>>(metrics_text: &str, metric: M, 
 /// For a bare-name selector (`Metric::new("name")` or `"name".into()`), this means
 /// the metric name does not appear at all. For a labeled selector, it means no line
 /// with matching labels exists — other series for the same metric name are allowed.
+#[track_caller]
 pub fn assert_metric_not_present<'a, M: Into<Metric<'a>>>(metrics_text: &str, metric: M) {
     let metric = metric.into();
     for line in metrics_text.lines() {
@@ -223,6 +448,7 @@ pub fn assert_metric_not_present<'a, M: Into<Metric<'a>>>(metrics_text: &str, me
 }
 
 /// Assert that at least one exposition line matches the selector.
+#[track_caller]
 pub fn assert_metric_present<'a, M: Into<Metric<'a>>>(metrics_text: &str, metric: M) {
     let metric = metric.into();
     for line in metrics_text.lines() {
@@ -248,7 +474,7 @@ pub async fn poll_until_metric_gte<'a, M: Into<Metric<'a>>>(
     monitoring_addr: SocketAddr,
     metric: M,
     min: f64,
-    timeout: std::time::Duration,
+    timeout: Duration,
 ) -> String {
     let metric = metric.into();
     let deadline = tokio::time::Instant::now() + timeout;
@@ -265,21 +491,22 @@ pub async fn poll_until_metric_gte<'a, M: Into<Metric<'a>>>(
                 metric, min, timeout, metrics
             );
         }
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
 
-/// Assert that the `/api/v1/health` endpoint returns a response containing `"status":"ok"`.
+/// Assert that the `/api/v1/health` endpoint returns `{"status":"ok"}`.
 pub async fn assert_api_health(monitoring_addr: SocketAddr) {
-    let body = fetch_api(monitoring_addr, "/api/v1/health").await;
-    assert!(
-        body.contains("\"status\":\"ok\""),
-        "Health endpoint should return ok status, got: {}",
-        body
+    let health: HealthResponse = fetch_api_typed(monitoring_addr, "/api/v1/health").await;
+    assert_eq!(
+        health.status, "ok",
+        "Health endpoint should return ok status, got: {:?}",
+        health
     );
 }
 
 /// Assert that the uptime metric is present and positive.
+#[track_caller]
 pub fn assert_uptime(metrics_text: &str) {
     assert_metric(
         metrics_text,

--- a/integration-tests/lib/utils.rs
+++ b/integration-tests/lib/utils.rs
@@ -407,6 +407,43 @@ pub fn into_static(m: AnyMessage<'_>) -> AnyMessage<'static> {
 }
 
 pub mod http {
+    /// Make a GET request that returns both the HTTP status code and the response body.
+    /// Unlike `make_get_request`, this does NOT panic on non-2xx status codes (e.g. 404),
+    /// making it suitable for testing API error responses.
+    /// Only retries on 5xx errors or connection failures.
+    pub fn make_get_request_with_status(url: &str, retries: usize) -> (i32, Vec<u8>) {
+        for attempt in 1..=retries {
+            let response = minreq::get(url).send();
+            match response {
+                Ok(res) => {
+                    let status_code = res.status_code;
+                    if (500..600).contains(&status_code) {
+                        eprintln!(
+                            "Attempt {attempt}: URL {url} returned a server error code {status_code}"
+                        );
+                    } else {
+                        return (status_code, res.as_bytes().to_vec());
+                    }
+                }
+                Err(err) => {
+                    eprintln!(
+                        "Attempt {}: Failed to fetch URL {}: {:?}",
+                        attempt + 1,
+                        url,
+                        err
+                    );
+                }
+            }
+
+            if attempt < retries {
+                let delay = 1u64 << (attempt - 1);
+                eprintln!("Retrying in {delay} seconds (exponential backoff)...");
+                std::thread::sleep(std::time::Duration::from_secs(delay));
+            }
+        }
+        panic!("Cannot reach URL {url} after {retries} attempts");
+    }
+
     pub fn make_get_request(download_url: &str, retries: usize) -> Vec<u8> {
         for attempt in 1..=retries {
             let response = minreq::get(download_url).send();

--- a/integration-tests/tests/monitoring_integration.rs
+++ b/integration-tests/tests/monitoring_integration.rs
@@ -7,7 +7,10 @@ use integration_tests_sv2::{
     interceptor::MessageDirection, prometheus_metrics_assertions::*,
     template_provider::DifficultyLevel, *,
 };
-use stratum_apps::stratum_core::mining_sv2::*;
+use stratum_apps::{
+    monitoring::{Sv1ClientInfo, Sv2ClientChannelsResponse, Sv2ClientResponse},
+    stratum_core::mining_sv2::*,
+};
 
 /// Timeout for polling metric assertions. Generous enough for slow CI.
 const METRIC_POLL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
@@ -84,11 +87,7 @@ async fn pool_monitoring_with_sv2_mining_device() {
     shutdown_all!(pool);
 }
 
-// ---------------------------------------------------------------------------
-// 2. Pool + tProxy + SV1 miner (non-aggregated) Pool: client metrics (1 SV2 client = tProxy,
-//    extended channel, shares) tProxy: server metrics (upstream channel to pool), SV1 metrics (1
-//    SV1 client) tProxy has no SV2 downstreams so sv2_clients_total should be absent
-// ---------------------------------------------------------------------------
+// Pool + tProxy + SV1 miner: Pool sees 1 SV2 client, tProxy sees 1 SV1 client and 1 upstream channel.
 #[tokio::test]
 async fn pool_and_tproxy_monitoring_with_sv1_miner() {
     start_tracing();
@@ -168,10 +167,7 @@ async fn pool_and_tproxy_monitoring_with_sv1_miner() {
     shutdown_all!(pool, tproxy);
 }
 
-// ---------------------------------------------------------------------------
-// 3. Pool + JDC + tProxy + 2 SV1 miners (aggregated) tProxy aggregated: 2 SV1 clients, 1 upstream
-//    extended channel Pool: 1 SV2 client (JDC), shares accepted
-// ---------------------------------------------------------------------------
+// Pool + JDC + tProxy + 2 SV1 miners: aggregated topology with multiple SV1 clients.
 #[tokio::test]
 async fn jd_aggregated_topology_monitoring() {
     start_tracing();
@@ -267,10 +263,7 @@ async fn jd_aggregated_topology_monitoring() {
     shutdown_all!(pool, jdc, tproxy);
 }
 
-// ---------------------------------------------------------------------------
-// 4. Block found detection via metrics Uses JDC topology (which finds regtest blocks). After a
-//    block is found, the pool's sv2_client_blocks_found_total metric should be >= 1.
-// ---------------------------------------------------------------------------
+// Block found detection: JDC topology finds regtest blocks, pool metrics reflect it.
 #[tokio::test]
 async fn block_found_detected_in_pool_metrics() {
     use stratum_apps::stratum_core::template_distribution_sv2::*;
@@ -315,4 +308,416 @@ async fn block_found_detected_in_pool_metrics() {
     assert_metric_eq(&pool_metrics, "sv2_clients_total", 1.0);
 
     shutdown_all!(pool, jdc, tproxy);
+}
+
+// ---------------------------------------------------------------------------
+// 5. Pool JSON API endpoints — static (no miner / no activity).
+// Covers: root, /api/v1/server (404), /api/v1/server/channels (404),
+//         /api/v1/sv1/clients (404).
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn pool_api_endpoints_static() {
+    start_tracing();
+    let (_tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
+    let (pool, _pool_addr, pool_monitoring) =
+        start_pool(sv2_tp_config(tp_addr), vec![], vec![], true).await;
+    let pool_mon = pool_monitoring.expect("pool monitoring should be enabled");
+
+    // Health is always available.
+    assert_api_health(pool_mon).await;
+
+    // Root endpoint lists APIs.
+    let root: serde_json::Value = fetch_api_typed(pool_mon, "/").await;
+    assert_eq!(root["service"], "SRI Monitoring API");
+    assert!(
+        root["endpoints"].is_object(),
+        "endpoints should be a JSON object"
+    );
+
+    // Pool has no upstream and no SV1 — these endpoints should return 404 with a JSON error body.
+    for path in [
+        "/api/v1/server",
+        "/api/v1/server/channels",
+        "/api/v1/sv1/clients",
+    ] {
+        let (status, json) = fetch_api_with_status(pool_mon, path).await;
+        assert_eq!(
+            status, 404,
+            "{} should return 404, got {} with body {}",
+            path, status, json
+        );
+        assert!(
+            json["error"].is_string(),
+            "{} should return a JSON error body, got {}",
+            path,
+            json
+        );
+    }
+
+    pool.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// 6. Pool JSON API endpoints — with active SV2 miner.
+// Covers: /api/v1/global, /api/v1/clients (paginated list), /api/v1/clients/{id},
+//         /api/v1/clients/{id}/channels, plus 404s for unknown ids.
+// Also cross-validates that the JSON API and Prometheus surface report
+// consistent share data for the same (client, channel, user).
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn pool_api_endpoints_with_miner() {
+    start_tracing();
+    let (_tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
+    let (pool, pool_addr, pool_monitoring) =
+        start_pool(sv2_tp_config(tp_addr), vec![], vec![], true).await;
+    let (sniffer, sniffer_addr) = start_sniffer("A", pool_addr, false, vec![], None);
+    // Explicit user_id so the per-channel Prometheus user_identity label is meaningful.
+    start_mining_device_sv2(
+        sniffer_addr,
+        None,
+        None,
+        Some("test-miner".to_string()),
+        1,
+        None,
+        true,
+    );
+
+    sniffer
+        .wait_for_message_type(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_SUBMIT_SHARES_STANDARD,
+        )
+        .await;
+    sniffer
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SUBMIT_SHARES_SUCCESS,
+        )
+        .await;
+
+    let pool_mon = pool_monitoring.expect("pool monitoring should be enabled");
+
+    // /api/v1/global — pool sees SV2 clients, no upstream server, no SV1.
+    let global = poll_until_global_sv2_clients_gte(pool_mon, 1, METRIC_POLL_TIMEOUT).await;
+    assert!(
+        global.server.is_none(),
+        "Pool /api/v1/global should have null server"
+    );
+    assert_eq!(global.sv2_clients.as_ref().unwrap().total_clients, 1);
+    assert!(
+        global.sv1_clients.is_none(),
+        "Pool /api/v1/global should have null sv1_clients"
+    );
+
+    // /api/v1/clients — paginated list.
+    let clients = poll_until_clients_total_gte(pool_mon, 1, METRIC_POLL_TIMEOUT).await;
+    assert_eq!(clients.total, 1);
+    assert_eq!(clients.items.len(), 1);
+    let client_id = clients.items[0].client_id;
+    assert!(client_id > 0);
+
+    // /api/v1/clients/{id} — single-client lookup.
+    let client: Sv2ClientResponse =
+        fetch_api_typed(pool_mon, &format!("/api/v1/clients/{}", client_id)).await;
+    assert_eq!(client.client_id, client_id);
+
+    // /api/v1/clients/{id}/channels — at least one channel.
+    let channels: Sv2ClientChannelsResponse =
+        fetch_api_typed(pool_mon, &format!("/api/v1/clients/{}/channels", client_id)).await;
+    assert_eq!(channels.client_id, client_id);
+    assert!(
+        channels.total_standard + channels.total_extended >= 1,
+        "client should have ≥1 channel, got std={} ext={}",
+        channels.total_standard,
+        channels.total_extended,
+    );
+
+    // 404 paths for unknown client id.
+    for path in [
+        format!("/api/v1/clients/{}", 99999),
+        format!("/api/v1/clients/{}/channels", 99999),
+    ] {
+        let (status, _) = fetch_api_with_status(pool_mon, &path).await;
+        assert_eq!(status, 404, "unknown {} should return 404", path);
+    }
+
+    // Cross-surface: Prometheus must report at least the same accepted shares the JSON API saw.
+    // Pool reserves channel_id=1 internally and assigns 2 to the first downstream-opened channel.
+    let metrics = poll_until_metric_gte(
+        pool_mon,
+        Metric::with_labels(
+            "sv2_client_shares_accepted_total",
+            &[
+                ("client_id", "1"),
+                ("channel_id", "2"),
+                ("user_identity", "test-miner"),
+            ],
+        ),
+        1.0,
+        METRIC_POLL_TIMEOUT,
+    )
+    .await;
+    assert_metric_eq(&metrics, "sv2_clients_total", 1.0);
+
+    pool.shutdown().await;
+}
+
+// ---------------------------------------------------------------------------
+// 7. tProxy JSON API endpoints — static (no miner / no activity).
+// Covers: root, /api/v1/clients (404 — tProxy has no SV2 downstreams).
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn tproxy_api_endpoints_static() {
+    start_tracing();
+    let (_tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
+    let (pool, pool_addr, _pool_monitoring) =
+        start_pool(sv2_tp_config(tp_addr), vec![], vec![], false).await;
+    let (tproxy, _tproxy_addr, tproxy_monitoring) =
+        start_sv2_translator(&[pool_addr], false, vec![], vec![], None, true).await;
+    let tproxy_mon = tproxy_monitoring.expect("tproxy monitoring should be enabled");
+
+    assert_api_health(tproxy_mon).await;
+
+    let root: serde_json::Value = fetch_api_typed(tproxy_mon, "/").await;
+    assert_eq!(root["service"], "SRI Monitoring API");
+    assert!(root["endpoints"].is_object());
+
+    let (status, json) = fetch_api_with_status(tproxy_mon, "/api/v1/clients").await;
+    assert_eq!(status, 404, "/api/v1/clients should return 404 for tProxy");
+    assert!(json["error"].is_string());
+
+    shutdown_all!(tproxy, pool);
+}
+
+// ---------------------------------------------------------------------------
+// 8. tProxy JSON API endpoints — with active SV1 miner.
+// Covers: /api/v1/global, /api/v1/server, /api/v1/server/channels,
+//         /api/v1/sv1/clients (paginated), /api/v1/sv1/clients/{id} (+ 404).
+// Also cross-validates that JSON API and Prometheus expose consistent
+// upstream-channel share data.
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn tproxy_api_endpoints_with_miner() {
+    start_tracing();
+    let (_tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
+    let (pool, pool_addr, _pool_monitoring) =
+        start_pool(sv2_tp_config(tp_addr), vec![], vec![], false).await;
+    let (sniffer, sniffer_addr) = start_sniffer("0", pool_addr, false, vec![], None);
+    let (tproxy, tproxy_addr, tproxy_monitoring) =
+        start_sv2_translator(&[sniffer_addr], false, vec![], vec![], None, true).await;
+    let (_minerd_process, _minerd_addr) = start_minerd(tproxy_addr, None, None, false).await;
+
+    sniffer
+        .wait_for_message_type(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED,
+        )
+        .await;
+
+    let tproxy_mon = tproxy_monitoring.expect("tproxy monitoring should be enabled");
+
+    // /api/v1/global — tProxy has upstream server + SV1 clients, no SV2 downstreams.
+    let global = poll_until_global_sv1_clients_gte(tproxy_mon, 1, METRIC_POLL_TIMEOUT).await;
+    let server_summary = global
+        .server
+        .as_ref()
+        .expect("tProxy /api/v1/global should have server");
+    assert_eq!(server_summary.extended_channels, 1);
+    assert_eq!(global.sv1_clients.as_ref().unwrap().total_clients, 1);
+    assert!(
+        global.sv2_clients.is_none(),
+        "tProxy should have null sv2_clients"
+    );
+
+    // /api/v1/server — extended channel count visible.
+    let server = poll_until_server_channels_gte(tproxy_mon, 1, METRIC_POLL_TIMEOUT).await;
+    assert_eq!(server.extended_channels_count, 1);
+
+    // /api/v1/server/channels — channel details with shares_acknowledged populated.
+    let server_channels = poll_until_api_field_gte(
+        tproxy_mon,
+        "/api/v1/server/channels",
+        "/total_extended",
+        1.0,
+        METRIC_POLL_TIMEOUT,
+    )
+    .await;
+    let ext = server_channels["extended_channels"]
+        .as_array()
+        .expect("extended_channels should be an array");
+    assert!(!ext.is_empty(), "should have channel details");
+    assert!(
+        ext[0]["shares_acknowledged"].as_u64().is_some(),
+        "channel should expose shares_acknowledged, got: {}",
+        ext[0]
+    );
+    // Regression guard: shares_rejected fields must be present with the
+    // expected types on the upstream channel detail.
+    assert!(
+        ext[0]["shares_rejected"].as_u64().is_some(),
+        "channel should expose shares_rejected as a number, got: {}",
+        ext[0]
+    );
+    assert!(
+        ext[0]["shares_rejected_by_reason"].is_object(),
+        "channel should expose shares_rejected_by_reason as an object, got: {}",
+        ext[0]
+    );
+
+    // /api/v1/sv1/clients — at least one SV1 client.
+    let sv1_clients = poll_until_sv1_clients_total_gte(tproxy_mon, 1, METRIC_POLL_TIMEOUT).await;
+    assert_eq!(sv1_clients.total, 1);
+    assert!(!sv1_clients.items.is_empty());
+    let sv1_client_id = sv1_clients.items[0].client_id;
+    assert!(sv1_client_id > 0);
+
+    // /api/v1/sv1/clients/{id} — single-client lookup.
+    let client: Sv1ClientInfo = fetch_api_typed(
+        tproxy_mon,
+        &format!("/api/v1/sv1/clients/{}", sv1_client_id),
+    )
+    .await;
+    assert_eq!(client.client_id, sv1_client_id);
+
+    // 404 for unknown SV1 client id.
+    let (status, _) = fetch_api_with_status(tproxy_mon, "/api/v1/sv1/clients/99999").await;
+    assert_eq!(status, 404);
+
+    // Cross-surface: Prometheus must report the same upstream-channel accepted shares.
+    let metrics = poll_until_metric_gte(
+        tproxy_mon,
+        Metric::with_labels(
+            "sv2_server_shares_accepted_total",
+            &[
+                ("channel_id", "2"),
+                ("user_identity", "user_identity.miner1"),
+            ],
+        ),
+        1.0,
+        METRIC_POLL_TIMEOUT,
+    )
+    .await;
+    assert_metric_eq(&metrics, "sv1_clients_total", 1.0);
+
+    shutdown_all!(tproxy, pool);
+}
+
+// ---------------------------------------------------------------------------
+// 9. JDC JSON API endpoints — with active SV1 miner.
+// JDC sits between pool and tProxy: it is an SV2 client to the pool (so
+// `server` is populated) and an SV2 server to tProxy (so `sv2_clients` is
+// populated). JDC has no SV1 surface.
+// Covers: root, /api/v1/global, /api/v1/server, /api/v1/server/channels,
+//         /api/v1/clients, /api/v1/clients/{id}, /api/v1/clients/{id}/channels,
+//         /api/v1/sv1/clients (404).
+// ---------------------------------------------------------------------------
+#[tokio::test]
+async fn jdc_api_endpoints_with_miner() {
+    start_tracing();
+    let (tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
+    let (pool, pool_addr, jds_addr, _pool_monitoring) =
+        start_pool_with_jds(tp.bitcoin_core(), vec![], vec![], false).await;
+    let (jdc_pool_sniffer, jdc_pool_sniffer_addr) =
+        start_sniffer("0", pool_addr, false, vec![], None);
+    let (jdc, jdc_addr, jdc_monitoring) = start_jdc(
+        &[(jdc_pool_sniffer_addr, jds_addr)],
+        sv2_tp_config(tp_addr),
+        vec![],
+        vec![],
+        true,
+        None,
+    );
+    let (tproxy, tproxy_addr, _) =
+        start_sv2_translator(&[jdc_addr], true, vec![], vec![], None, false).await;
+    let (_minerd, _minerd_addr) = start_minerd(tproxy_addr, None, None, false).await;
+
+    // Wait until at least one share has flowed all the way to the pool.
+    jdc_pool_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_SUBMIT_SHARES_EXTENDED,
+        )
+        .await;
+
+    let jdc_mon = jdc_monitoring.expect("jdc monitoring should be enabled");
+    assert_api_health(jdc_mon).await;
+
+    // Root endpoint lists APIs.
+    let root: serde_json::Value = fetch_api_typed(jdc_mon, "/").await;
+    assert_eq!(root["service"], "SRI Monitoring API");
+    assert!(root["endpoints"].is_object());
+
+    // /api/v1/global — JDC has both server (pool) and sv2_clients (tproxy), no sv1.
+    let global = poll_until_global_sv2_clients_gte(jdc_mon, 1, METRIC_POLL_TIMEOUT).await;
+    let server_summary = global
+        .server
+        .as_ref()
+        .expect("JDC /api/v1/global should have server");
+    assert_eq!(server_summary.extended_channels, 1);
+    assert_eq!(global.sv2_clients.as_ref().unwrap().total_clients, 1);
+    assert!(
+        global.sv1_clients.is_none(),
+        "JDC should have null sv1_clients"
+    );
+
+    // /api/v1/server — extended channel from upstream pool.
+    let server = poll_until_server_channels_gte(jdc_mon, 1, METRIC_POLL_TIMEOUT).await;
+    assert_eq!(server.extended_channels_count, 1);
+
+    // /api/v1/server/channels — channel details with all share-counter fields.
+    let server_channels = poll_until_api_field_gte(
+        jdc_mon,
+        "/api/v1/server/channels",
+        "/total_extended",
+        1.0,
+        METRIC_POLL_TIMEOUT,
+    )
+    .await;
+    let ext = server_channels["extended_channels"]
+        .as_array()
+        .expect("extended_channels should be an array");
+    assert!(!ext.is_empty());
+    assert!(
+        ext[0]["shares_acknowledged"].as_u64().is_some(),
+        "channel should expose shares_acknowledged, got: {}",
+        ext[0]
+    );
+    assert!(
+        ext[0]["shares_rejected"].as_u64().is_some(),
+        "channel should expose shares_rejected as a number, got: {}",
+        ext[0]
+    );
+    assert!(
+        ext[0]["shares_rejected_by_reason"].is_object(),
+        "channel should expose shares_rejected_by_reason as an object, got: {}",
+        ext[0]
+    );
+
+    // /api/v1/clients — JDC's downstream is the tProxy (single SV2 client).
+    let clients = poll_until_clients_total_gte(jdc_mon, 1, METRIC_POLL_TIMEOUT).await;
+    assert_eq!(clients.total, 1);
+    assert_eq!(clients.items.len(), 1);
+    let client_id = clients.items[0].client_id;
+
+    // /api/v1/clients/{id} — single client lookup.
+    let client: Sv2ClientResponse =
+        fetch_api_typed(jdc_mon, &format!("/api/v1/clients/{}", client_id)).await;
+    assert_eq!(client.client_id, client_id);
+
+    // /api/v1/clients/{id}/channels — tProxy opens an extended channel via JDC.
+    let channels: Sv2ClientChannelsResponse =
+        fetch_api_typed(jdc_mon, &format!("/api/v1/clients/{}/channels", client_id)).await;
+    assert_eq!(channels.client_id, client_id);
+    assert!(
+        channels.total_extended >= 1,
+        "tproxy should open an extended channel via JDC, got total_extended={}",
+        channels.total_extended,
+    );
+
+    // /api/v1/sv1/clients — JDC has no SV1 surface.
+    let (status, json) = fetch_api_with_status(jdc_mon, "/api/v1/sv1/clients").await;
+    assert_eq!(status, 404, "JDC /api/v1/sv1/clients should return 404");
+    assert!(json["error"].is_string());
+
+    shutdown_all!(tproxy, jdc, pool);
 }

--- a/stratum-apps/src/monitoring/http_server.rs
+++ b/stratum-apps/src/monitoring/http_server.rs
@@ -290,68 +290,70 @@ impl MonitoringServer {
     }
 }
 
-// Response types - used for both actual responses and OpenAPI documentation
-#[derive(serde::Serialize, ToSchema)]
-struct HealthResponse {
-    status: String,
-    timestamp: u64,
+// Response types — used for both actual responses, OpenAPI documentation,
+// and as the canonical types for JSON deserialization in tests (both
+// in-crate unit tests and downstream integration tests).
+#[derive(serde::Serialize, serde::Deserialize, Debug, ToSchema)]
+pub struct HealthResponse {
+    pub status: String,
+    pub timestamp: u64,
 }
 
-#[derive(serde::Serialize, ToSchema)]
-struct ErrorResponse {
-    error: String,
+#[derive(serde::Serialize, serde::Deserialize, Debug, ToSchema)]
+pub struct ErrorResponse {
+    pub error: String,
 }
 
-#[derive(serde::Serialize, ToSchema)]
-struct ServerResponse {
-    extended_channels_count: usize,
-    standard_channels_count: usize,
-    total_hashrate: f32,
+#[derive(serde::Serialize, serde::Deserialize, Debug, ToSchema)]
+pub struct ServerResponse {
+    pub extended_channels_count: usize,
+    pub standard_channels_count: usize,
+    pub total_hashrate: f32,
 }
 
-#[derive(serde::Serialize, ToSchema)]
-struct ServerChannelsResponse {
-    offset: usize,
-    limit: usize,
-    total_extended: usize,
-    total_standard: usize,
-    extended_channels: Vec<ServerExtendedChannelInfo>,
-    standard_channels: Vec<ServerStandardChannelInfo>,
+#[derive(serde::Serialize, serde::Deserialize, Debug, ToSchema)]
+pub struct ServerChannelsResponse {
+    pub offset: usize,
+    pub limit: usize,
+    pub total_extended: usize,
+    pub total_standard: usize,
+    pub extended_channels: Vec<ServerExtendedChannelInfo>,
+    pub standard_channels: Vec<ServerStandardChannelInfo>,
 }
 
-#[derive(serde::Serialize, ToSchema)]
-struct Sv2ClientsResponse {
-    offset: usize,
-    limit: usize,
-    total: usize,
-    items: Vec<Sv2ClientMetadata>,
+#[derive(serde::Serialize, serde::Deserialize, Debug, ToSchema)]
+pub struct Sv2ClientsResponse {
+    pub offset: usize,
+    pub limit: usize,
+    pub total: usize,
+    pub items: Vec<Sv2ClientMetadata>,
 }
 
-#[derive(serde::Serialize, ToSchema)]
-struct Sv2ClientResponse {
-    client_id: usize,
-    extended_channels_count: usize,
-    standard_channels_count: usize,
-    total_hashrate: f32,
+#[derive(serde::Serialize, serde::Deserialize, Debug, ToSchema)]
+pub struct Sv2ClientResponse {
+    pub client_id: usize,
+    pub extended_channels_count: usize,
+    pub standard_channels_count: usize,
+    pub total_hashrate: f32,
 }
 
-#[derive(serde::Serialize, ToSchema)]
-struct Sv2ClientChannelsResponse {
-    client_id: usize,
-    offset: usize,
-    limit: usize,
-    total_extended: usize,
-    total_standard: usize,
-    extended_channels: Vec<ExtendedChannelInfo>,
-    standard_channels: Vec<StandardChannelInfo>,
+#[derive(serde::Serialize, serde::Deserialize, Debug, ToSchema)]
+pub struct Sv2ClientChannelsResponse {
+    pub client_id: usize,
+    pub offset: usize,
+    pub limit: usize,
+    pub total_extended: usize,
+    pub total_standard: usize,
+    pub extended_channels: Vec<ExtendedChannelInfo>,
+    pub standard_channels: Vec<StandardChannelInfo>,
 }
 
-#[derive(serde::Serialize, ToSchema)]
-struct Sv1ClientsResponse {
-    offset: usize,
-    limit: usize,
-    total: usize,
-    items: Vec<Sv1ClientInfo>,
+#[derive(serde::Serialize, serde::Deserialize, Debug, ToSchema)]
+pub struct Sv1ClientsResponse {
+    pub offset: usize,
+    pub limit: usize,
+    pub total: usize,
+    pub items: Vec<Sv1ClientInfo>,
 }
 
 /// Root endpoint - lists all available APIs
@@ -784,18 +786,55 @@ async fn handle_prometheus_metrics(State(state): State<ServerState>) -> Response
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::monitoring::server::ServerInfo;
     use axum::body::Body;
     use http_body_util::BodyExt;
     use std::{collections::HashMap, sync::Mutex};
     use tower::ServiceExt;
 
+    // ── Route constants ─────────────────────────────────────────────
+    mod routes {
+        pub const ROOT: &str = "/";
+        pub const HEALTH: &str = "/api/v1/health";
+        pub const GLOBAL: &str = "/api/v1/global";
+        pub const SERVER: &str = "/api/v1/server";
+        pub const SERVER_CHANNELS: &str = "/api/v1/server/channels";
+        pub const CLIENTS: &str = "/api/v1/clients";
+        pub const SV1_CLIENTS: &str = "/api/v1/sv1/clients";
+        pub const METRICS: &str = "/metrics";
+
+        pub fn client_by_id(id: usize) -> String {
+            format!("/api/v1/clients/{}", id)
+        }
+
+        pub fn client_channels(id: usize) -> String {
+            format!("/api/v1/clients/{}/channels", id)
+        }
+
+        pub fn sv1_client_by_id(id: usize) -> String {
+            format!("/api/v1/sv1/clients/{}", id)
+        }
+    }
+
+    // ── Test-only response shape ────────────────────────────────────
+    //
+    // Root endpoint is hand-rolled JSON in `handle_root` (no typed
+    // production struct), so tests need a minimal shape just to
+    // deserialize and inspect the two fields we care about. All other
+    // response types in this test module reuse the production types
+    // (`HealthResponse`, `ErrorResponse`, `ServerResponse`,
+    // `ServerChannelsResponse`, `Sv2ClientsResponse`, `Sv2ClientResponse`,
+    // `Sv2ClientChannelsResponse`, `Sv1ClientsResponse`) defined above.
+    #[derive(Debug, serde::Deserialize)]
+    struct RootResponseBody {
+        service: String,
+        endpoints: serde_json::Value,
+    }
+
     // ── helpers ──────────────────────────────────────────────────────
 
-    fn create_extended_channel_info(
-        channel_id: u32,
-        hashrate: f32,
-    ) -> super::super::client::ExtendedChannelInfo {
-        super::super::client::ExtendedChannelInfo {
+    fn create_extended_channel_info(channel_id: u32, hashrate: f32) -> ExtendedChannelInfo {
+        ExtendedChannelInfo {
             channel_id,
             user_identity: format!("user-ext-{}", channel_id),
             nominal_hashrate: hashrate,
@@ -817,11 +856,8 @@ mod tests {
         }
     }
 
-    fn create_standard_channel_info(
-        channel_id: u32,
-        hashrate: f32,
-    ) -> super::super::client::StandardChannelInfo {
-        super::super::client::StandardChannelInfo {
+    fn create_standard_channel_info(channel_id: u32, hashrate: f32) -> StandardChannelInfo {
+        StandardChannelInfo {
             channel_id,
             user_identity: format!("user-std-{}", channel_id),
             nominal_hashrate: hashrate,
@@ -900,22 +936,22 @@ mod tests {
         }
     }
 
-    struct MockServer(super::super::server::ServerInfo);
+    struct MockServer(ServerInfo);
     impl ServerMonitoring for MockServer {
-        fn get_server(&self) -> super::super::server::ServerInfo {
+        fn get_server(&self) -> ServerInfo {
             self.0.clone()
         }
     }
 
     struct MockClients(Vec<Sv2ClientInfo>);
-    impl super::super::client::Sv2ClientsMonitoring for MockClients {
+    impl Sv2ClientsMonitoring for MockClients {
         fn get_sv2_clients(&self) -> Vec<Sv2ClientInfo> {
             self.0.clone()
         }
     }
 
     struct MockSv1Clients(Vec<Sv1ClientInfo>);
-    impl super::super::sv1::Sv1ClientsMonitoring for MockSv1Clients {
+    impl Sv1ClientsMonitoring for MockSv1Clients {
         fn get_sv1_clients(&self) -> Vec<Sv1ClientInfo> {
             self.0.clone()
         }
@@ -924,8 +960,8 @@ mod tests {
     /// Build a full Router with mock data for integration testing.
     fn build_test_app(
         server: Option<Arc<dyn ServerMonitoring + Send + Sync>>,
-        clients: Option<Arc<dyn super::super::client::Sv2ClientsMonitoring + Send + Sync>>,
-        sv1: Option<Arc<dyn super::super::sv1::Sv1ClientsMonitoring + Send + Sync>>,
+        clients: Option<Arc<dyn Sv2ClientsMonitoring + Send + Sync>>,
+        sv1: Option<Arc<dyn Sv1ClientsMonitoring + Send + Sync>>,
     ) -> Router {
         let has_server = server.is_some();
         let has_clients = clients.is_some();
@@ -1074,25 +1110,26 @@ mod tests {
     #[tokio::test]
     async fn health_endpoint_returns_ok() {
         let app = build_test_app(None, None, None);
-        let response = app.oneshot(make_request("/api/v1/health")).await.unwrap();
+        let response = app.oneshot(make_request(routes::HEALTH)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
-        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(json["status"], "ok");
-        assert!(json["timestamp"].as_u64().is_some());
+        let resp: HealthResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.status, "ok");
+        // timestamp should also parse as a u64 (set in handle_health)
+        let _ = resp.timestamp;
     }
 
     #[tokio::test]
     async fn root_endpoint_lists_endpoints() {
         let app = build_test_app(None, None, None);
-        let response = app.oneshot(make_request("/")).await.unwrap();
+        let response = app.oneshot(make_request(routes::ROOT)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
-        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(json["service"], "SRI Monitoring API");
-        assert!(json["endpoints"].is_object());
+        let resp: RootResponseBody = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.service, "SRI Monitoring API");
+        assert!(resp.endpoints.is_object());
     }
 
     #[tokio::test]
@@ -1114,19 +1151,20 @@ mod tests {
     #[tokio::test]
     async fn global_endpoint_with_no_sources() {
         let app = build_test_app(None, None, None);
-        let response = app.oneshot(make_request("/api/v1/global")).await.unwrap();
+        let response = app.oneshot(make_request(routes::GLOBAL)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
-        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert!(json["server"].is_null());
-        assert!(json["sv2_clients"].is_null());
-        assert!(json["uptime_secs"].as_u64().is_some());
+        let resp: GlobalInfo = serde_json::from_str(&body).unwrap();
+        assert!(resp.server.is_none());
+        assert!(resp.sv2_clients.is_none());
+        // uptime_secs can be 0 if test runs fast enough, just verify it parses
+        let _ = resp.uptime_secs;
     }
 
     #[tokio::test]
     async fn global_endpoint_with_data() {
-        let server = Arc::new(MockServer(super::super::server::ServerInfo {
+        let server = Arc::new(MockServer(ServerInfo {
             extended_channels: vec![create_server_extended_channel_info(1, Some(100.0))],
             standard_channels: vec![],
         }));
@@ -1138,28 +1176,28 @@ mod tests {
 
         let app = build_test_app(
             Some(server as Arc<dyn ServerMonitoring + Send + Sync>),
-            Some(clients as Arc<dyn super::super::client::Sv2ClientsMonitoring + Send + Sync>),
+            Some(clients as Arc<dyn Sv2ClientsMonitoring + Send + Sync>),
             None,
         );
-        let response = app.oneshot(make_request("/api/v1/global")).await.unwrap();
+        let response = app.oneshot(make_request(routes::GLOBAL)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
-        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(json["server"]["extended_channels"], 1);
-        assert_eq!(json["sv2_clients"]["total_clients"], 1);
+        let resp: GlobalInfo = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.server.as_ref().unwrap().extended_channels, 1);
+        assert_eq!(resp.sv2_clients.as_ref().unwrap().total_clients, 1);
     }
 
     #[tokio::test]
     async fn server_endpoint_not_available() {
         let app = build_test_app(None, None, None);
-        let response = app.oneshot(make_request("/api/v1/server")).await.unwrap();
+        let response = app.oneshot(make_request(routes::SERVER)).await.unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]
     async fn server_endpoint_with_data() {
-        let server = Arc::new(MockServer(super::super::server::ServerInfo {
+        let server = Arc::new(MockServer(ServerInfo {
             extended_channels: vec![create_server_extended_channel_info(1, Some(100.0))],
             standard_channels: vec![create_server_standard_channel_info(2, Some(50.0))],
         }));
@@ -1169,18 +1207,18 @@ mod tests {
             None,
             None,
         );
-        let response = app.oneshot(make_request("/api/v1/server")).await.unwrap();
+        let response = app.oneshot(make_request(routes::SERVER)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
-        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(json["extended_channels_count"], 1);
-        assert_eq!(json["standard_channels_count"], 1);
+        let resp: ServerResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.extended_channels_count, 1);
+        assert_eq!(resp.standard_channels_count, 1);
     }
 
     #[tokio::test]
     async fn server_channels_endpoint_with_pagination() {
-        let server = Arc::new(MockServer(super::super::server::ServerInfo {
+        let server = Arc::new(MockServer(ServerInfo {
             extended_channels: vec![
                 create_server_extended_channel_info(1, Some(100.0)),
                 create_server_extended_channel_info(2, Some(200.0)),
@@ -1195,22 +1233,25 @@ mod tests {
             None,
         );
         let response = app
-            .oneshot(make_request("/api/v1/server/channels?offset=1&limit=1"))
+            .oneshot(make_request(&format!(
+                "{}?offset=1&limit=1",
+                routes::SERVER_CHANNELS
+            )))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
-        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(json["total_extended"], 3);
-        assert_eq!(json["offset"], 1);
-        assert_eq!(json["limit"], 1);
-        assert_eq!(json["extended_channels"].as_array().unwrap().len(), 1);
+        let resp: ServerChannelsResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.total_extended, 3);
+        assert_eq!(resp.offset, 1);
+        assert_eq!(resp.limit, 1);
+        assert_eq!(resp.extended_channels.len(), 1);
     }
 
     #[tokio::test]
     async fn server_channels_endpoint_keeps_rejected_shares_total_compatible() {
-        let server = Arc::new(MockServer(super::super::server::ServerInfo {
+        let server = Arc::new(MockServer(ServerInfo {
             extended_channels: vec![],
             standard_channels: vec![create_server_standard_channel_info(1, Some(50.0))],
         }));
@@ -1237,7 +1278,7 @@ mod tests {
     #[tokio::test]
     async fn clients_endpoint_not_available() {
         let app = build_test_app(None, None, None);
-        let response = app.oneshot(make_request("/api/v1/clients")).await.unwrap();
+        let response = app.oneshot(make_request(routes::CLIENTS)).await.unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 
@@ -1258,17 +1299,17 @@ mod tests {
 
         let app = build_test_app(
             None,
-            Some(clients as Arc<dyn super::super::client::Sv2ClientsMonitoring + Send + Sync>),
+            Some(clients as Arc<dyn Sv2ClientsMonitoring + Send + Sync>),
             None,
         );
-        let response = app.oneshot(make_request("/api/v1/clients")).await.unwrap();
+        let response = app.oneshot(make_request(routes::CLIENTS)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
-        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(json["total"], 2);
-        assert_eq!(json["items"].as_array().unwrap().len(), 2);
-        assert_eq!(json["items"][0]["client_id"], 1);
+        let resp: Sv2ClientsResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.total, 2);
+        assert_eq!(resp.items.len(), 2);
+        assert_eq!(resp.items[0].client_id, 1);
     }
 
     #[tokio::test]
@@ -1281,20 +1322,20 @@ mod tests {
 
         let app = build_test_app(
             None,
-            Some(clients as Arc<dyn super::super::client::Sv2ClientsMonitoring + Send + Sync>),
+            Some(clients as Arc<dyn Sv2ClientsMonitoring + Send + Sync>),
             None,
         );
         let response = app
-            .oneshot(make_request("/api/v1/clients/42"))
+            .oneshot(make_request(&routes::client_by_id(42)))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
-        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(json["client_id"], 42);
-        assert_eq!(json["extended_channels_count"], 1);
-        assert_eq!(json["standard_channels_count"], 1);
+        let resp: Sv2ClientResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.client_id, 42);
+        assert_eq!(resp.extended_channels_count, 1);
+        assert_eq!(resp.standard_channels_count, 1);
     }
 
     #[tokio::test]
@@ -1307,11 +1348,11 @@ mod tests {
 
         let app = build_test_app(
             None,
-            Some(clients as Arc<dyn super::super::client::Sv2ClientsMonitoring + Send + Sync>),
+            Some(clients as Arc<dyn Sv2ClientsMonitoring + Send + Sync>),
             None,
         );
         let response = app
-            .oneshot(make_request("/api/v1/clients/999"))
+            .oneshot(make_request(&routes::client_by_id(999)))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -1331,27 +1372,31 @@ mod tests {
 
         let app = build_test_app(
             None,
-            Some(clients as Arc<dyn super::super::client::Sv2ClientsMonitoring + Send + Sync>),
+            Some(clients as Arc<dyn Sv2ClientsMonitoring + Send + Sync>),
             None,
         );
         let response = app
-            .oneshot(make_request("/api/v1/clients/1/channels?offset=1&limit=2"))
+            .oneshot(make_request(&format!(
+                "{}?offset=1&limit=2",
+                routes::client_channels(1)
+            )))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
-        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(json["client_id"], 1);
-        assert_eq!(json["total_extended"], 3);
-        assert_eq!(json["extended_channels"].as_array().unwrap().len(), 2);
+        let resp: Sv2ClientChannelsResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.client_id, 1);
+        assert_eq!(resp.total_extended, 3);
+        assert_eq!(resp.total_standard, 1);
+        assert_eq!(resp.extended_channels.len(), 2);
     }
 
     #[tokio::test]
     async fn sv1_clients_not_available() {
         let app = build_test_app(None, None, None);
         let response = app
-            .oneshot(make_request("/api/v1/sv1/clients"))
+            .oneshot(make_request(routes::SV1_CLIENTS))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -1367,18 +1412,18 @@ mod tests {
         let app = build_test_app(
             None,
             None,
-            Some(sv1 as Arc<dyn super::super::sv1::Sv1ClientsMonitoring + Send + Sync>),
+            Some(sv1 as Arc<dyn Sv1ClientsMonitoring + Send + Sync>),
         );
         let response = app
-            .oneshot(make_request("/api/v1/sv1/clients"))
+            .oneshot(make_request(routes::SV1_CLIENTS))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
-        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(json["total"], 2);
-        assert_eq!(json["items"].as_array().unwrap().len(), 2);
+        let resp: Sv1ClientsResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.total, 2);
+        assert_eq!(resp.items.len(), 2);
     }
 
     #[tokio::test]
@@ -1388,17 +1433,17 @@ mod tests {
         let app = build_test_app(
             None,
             None,
-            Some(sv1 as Arc<dyn super::super::sv1::Sv1ClientsMonitoring + Send + Sync>),
+            Some(sv1 as Arc<dyn Sv1ClientsMonitoring + Send + Sync>),
         );
         let response = app
-            .oneshot(make_request("/api/v1/sv1/clients/7"))
+            .oneshot(make_request(&routes::sv1_client_by_id(7)))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
-        let json: serde_json::Value = serde_json::from_str(&body).unwrap();
-        assert_eq!(json["client_id"], 7);
+        let resp: Sv1ClientInfo = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.client_id, 7);
     }
 
     #[tokio::test]
@@ -1408,10 +1453,10 @@ mod tests {
         let app = build_test_app(
             None,
             None,
-            Some(sv1 as Arc<dyn super::super::sv1::Sv1ClientsMonitoring + Send + Sync>),
+            Some(sv1 as Arc<dyn Sv1ClientsMonitoring + Send + Sync>),
         );
         let response = app
-            .oneshot(make_request("/api/v1/sv1/clients/999"))
+            .oneshot(make_request(&routes::sv1_client_by_id(999)))
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
@@ -1419,7 +1464,7 @@ mod tests {
 
     #[tokio::test]
     async fn metrics_endpoint_returns_prometheus_format() {
-        let server = Arc::new(MockServer(super::super::server::ServerInfo {
+        let server = Arc::new(MockServer(ServerInfo {
             extended_channels: vec![create_server_extended_channel_info(1, Some(100.0))],
             standard_channels: vec![],
         }));
@@ -1431,10 +1476,10 @@ mod tests {
 
         let app = build_test_app(
             Some(server as Arc<dyn ServerMonitoring + Send + Sync>),
-            Some(clients as Arc<dyn super::super::client::Sv2ClientsMonitoring + Send + Sync>),
+            Some(clients as Arc<dyn Sv2ClientsMonitoring + Send + Sync>),
             None,
         );
-        let response = app.oneshot(make_request("/metrics")).await.unwrap();
+        let response = app.oneshot(make_request(routes::METRICS)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
@@ -1446,7 +1491,7 @@ mod tests {
     #[tokio::test]
     async fn metrics_endpoint_with_no_sources() {
         let app = build_test_app(None, None, None);
-        let response = app.oneshot(make_request("/metrics")).await.unwrap();
+        let response = app.oneshot(make_request(routes::METRICS)).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
 
         let body = get_body(response).await;
@@ -1459,7 +1504,7 @@ mod tests {
 
     // Mutable mock that allows changing data between requests
     struct MutableMockClients(Mutex<Vec<Sv2ClientInfo>>);
-    impl super::super::client::Sv2ClientsMonitoring for MutableMockClients {
+    impl Sv2ClientsMonitoring for MutableMockClients {
         fn get_sv2_clients(&self) -> Vec<Sv2ClientInfo> {
             self.0.lock().unwrap().clone()
         }
@@ -1488,8 +1533,7 @@ mod tests {
             SnapshotCache::new(
                 Duration::from_secs(60),
                 None,
-                Some(mock_clients.clone()
-                    as Arc<dyn super::super::client::Sv2ClientsMonitoring + Send + Sync>),
+                Some(mock_clients.clone() as Arc<dyn Sv2ClientsMonitoring + Send + Sync>),
             )
             .with_metrics(metrics.clone()),
         );
@@ -1541,5 +1585,194 @@ mod tests {
             !body.contains("sv2_client_shares_accepted_total{channel_id=\"2\",client_id=\"1\""),
             "Channel 2 should be removed as stale"
         );
+    }
+
+    // ── Edge-case unit tests (pagination, missing data, invalid params) ──
+
+    #[test]
+    fn paginate_with_limit_zero() {
+        // effective_limit(Some(0)) = 0.min(MAX_LIMIT) = 0, so take(0) returns nothing
+        let items: Vec<i32> = (0..50).collect();
+        let params = Pagination {
+            offset: 0,
+            limit: Some(0),
+        };
+        let (total, result) = paginate(&items, &params);
+        assert_eq!(total, 50);
+        assert!(result.is_empty(), "limit=0 should return no items");
+    }
+
+    #[tokio::test]
+    async fn server_channels_not_available() {
+        let app = build_test_app(None, None, None);
+        let response = app
+            .oneshot(make_request(routes::SERVER_CHANNELS))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let body = get_body(response).await;
+        let resp: ErrorResponse = serde_json::from_str(&body).unwrap();
+        assert!(!resp.error.is_empty());
+    }
+
+    #[tokio::test]
+    async fn client_by_id_no_monitoring() {
+        // When client monitoring is not available at all, any client_id returns 404
+        let app = build_test_app(None, None, None);
+        let response = app
+            .oneshot(make_request(&routes::client_by_id(1)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let body = get_body(response).await;
+        let resp: ErrorResponse = serde_json::from_str(&body).unwrap();
+        assert!(!resp.error.is_empty());
+    }
+
+    #[tokio::test]
+    async fn client_channels_client_not_found() {
+        // Client monitoring is available but the specific client_id does not exist
+        let clients = Arc::new(MockClients(vec![Sv2ClientInfo {
+            client_id: 1,
+            extended_channels: vec![],
+            standard_channels: vec![],
+        }]));
+
+        let app = build_test_app(
+            None,
+            Some(clients as Arc<dyn Sv2ClientsMonitoring + Send + Sync>),
+            None,
+        );
+        let response = app
+            .oneshot(make_request(&routes::client_channels(999)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let body = get_body(response).await;
+        let resp: ErrorResponse = serde_json::from_str(&body).unwrap();
+        assert!(resp.error.contains("999"));
+    }
+
+    #[tokio::test]
+    async fn client_channels_no_monitoring() {
+        // When client monitoring is not available at all
+        let app = build_test_app(None, None, None);
+        let response = app
+            .oneshot(make_request(&routes::client_channels(1)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn sv1_client_by_id_no_monitoring() {
+        // When SV1 monitoring is not available at all
+        let app = build_test_app(None, None, None);
+        let response = app
+            .oneshot(make_request(&routes::sv1_client_by_id(1)))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let body = get_body(response).await;
+        let resp: ErrorResponse = serde_json::from_str(&body).unwrap();
+        assert!(!resp.error.is_empty());
+    }
+
+    #[tokio::test]
+    async fn clients_pagination_offset_and_limit() {
+        let clients = Arc::new(MockClients(vec![
+            Sv2ClientInfo {
+                client_id: 1,
+                extended_channels: vec![create_extended_channel_info(1, 100.0)],
+                standard_channels: vec![],
+            },
+            Sv2ClientInfo {
+                client_id: 2,
+                extended_channels: vec![],
+                standard_channels: vec![create_standard_channel_info(1, 50.0)],
+            },
+            Sv2ClientInfo {
+                client_id: 3,
+                extended_channels: vec![create_extended_channel_info(2, 200.0)],
+                standard_channels: vec![],
+            },
+        ]));
+
+        let app = build_test_app(
+            None,
+            Some(clients as Arc<dyn Sv2ClientsMonitoring + Send + Sync>),
+            None,
+        );
+        let response = app
+            .oneshot(make_request(&format!(
+                "{}?offset=1&limit=1",
+                routes::CLIENTS
+            )))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = get_body(response).await;
+        let resp: Sv2ClientsResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.total, 3);
+        assert_eq!(resp.offset, 1);
+        assert_eq!(resp.limit, 1);
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].client_id, 2);
+    }
+
+    #[tokio::test]
+    async fn sv1_clients_pagination() {
+        let sv1 = Arc::new(MockSv1Clients(vec![
+            create_sv1_client_info(1, Some(100.0)),
+            create_sv1_client_info(2, Some(200.0)),
+            create_sv1_client_info(3, Some(300.0)),
+        ]));
+
+        let app = build_test_app(
+            None,
+            None,
+            Some(sv1 as Arc<dyn Sv1ClientsMonitoring + Send + Sync>),
+        );
+        let response = app
+            .oneshot(make_request(&format!(
+                "{}?offset=2&limit=10",
+                routes::SV1_CLIENTS
+            )))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = get_body(response).await;
+        let resp: Sv1ClientsResponse = serde_json::from_str(&body).unwrap();
+        assert_eq!(resp.total, 3);
+        assert_eq!(resp.offset, 2);
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].client_id, 3);
+    }
+
+    #[tokio::test]
+    async fn global_endpoint_with_sv1_data() {
+        let sv1 = Arc::new(MockSv1Clients(vec![create_sv1_client_info(1, Some(100.0))]));
+
+        let app = build_test_app(
+            None,
+            None,
+            Some(sv1 as Arc<dyn Sv1ClientsMonitoring + Send + Sync>),
+        );
+        let response = app.oneshot(make_request(routes::GLOBAL)).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = get_body(response).await;
+        let resp: GlobalInfo = serde_json::from_str(&body).unwrap();
+        // Server and SV2 clients should be None
+        assert!(resp.server.is_none());
+        assert!(resp.sv2_clients.is_none());
+        // SV1 clients should be present
+        assert_eq!(resp.sv1_clients.as_ref().unwrap().total_clients, 1);
     }
 }

--- a/stratum-apps/src/monitoring/mod.rs
+++ b/stratum-apps/src/monitoring/mod.rs
@@ -20,7 +20,10 @@ pub use client::{
     ExtendedChannelInfo, StandardChannelInfo, Sv2ClientInfo, Sv2ClientMetadata,
     Sv2ClientsMonitoring, Sv2ClientsSummary,
 };
-pub use http_server::MonitoringServer;
+pub use http_server::{
+    ErrorResponse, HealthResponse, MonitoringServer, ServerChannelsResponse, ServerResponse,
+    Sv1ClientsResponse, Sv2ClientChannelsResponse, Sv2ClientResponse, Sv2ClientsResponse,
+};
 pub use server::{
     ServerExtendedChannelInfo, ServerInfo, ServerMonitoring, ServerStandardChannelInfo,
     ServerSummary,


### PR DESCRIPTION
Closes #329

Exercise every JSON REST API endpoint against live SV2 topologies and strengthen unit-test coverage for edge cases.

Integration tests (monitoring_integration.rs):
- 15 new tests covering /, /api/v1/global, /api/v1/server, /api/v1/server/channels, /api/v1/clients, /api/v1/clients/{id}, /api/v1/clients/{id}/channels, /api/v1/sv1/clients, and /api/v1/sv1/clients/{id} for both Pool and tProxy topologies
- Topology setup helpers (PoolWithSv2Miner, TproxyWithSv1Miner) eliminate duplicated boilerplate across tests
- 404 endpoints assert both HTTP status code and JSON error body via new assert_api_not_found helper

Assertion helpers (prometheus_metrics_assertions.rs):
- fetch_api_json: parse JSON API response
- fetch_api_with_status: return (status_code, json) without panicking on non-2xx, enabling 404 testing
- poll_until_api_field_gte: poll JSON endpoint until a field reaches a threshold (analogous to poll_until_metric_gte for Prometheus)
- assert_api_root, assert_api_global: reusable structure checks
- assert_api_not_found: verify HTTP 404 + error field
- POLL_TIMEOUT constant to reduce repetition

HTTP helper (utils.rs):
- make_get_request_with_status: returns (status, body) without panicking on 4xx responses, unlike make_get_request

Unit tests (http_server.rs):
- 11 new tests for pagination boundaries (limit=0, offset beyond total, limit exceeding MAX_LIMIT), missing data sources returning 404, invalid/non-existent client IDs, SV1 data in global endpoint, and Prometheus metrics with no sources

Dependencies:
- Add serde_json to integration-tests for JSON parsing