### PR TITLE
add config option to start JDC in solo mining mode

### DIFF
--- a/integration-tests/lib/mod.rs
+++ b/integration-tests/lib/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     sv1_minerd::MinerdProcess, template_provider::*,
 };
 use interceptor::InterceptAction;
-use jd_client_sv2::JobDeclaratorClient;
+use jd_client_sv2::{config::ConfigJDCMode, JobDeclaratorClient};
 use once_cell::sync::OnceCell;
 use pool_sv2::PoolSv2;
 use std::{
@@ -197,6 +197,7 @@ pub fn start_jdc(
     supported_extensions: Vec<u16>,
     required_extensions: Vec<u16>,
     enable_monitoring: bool,
+    jdc_mode: Option<ConfigJDCMode>,
 ) -> (JobDeclaratorClient, SocketAddr, Option<SocketAddr>) {
     use jd_client_sv2::config::{JobDeclaratorClientConfig, PoolConfig, ProtocolConfig, Upstream};
     let jdc_address = get_available_address();
@@ -255,7 +256,7 @@ pub fn start_jdc(
         template_provider_config,
         upstreams,
         jdc_signature,
-        None,
+        jdc_mode,
         supported_extensions,
         required_extensions,
         monitoring_address,

--- a/integration-tests/tests/bitcoin_core_ipc_integration.rs
+++ b/integration-tests/tests/bitcoin_core_ipc_integration.rs
@@ -3,6 +3,7 @@ use integration_tests_sv2::{
     template_provider::DifficultyLevel,
     *,
 };
+use jd_client_sv2::config::ConfigJDCMode;
 use stratum_apps::stratum_core::{common_messages_sv2::*, job_declaration_sv2::*};
 
 // Pool propagates block via IPC
@@ -71,6 +72,7 @@ async fn jdc_propagates_block_with_bitcoin_core_ipc() {
         vec![],
         vec![],
         false,
+        None,
     );
     let (translator, tproxy_addr, _) =
         start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;
@@ -116,6 +118,49 @@ async fn jdc_propagates_block_with_bitcoin_core_ipc() {
         if start_time.elapsed() > timeout {
             panic!(
                 "JDC with BitcoinCoreIpc should have propagated a new block within {} seconds",
+                timeout.as_secs()
+            );
+        }
+    }
+}
+
+// JDC solo mining mode with BitcoinCoreIpc (mode = SOLOMINING, no upstreams)
+#[tokio::test]
+async fn jdc_solo_mining_with_bitcoin_core_ipc() {
+    start_tracing();
+    let bitcoin_core = start_bitcoin_core(DifficultyLevel::Low);
+    let current_block_hash = bitcoin_core.get_best_block_hash().unwrap();
+
+    let (jdc, jdc_addr, _) = start_jdc(
+        &[],
+        ipc_config(
+            bitcoin_core.data_dir().clone(),
+            bitcoin_core.is_signet(),
+            None,
+        ),
+        vec![],
+        vec![],
+        false,
+        Some(ConfigJDCMode::SoloMining),
+    );
+
+    let (translator, tproxy_addr, _) =
+        start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;
+    let (_minerd, _) = start_minerd(tproxy_addr, None, None, false).await;
+
+    let timeout = tokio::time::Duration::from_secs(60);
+    let poll_interval = tokio::time::Duration::from_secs(2);
+    let start_time = tokio::time::Instant::now();
+    loop {
+        tokio::time::sleep(poll_interval).await;
+        let new_block_hash = bitcoin_core.get_best_block_hash().unwrap();
+        if new_block_hash != current_block_hash {
+            shutdown_all!(jdc, translator);
+            return;
+        }
+        if start_time.elapsed() > timeout {
+            panic!(
+                "JDC solo mining with BitcoinCoreIpc should have propagated a new block within {} seconds",
                 timeout.as_secs()
             );
         }

--- a/integration-tests/tests/jd_integration.rs
+++ b/integration-tests/tests/jd_integration.rs
@@ -31,6 +31,7 @@ async fn jds_should_not_panic_if_jdc_shutsdown() {
         vec![],
         vec![],
         false,
+        None,
     );
     sniffer_a
         .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
@@ -50,6 +51,7 @@ async fn jds_should_not_panic_if_jdc_shutsdown() {
         vec![],
         vec![],
         false,
+        None,
     );
     sniffer
         .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
@@ -74,6 +76,7 @@ async fn jdc_tp_success_setup() {
         vec![],
         vec![],
         false,
+        None,
     );
     // This is needed because jd-client waits for a downstream connection before it starts
     // exchanging messages with the Template Provider.
@@ -314,6 +317,7 @@ async fn pool_rejects_reused_set_custom_mining_job_token() {
         vec![],
         vec![],
         false,
+        None,
     );
     let (translator, tproxy_addr, _) =
         start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;
@@ -447,6 +451,7 @@ async fn jds_receive_solution_while_processing_declared_job_test() {
         vec![],
         vec![],
         false,
+        None,
     );
     let (translator, tproxy_addr, _) =
         start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;
@@ -540,6 +545,7 @@ async fn jds_wont_exit_upon_receiving_unexpected_txids_in_provide_missing_transa
         vec![],
         vec![],
         false,
+        None,
     );
     let (translator, tproxy_addr, _) =
         start_sv2_translator(&[jdc_addr_1], false, vec![], vec![], None, false).await;
@@ -606,6 +612,7 @@ async fn jdc_group_extended_channels() {
         vec![],
         vec![],
         false,
+        None,
     );
 
     let (sniffer, sniffer_addr) = start_sniffer("sniffer", jdc_addr, false, vec![], None);
@@ -790,6 +797,7 @@ async fn jdc_group_standard_channels() {
         vec![],
         vec![],
         false,
+        None,
     );
 
     let (sniffer, sniffer_addr) = start_sniffer("sniffer", jdc_addr, false, vec![], None);
@@ -983,6 +991,7 @@ async fn jdc_require_standard_jobs_set_does_not_group_standard_channels() {
         vec![],
         vec![],
         false,
+        None,
     );
 
     let (sniffer, sniffer_addr) = start_sniffer("sniffer", jdc_addr, false, vec![], None);

--- a/integration-tests/tests/jd_provide_missing_transaction.rs
+++ b/integration-tests/tests/jd_provide_missing_transaction.rs
@@ -15,6 +15,7 @@ async fn jds_ask_for_missing_transactions() {
         vec![],
         vec![],
         false,
+        None,
     );
     let (translator, tproxy_addr, _) =
         start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;

--- a/integration-tests/tests/jd_tproxy_integration.rs
+++ b/integration-tests/tests/jd_tproxy_integration.rs
@@ -19,6 +19,7 @@ async fn jd_non_aggregated_tproxy_integration() {
         vec![],
         vec![],
         false,
+        None,
     );
     let (tproxy_jdc_sniffer, tproxy_jdc_sniffer_addr) =
         start_sniffer("1", jdc_addr, false, vec![], None);
@@ -107,6 +108,7 @@ async fn jd_aggregated_tproxy_integration() {
         vec![],
         vec![],
         false,
+        None,
     );
     let (tproxy_jdc_sniffer, tproxy_jdc_sniffer_addr) =
         start_sniffer("1", jdc_addr, false, vec![], None);

--- a/integration-tests/tests/jdc_block_propagation.rs
+++ b/integration-tests/tests/jdc_block_propagation.rs
@@ -29,6 +29,7 @@ async fn propagated_from_jdc_to_tp() {
         vec![],
         vec![],
         false,
+        None,
     );
     let (translator, tproxy_addr, _) =
         start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;

--- a/integration-tests/tests/jdc_cached_shares.rs
+++ b/integration-tests/tests/jdc_cached_shares.rs
@@ -45,6 +45,7 @@ async fn jdc_cached_shares_relayed_on_set_custom_job_success() {
         vec![],
         vec![],
         false,
+        None,
     );
     let (translator, tproxy_addr, _) =
         start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;

--- a/integration-tests/tests/jdc_receives_submit_shares_success.rs
+++ b/integration-tests/tests/jdc_receives_submit_shares_success.rs
@@ -14,6 +14,7 @@ async fn jdc_submit_shares_success() {
         vec![],
         vec![],
         false,
+        None,
     );
     let (translator, tproxy_addr, _) =
         start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;

--- a/integration-tests/tests/jds_block_propagation.rs
+++ b/integration-tests/tests/jds_block_propagation.rs
@@ -31,6 +31,7 @@ async fn propagated_from_jds_to_tp() {
         vec![],
         vec![],
         false,
+        None,
     );
     let (translator, tproxy_addr, _) =
         start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;

--- a/integration-tests/tests/monitoring_integration.rs
+++ b/integration-tests/tests/monitoring_integration.rs
@@ -139,6 +139,7 @@ async fn jd_aggregated_topology_monitoring() {
         vec![],
         vec![],
         true,
+        None,
     );
     let (_tproxy_jdc_sniffer, tproxy_jdc_sniffer_addr) =
         start_sniffer("1", jdc_addr, false, vec![], None);
@@ -213,6 +214,7 @@ async fn block_found_detected_in_pool_metrics() {
         vec![],
         vec![],
         false,
+        None,
     );
     let (_tproxy, tproxy_addr, _) =
         start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;

--- a/integration-tests/tests/pool_integration.rs
+++ b/integration-tests/tests/pool_integration.rs
@@ -260,6 +260,7 @@ async fn pool_does_not_send_jobs_to_jdc() {
         vec![],
         vec![],
         false,
+        None,
     );
     // Block NewExtendedMiningJob and SetNewPrevHash messages between JDC and translator proxy
     let (_tproxy_jdc_sniffer, tproxy_jdc_sniffer_addr) = start_sniffer(

--- a/miner-apps/jd-client/config-examples/mainnet/jdc-config-solo-mining-example.toml
+++ b/miner-apps/jd-client/config-examples/mainnet/jdc-config-solo-mining-example.toml
@@ -1,0 +1,44 @@
+# JDC Solo Mining config
+#
+# This config starts JDC in solo mining mode.
+# No Pool or JDS connections are needed.
+# Miners connect to JDC, which gets templates directly from
+# the Template Provider (Bitcoin Core) and submits found blocks.
+listening_address = "0.0.0.0:34265"
+
+# Version support
+max_supported_version = 2
+min_supported_version = 2
+
+# Auth keys for open encrypted connection downstream
+authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
+cert_validity_sec = 3600
+
+# User identity/username
+user_identity = "solo_miner"
+
+# How many shares we expect to receive in a minute (determines difficulty targets)
+shares_per_minute = 6.0
+
+# How many shares do we want to acknowledge in a batch
+share_batch_size = 10
+
+# JDC mode: FULLTEMPLATE, COINBASEONLY, or SOLOMINING
+mode = "SOLOMINING"
+
+# string to be added into the Coinbase scriptSig
+jdc_signature = "Sv2SoloMiner"
+
+# Coinbase output used to build the coinbase tx for solo mining
+# This is where your block reward goes
+coinbase_reward_script = "addr(bc1q9f9vj7spn8h7qda6pn8d4g4j99f0mn9lhwz55j)"
+
+# No upstreams needed in solo mining mode.
+upstreams = []
+
+# Templates come directly from the Template Provider below.
+
+# Local Sv2 Template Provider config
+[template_provider_type.Sv2Tp]
+address = "127.0.0.1:8442"

--- a/miner-apps/jd-client/src/lib/config.rs
+++ b/miner-apps/jd-client/src/lib/config.rs
@@ -45,7 +45,7 @@ pub struct JobDeclaratorClientConfig {
     shares_per_minute: SharesPerMinute,
     /// share batch size
     share_batch_size: SharesBatchSize,
-    /// JDC mode: FullTemplate or CoinbaseOnly
+    /// JDC mode: FullTemplate, CoinbaseOnly, or SoloMining
     #[serde(deserialize_with = "deserialize_jdc_mode", default)]
     pub mode: ConfigJDCMode,
     /// Protocol extensions that the JDC supports (will accept if requested by downstream clients).
@@ -74,7 +74,7 @@ impl JobDeclaratorClientConfig {
         template_provider_type: TemplateProviderType,
         upstreams: Vec<Upstream>,
         jdc_signature: String,
-        jdc_mode: Option<String>,
+        jdc_mode: Option<ConfigJDCMode>,
         supported_extensions: Vec<u16>,
         required_extensions: Vec<u16>,
         monitoring_address: Option<SocketAddr>,
@@ -95,9 +95,7 @@ impl JobDeclaratorClientConfig {
             user_identity,
             shares_per_minute,
             share_batch_size: shares_batch_size,
-            mode: jdc_mode
-                .map(|s| s.parse::<ConfigJDCMode>().unwrap_or_default())
-                .unwrap_or_default(),
+            mode: jdc_mode.unwrap_or_default(),
             supported_extensions,
             required_extensions,
             monitoring_address,
@@ -200,12 +198,13 @@ impl JobDeclaratorClientConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, Default)]
+#[derive(Debug, Deserialize, Clone, Default, PartialEq)]
 #[serde(rename_all = "UPPERCASE")]
 pub enum ConfigJDCMode {
     #[default]
     FullTemplate,
     CoinbaseOnly,
+    SoloMining,
 }
 
 impl std::str::FromStr for ConfigJDCMode {
@@ -214,6 +213,7 @@ impl std::str::FromStr for ConfigJDCMode {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_uppercase().as_str() {
             "COINBASEONLY" => Ok(ConfigJDCMode::CoinbaseOnly),
+            "SOLOMINING" => Ok(ConfigJDCMode::SoloMining),
             _ => Ok(ConfigJDCMode::FullTemplate),
         }
     }

--- a/miner-apps/jd-client/src/lib/job_declarator/message_handler.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/message_handler.rs
@@ -37,6 +37,7 @@ impl HandleCommonMessagesFromServerAsync for JobDeclarator {
         let jd_mode = match self.mode {
             ConfigJDCMode::CoinbaseOnly => JdMode::CoinbaseOnly,
             ConfigJDCMode::FullTemplate => JdMode::FullTemplate,
+            ConfigJDCMode::SoloMining => JdMode::SoloMining,
         };
 
         set_jd_mode(jd_mode);

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -274,53 +274,69 @@ impl JobDeclaratorClient {
             )
             .await;
 
-        info!("Attempting to initialize upstream...");
-
-        match self
-            .initialize_jd(
-                &mut upstream_addresses,
-                channel_manager_to_upstream_receiver.clone(),
-                upstream_to_channel_manager_sender.clone(),
-                channel_manager_to_jd_receiver.clone(),
-                jd_to_channel_manager_sender.clone(),
-                self.cancellation_token.clone(),
-                fallback_coordinator.clone(),
-                self.config.mode.clone(),
-                task_manager.clone(),
-            )
-            .await
-        {
-            Ok((upstream, job_declarator)) => {
-                upstream
-                    .start(
-                        self.config.min_supported_version(),
-                        self.config.max_supported_version(),
-                        self.cancellation_token.clone(),
-                        fallback_coordinator.clone(),
-                        status_sender.clone(),
-                        task_manager.clone(),
-                    )
-                    .await;
-
-                job_declarator
-                    .start(
-                        self.cancellation_token.clone(),
-                        fallback_coordinator.clone(),
-                        status_sender.clone(),
-                        task_manager.clone(),
-                    )
-                    .await;
-
-                channel_manager_clone
-                    .upstream_state
-                    .set(UpstreamState::NoChannel);
-                _ = channel_manager_clone.allocate_tokens(2).await;
+        if self.config.mode == config::ConfigJDCMode::SoloMining {
+            if !upstream_addresses.is_empty() {
+                warn!(
+                    "Solo mining mode configured but upstreams are present - they will be ignored"
+                );
             }
-            Err(e) => {
-                tracing::error!("Failed to initialize upstream: {:?}", e);
-                set_jd_mode(jd_mode::JdMode::SoloMining);
-            }
-        };
+            info!("Starting in solo mining mode");
+            set_jd_mode(jd_mode::JdMode::SoloMining);
+        } else if upstream_addresses.is_empty() {
+            error!(
+                "No upstreams configured for {:?} mode - at least one upstream is required",
+                self.config.mode
+            );
+            self.cancellation_token.cancel();
+        } else {
+            info!("Attempting to initialize upstream...");
+
+            match self
+                .initialize_jd(
+                    &mut upstream_addresses,
+                    channel_manager_to_upstream_receiver.clone(),
+                    upstream_to_channel_manager_sender.clone(),
+                    channel_manager_to_jd_receiver.clone(),
+                    jd_to_channel_manager_sender.clone(),
+                    self.cancellation_token.clone(),
+                    fallback_coordinator.clone(),
+                    self.config.mode.clone(),
+                    task_manager.clone(),
+                )
+                .await
+            {
+                Ok((upstream, job_declarator)) => {
+                    upstream
+                        .start(
+                            self.config.min_supported_version(),
+                            self.config.max_supported_version(),
+                            self.cancellation_token.clone(),
+                            fallback_coordinator.clone(),
+                            status_sender.clone(),
+                            task_manager.clone(),
+                        )
+                        .await;
+
+                    job_declarator
+                        .start(
+                            self.cancellation_token.clone(),
+                            fallback_coordinator.clone(),
+                            status_sender.clone(),
+                            task_manager.clone(),
+                        )
+                        .await;
+
+                    channel_manager_clone
+                        .upstream_state
+                        .set(UpstreamState::NoChannel);
+                    _ = channel_manager_clone.allocate_tokens(2).await;
+                }
+                Err(e) => {
+                    tracing::error!("Failed to initialize upstream: {:?}", e);
+                    set_jd_mode(jd_mode::JdMode::SoloMining);
+                }
+            };
+        }
 
         _ = channel_manager_clone
             .clone()


### PR DESCRIPTION
When `upstreams` is omitted from the TOML config, JDC starts directly in solo mining mode. No upstream connection attempts, no retry delay. Templates come from the Template Provider and blocks are submitted via SubmitSolution.

Unblocks stratum-mining/sv2-ui#36

Closes #371