### PR TITLE
JDC exits immediately if `node.sock` is not available (no retry)

### DIFF
--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -643,7 +643,13 @@ impl JobDeclaratorClient {
                 upstream_entry.jds_port,
             );
 
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            tokio::select! {
+                _ = cancellation_token.cancelled() => {
+                    info!("Shutdown requested while waiting to initialize upstream, aborting retries");
+                    return Err(JDCErrorKind::CouldNotInitiateSystem);
+                }
+                _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+            }
 
             if upstream_entry.tried_or_flagged {
                 info!(
@@ -653,6 +659,13 @@ impl JobDeclaratorClient {
             }
 
             for attempt in 1..=MAX_RETRIES {
+                if cancellation_token.is_cancelled() {
+                    info!(
+                        "Shutdown requested before upstream connection attempt, aborting retries"
+                    );
+                    return Err(JDCErrorKind::CouldNotInitiateSystem);
+                }
+
                 info!("Connection attempt {}/{}...", attempt, MAX_RETRIES);
 
                 match try_initialize_single(
@@ -675,7 +688,15 @@ impl JobDeclaratorClient {
                     }
                     Err(e) => {
                         tracing::error!("Upstream and JDS connection terminated");
-                        tokio::time::sleep(Duration::from_secs(1)).await;
+
+                        tokio::select! {
+                            _ = cancellation_token.cancelled() => {
+                                info!("Shutdown requested after upstream initialization failure, aborting retries");
+                                return Err(JDCErrorKind::CouldNotInitiateSystem);
+                            }
+                            _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                        }
+
                         warn!(
                             "Attempt {}/{} failed for pool={}:{}, jds={}:{}: {:?}",
                             attempt,


### PR DESCRIPTION
follow-up to #420 

instead of this:
```
2026-04-09T00:33:07.610679Z  INFO jd_client_sv2: Job declarator client starting... setting up subsystems, User Identity: your_username_here
2026-04-09T00:33:07.610853Z  INFO jd_client_sv2: Initializing monitoring server on http://0.0.0.0:9091
2026-04-09T00:33:07.611430Z  INFO stratum_apps::monitoring::http_server: Starting monitoring server on http://0.0.0.0:9091
2026-04-09T00:33:07.611461Z  INFO stratum_apps::monitoring::http_server: Cache refresh interval: 15s
2026-04-09T00:33:07.611491Z  INFO jd_client_sv2: Using Bitcoin Core IPC socket at: /Users/plebhash/Library/Application Support/Bitcoin/node.sock
2026-04-09T00:33:07.612139Z  INFO jd_client_sv2: Attempting to initialize upstream...
2026-04-09T00:33:07.612157Z  INFO jd_client_sv2: Trying upstream 1 of 1: pool=75.119.150.111:3333, jds=75.119.150.111:3334
2026-04-09T00:33:07.613154Z  INFO bitcoin_core_sv2::template_distribution_protocol: Creating new BitcoinCoreSv2TDP via IPC over UNIX socket: /Users/plebhash/Library/Application Support/Bitcoin/node.sock
2026-04-09T00:33:07.613323Z ERROR jd_client_sv2::template_receiver::bitcoin_core: Failed to create BitcoinCoreToSv2: CannotConnectToUnixSocket("/Users/plebhash/Library/Application Support/Bitcoin/node.sock", "Connection refused (os error 61)")
2026-04-09T00:33:07.613599Z  INFO jd_client_sv2::channel_manager: Channel Manager: received shutdown signal
2026-04-09T00:33:07.614208Z  INFO stratum_apps::monitoring::http_server: Swagger UI available at http://0.0.0.0:9091/swagger-ui
2026-04-09T00:33:07.614221Z  INFO stratum_apps::monitoring::http_server: Prometheus metrics available at http://0.0.0.0:9091/metrics
2026-04-09T00:33:07.614311Z  INFO jd_client_sv2: Monitoring server: received shutdown signal.
2026-04-09T00:33:07.614339Z  INFO stratum_apps::monitoring::http_server: Monitoring server received shutdown signal, stopping...
2026-04-09T00:33:07.614492Z  INFO stratum_apps::monitoring::http_server: Monitoring server stopped
2026-04-09T00:33:07.614523Z  INFO jd_client_sv2: Monitoring server task exited and signaled fallback coordinator
2026-04-09T00:33:08.614578Z  INFO jd_client_sv2: Connection attempt 1/3...
2026-04-09T00:33:08.614650Z  INFO jd_client_sv2: Upstream connection in-progress at initialize single
2026-04-09T00:33:08.833440Z  INFO jd_client_sv2::upstream: Connected to upstream at 75.119.150.111:3333
2026-04-09T00:33:08.833869Z  INFO jd_client_sv2::upstream: Shutdown received during handshake, dropping connection
2026-04-09T00:33:08.833906Z ERROR jd_client_sv2: Upstream and JDS connection terminated
2026-04-09T00:33:09.835898Z  WARN jd_client_sv2: Attempt 1/3 failed for pool=75.119.150.111:3333, jds=75.119.150.111:3334: CouldNotInitiateSystem
2026-04-09T00:33:09.835981Z  INFO jd_client_sv2: Connection attempt 2/3...
2026-04-09T00:33:09.836023Z  INFO jd_client_sv2: Upstream connection in-progress at initialize single
2026-04-09T00:33:10.053253Z  INFO jd_client_sv2::upstream: Connected to upstream at 75.119.150.111:3333
2026-04-09T00:33:10.055978Z  INFO jd_client_sv2::upstream: Shutdown received during handshake, dropping connection
2026-04-09T00:33:10.056043Z ERROR jd_client_sv2: Upstream and JDS connection terminated
2026-04-09T00:33:11.058307Z  WARN jd_client_sv2: Attempt 2/3 failed for pool=75.119.150.111:3333, jds=75.119.150.111:3334: CouldNotInitiateSystem
2026-04-09T00:33:11.058383Z  INFO jd_client_sv2: Connection attempt 3/3...
2026-04-09T00:33:11.058407Z  INFO jd_client_sv2: Upstream connection in-progress at initialize single
2026-04-09T00:33:11.277973Z  INFO jd_client_sv2::upstream: Connected to upstream at 75.119.150.111:3333
2026-04-09T00:33:11.279707Z  INFO jd_client_sv2::upstream: Shutdown received during handshake, dropping connection
2026-04-09T00:33:11.279761Z ERROR jd_client_sv2: Upstream and JDS connection terminated
2026-04-09T00:33:12.281316Z  WARN jd_client_sv2: Attempt 3/3 failed for pool=75.119.150.111:3333, jds=75.119.150.111:3334: CouldNotInitiateSystem
2026-04-09T00:33:12.281339Z  WARN jd_client_sv2: Max retries reached for pool=75.119.150.111:3333, jds=75.119.150.111:3334, moving to next upstream
2026-04-09T00:33:12.281342Z ERROR jd_client_sv2: All upstreams failed after 3 retries each
2026-04-09T00:33:12.281347Z ERROR jd_client_sv2: Failed to initialize upstream: CouldNotInitiateSystem
2026-04-09T00:33:12.281385Z  WARN jd_client_sv2::channel_manager: Waiting for initial template and prevhash from Template Provider...
2026-04-09T00:33:12.281393Z  INFO jd_client_sv2::channel_manager: Channel Manager: received shutdown while waiting for templates
2026-04-09T00:33:12.281398Z  INFO jd_client_sv2: Spawning status listener task...
2026-04-09T00:33:12.281414Z  INFO jd_client_sv2: Waiting for BitcoinCoreSv2TDP dedicated thread to shutdown...
2026-04-09T00:33:12.281472Z  INFO jd_client_sv2: BitcoinCoreSv2TDP dedicated thread shutdown complete.
2026-04-09T00:33:12.281475Z  WARN jd_client_sv2: Graceful shutdown: waiting 5 seconds for tasks to finish
2026-04-09T00:33:12.281490Z  INFO jd_client_sv2: All tasks joined cleanly
2026-04-09T00:33:12.281492Z  INFO jd_client_sv2: JD Client shutdown complete.
2026-04-09T00:33:12.281541Z  INFO jd_client_sv2: JobDeclaratorClient dropped
```

we get this:
```
2026-04-09T00:41:01.708246Z  INFO jd_client_sv2: Job declarator client starting... setting up subsystems, User Identity: your_username_here
2026-04-09T00:41:01.708440Z  INFO jd_client_sv2: Initializing monitoring server on http://0.0.0.0:9091
2026-04-09T00:41:01.708841Z  INFO stratum_apps::monitoring::http_server: Starting monitoring server on http://0.0.0.0:9091
2026-04-09T00:41:01.708854Z  INFO stratum_apps::monitoring::http_server: Cache refresh interval: 15s
2026-04-09T00:41:01.708902Z  INFO jd_client_sv2: Using Bitcoin Core IPC socket at: /Users/plebhash/Library/Application Support/Bitcoin/node.sock
2026-04-09T00:41:01.709211Z  INFO jd_client_sv2: Attempting to initialize upstream...
2026-04-09T00:41:01.709216Z  INFO jd_client_sv2: Trying upstream 1 of 1: pool=75.119.150.111:3333, jds=75.119.150.111:3334
2026-04-09T00:41:01.709747Z  INFO bitcoin_core_sv2::template_distribution_protocol: Creating new BitcoinCoreSv2TDP via IPC over UNIX socket: /Users/plebhash/Library/Application Support/Bitcoin/node.sock
2026-04-09T00:41:01.709830Z ERROR jd_client_sv2::template_receiver::bitcoin_core: Failed to create BitcoinCoreToSv2: CannotConnectToUnixSocket("/Users/plebhash/Library/Application Support/Bitcoin/node.sock", "Connection refused (os error 61)")
2026-04-09T00:41:01.709940Z  INFO jd_client_sv2::channel_manager: Channel Manager: received shutdown signal
2026-04-09T00:41:01.709944Z  INFO jd_client_sv2: Shutdown requested while waiting to initialize upstream, aborting retries
2026-04-09T00:41:01.709958Z ERROR jd_client_sv2: Failed to initialize upstream: CouldNotInitiateSystem
2026-04-09T00:41:01.709989Z  WARN jd_client_sv2::channel_manager: Waiting for initial template and prevhash from Template Provider...
2026-04-09T00:41:01.709996Z  INFO jd_client_sv2::channel_manager: Channel Manager: received shutdown while waiting for templates
2026-04-09T00:41:01.709999Z  INFO jd_client_sv2: Spawning status listener task...
2026-04-09T00:41:01.710012Z  INFO jd_client_sv2: Waiting for BitcoinCoreSv2TDP dedicated thread to shutdown...
2026-04-09T00:41:01.710225Z  INFO jd_client_sv2: BitcoinCoreSv2TDP dedicated thread shutdown complete.
2026-04-09T00:41:01.710233Z  WARN jd_client_sv2: Graceful shutdown: waiting 5 seconds for tasks to finish
2026-04-09T00:41:01.710290Z  INFO stratum_apps::monitoring::http_server: Swagger UI available at http://0.0.0.0:9091/swagger-ui
2026-04-09T00:41:01.710296Z  INFO stratum_apps::monitoring::http_server: Prometheus metrics available at http://0.0.0.0:9091/metrics
2026-04-09T00:41:01.710327Z  INFO jd_client_sv2: Monitoring server: received shutdown signal.
2026-04-09T00:41:01.710340Z  INFO stratum_apps::monitoring::http_server: Monitoring server received shutdown signal, stopping...
2026-04-09T00:41:01.710424Z  INFO stratum_apps::monitoring::http_server: Monitoring server stopped
2026-04-09T00:41:01.710437Z  INFO jd_client_sv2: Monitoring server task exited and signaled fallback coordinator
2026-04-09T00:41:01.710446Z  INFO jd_client_sv2: All tasks joined cleanly
2026-04-09T00:41:01.710449Z  INFO jd_client_sv2: JD Client shutdown complete.
2026-04-09T00:41:01.710477Z  INFO jd_client_sv2: JobDeclaratorClient dropped
```