### PR TITLE
version bumps for v0.3.4

### DIFF
--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-channel 1.9.0",
  "clap",

--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",

--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "integration_tests_sv2"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-channel 1.9.0",
  "clap",

--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -3079,7 +3079,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-channel 1.9.0",
  "axum",

--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -1932,7 +1932,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jd_client_sv2"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-channel 1.9.0",
  "bitcoin_core_sv2",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "integration_tests_sv2"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "Sv2 Integration Tests Framework"

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-channel",
  "clap",

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -1517,7 +1517,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jd_client_sv2"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-channel",
  "bitcoin_core_sv2",

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -2432,7 +2432,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-channel",
  "axum",

--- a/miner-apps/jd-client/Cargo.toml
+++ b/miner-apps/jd-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jd_client_sv2"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "Job Declarator Client (JDC) role"

--- a/miner-apps/translator/Cargo.toml
+++ b/miner-apps/translator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "translator_sv2"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "SV1 to SV2 translation proxy"

--- a/pool-apps/Cargo.lock
+++ b/pool-apps/Cargo.lock
@@ -2439,7 +2439,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-channel",
  "axum",

--- a/pool-apps/Cargo.lock
+++ b/pool-apps/Cargo.lock
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "pool_sv2"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-channel",
  "bitcoin_core_sv2",

--- a/pool-apps/pool/Cargo.toml
+++ b/pool-apps/pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pool_sv2"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "SV2 pool role"

--- a/stratum-apps/Cargo.lock
+++ b/stratum-apps/Cargo.lock
@@ -2046,7 +2046,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-channel",
  "axum",

--- a/stratum-apps/Cargo.toml
+++ b/stratum-apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stratum-apps"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 readme = "README.md"
@@ -25,7 +25,7 @@ tokio = { version = "1.44.1", features = ["full"] }
 futures = { version = "0.3.28" }
 tokio-util = { version = "0.7.10", default-features = false, features = ["codec"], optional = true }
 
-# Config helpers dependencies  
+# Config helpers dependencies
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 miniscript = { version = "13.0.0", default-features = false }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }


### PR DESCRIPTION
close #428 

| Crate | From | To | Reason | PRs |
| --- | --- | --- | --- | --- |
| `stratum-apps` | `0.3.0` | `0.3.1` | Fix `ServerStandardChannelInfo` share accounting | #425 |
| `jd_client_sv2` | `0.1.3` | `0.1.4` | Remove broadcast channel; handle missing bitcoin connection shutdown correctly | #317, #420, #422 |
| `translator_sv2` | `0.2.2` | `0.2.3` | Remove broadcast channel; improve display/log output in translator | #317, #421 |
| `pool_sv2` | `0.2.1` | `0.2.2` | Remove broadcast channel; handle missing bitcoin connection shutdown correctly; remove status main loop | #317, #420, #426 |
| `integration_tests_sv2` | `0.1.0` | `0.1.1` | Update packaged test/manifest contents | #317, #413 |
