### PR TITLE
Remove unwraps from downstream message handler

### DIFF
--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -465,7 +465,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "aes-gcm",
 ]
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -855,7 +855,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -874,7 +874,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -1132,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 
 [[package]]
 name = "digest"
@@ -1272,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1964,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -2122,7 +2122,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "8.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "stratum_translation"
 version = "0.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -3154,8 +3154,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sv1_api"
-version = "3.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+version = "4.0.0"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "aes-gcm",
 ]
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -610,7 +610,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 
 [[package]]
 name = "digest"
@@ -935,7 +935,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1534,7 +1534,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -1654,7 +1654,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "8.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "stratum_translation"
 version = "0.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2507,8 +2507,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sv1_api"
-version = "3.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+version = "4.0.0"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",
@@ -2555,7 +2555,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]

--- a/miner-apps/translator/src/lib/sv1/sv1_server/downstream_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/downstream_message_handler.rs
@@ -1,5 +1,7 @@
 use stratum_apps::stratum_core::sv1_api::{
-    client_to_server, json_rpc,
+    client_to_server,
+    error::Error,
+    json_rpc,
     server_to_client::{self, Notify},
     utils::{Extranonce, HexU32Be},
     IsServer,
@@ -19,16 +21,16 @@ impl IsServer<'static> for Sv1Server {
         &mut self,
         client_id: Option<usize>,
         request: &client_to_server::Configure,
-    ) -> (Option<server_to_client::VersionRollingParams>, Option<bool>) {
+    ) -> Result<(Option<server_to_client::VersionRollingParams>, Option<bool>), Error<'static>>
+    {
         let downstream_id = client_id.expect("Downstream id should exist");
 
         info!("Received mining.configure from SV1 downstream");
         debug!("Downstream {downstream_id}: mining.configure = {}", request);
 
-        let downstream = self
-            .downstreams
-            .get(&downstream_id)
-            .expect("Downstream should exist");
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Err(Error::UnknownID(downstream_id as u64));
+        };
 
         downstream.downstream_data.super_safe_lock(|data| {
             data.version_rolling_mask = request
@@ -51,7 +53,7 @@ impl IsServer<'static> for Sv1Server {
                  automatic mask selection is not supported",
             );
 
-            (Some(params), Some(false))
+            Ok((Some(params), Some(false)))
         })
     }
 
@@ -59,7 +61,7 @@ impl IsServer<'static> for Sv1Server {
         &self,
         client_id: Option<usize>,
         request: &client_to_server::Subscribe,
-    ) -> Vec<(String, String)> {
+    ) -> Result<Vec<(String, String)>, Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
 
         info!("Received mining.subscribe from Sv1 downstream");
@@ -75,31 +77,30 @@ impl IsServer<'static> for Sv1Server {
             "ae6812eb4cd7735a302a8a9dd95cf71f".to_string(),
         );
 
-        vec![set_difficulty_sub, notify_sub]
+        Ok(vec![set_difficulty_sub, notify_sub])
     }
 
     fn handle_authorize(
         &self,
         client_id: Option<usize>,
         request: &client_to_server::Authorize,
-    ) -> bool {
+    ) -> Result<bool, Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
         info!("Received mining.authorize from Sv1 downstream {downstream_id}");
         debug!("Down: Handling mining.authorize: {}", request);
-        true
+        Ok(true)
     }
 
     fn handle_submit(
         &self,
         client_id: Option<usize>,
         request: &client_to_server::Submit<'static>,
-    ) -> bool {
+    ) -> Result<bool, Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
 
-        let downstream = self
-            .downstreams
-            .get(&downstream_id)
-            .expect("Downstream should exist");
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Err(Error::UnknownID(downstream_id as u64));
+        };
 
         let job_id = &request.job_id;
 
@@ -107,7 +108,7 @@ impl IsServer<'static> for Sv1Server {
             .downstream_data
             .super_safe_lock(|data| data.channel_id)
         else {
-            return false;
+            return Ok(false);
         };
 
         let channel_id = if is_aggregated() {
@@ -125,7 +126,7 @@ impl IsServer<'static> for Sv1Server {
             .and_then(|jobs| find_job(jobs.as_ref()));
 
         let Some(job) = job else {
-            return false;
+            return Ok(false);
         };
 
         downstream.downstream_data.super_safe_lock(|data| {
@@ -136,7 +137,7 @@ impl IsServer<'static> for Sv1Server {
                         "Cannot submit share: channel_id is None \
                          (waiting for OpenExtendedMiningChannelSuccess)"
                     );
-                    return false;
+                    return Ok(false);
                 }
             };
 
@@ -156,7 +157,7 @@ impl IsServer<'static> for Sv1Server {
 
             if !is_valid {
                 error!("Invalid share for channel id: {}", channel_id);
-                return false;
+                return Ok(false);
             }
 
             data.pending_share = Some(SubmitShareWithChannelId {
@@ -169,34 +170,35 @@ impl IsServer<'static> for Sv1Server {
                 job_version: data.last_job_version_field,
             });
 
-            true
+            Ok(true)
         })
     }
 
     /// Indicates to the server that the client supports the mining.set_extranonce method.
-    fn handle_extranonce_subscribe(&self) {}
+    fn handle_extranonce_subscribe(&self) -> Result<(), Error<'static>> {
+        Ok(())
+    }
 
     /// Checks if a Downstream role is authorized.
-    fn is_authorized(&self, client_id: Option<usize>, name: &str) -> bool {
+    fn is_authorized(&self, client_id: Option<usize>, name: &str) -> Result<bool, Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
-        let downstream = self
-            .downstreams
-            .get(&downstream_id)
-            .expect("Downstream should exist");
-        downstream
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Err(Error::UnknownID(downstream_id as u64));
+        };
+        let is_authorized = downstream
             .downstream_data
-            .super_safe_lock(|data| data.authorized_worker_name == *name)
+            .super_safe_lock(|data| data.authorized_worker_name == *name);
+        Ok(is_authorized)
     }
 
     /// Authorizes a Downstream role.
-    fn authorize(&mut self, client_id: Option<usize>, name: &str) {
+    fn authorize(&mut self, client_id: Option<usize>, name: &str) -> Result<(), Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
-        let downstream = self
-            .downstreams
-            .get(&downstream_id)
-            .expect("Downstream should exist");
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Err(Error::UnknownID(downstream_id as u64));
+        };
 
-        let is_authorized = self.is_authorized(client_id, name);
+        let is_authorized = self.is_authorized(client_id, name)?;
         downstream.downstream_data.super_safe_lock(|data| {
             if !is_authorized {
                 data.authorized_worker_name = name.to_string();
@@ -207,6 +209,7 @@ impl IsServer<'static> for Sv1Server {
                 data.user_identity, downstream_id
             );
         });
+        Ok(())
     }
 
     /// Sets the `extranonce1` field sent in the SV1 `mining.notify` message to the value specified
@@ -215,21 +218,25 @@ impl IsServer<'static> for Sv1Server {
         &mut self,
         client_id: Option<usize>,
         _extranonce1: Option<Extranonce<'static>>,
-    ) -> Extranonce<'static> {
+    ) -> Result<Extranonce<'static>, Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
-        let downstream = self.downstreams.get(&downstream_id).unwrap();
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Err(Error::UnknownID(downstream_id as u64));
+        };
         downstream
             .downstream_data
-            .super_safe_lock(|data| data.extranonce1.clone())
+            .super_safe_lock(|data| Ok(data.extranonce1.clone()))
     }
 
     /// Returns the `Downstream`'s `extranonce1` value.
-    fn extranonce1(&self, client_id: Option<usize>) -> Extranonce<'static> {
+    fn extranonce1(&self, client_id: Option<usize>) -> Result<Extranonce<'static>, Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
-        let downstream = self.downstreams.get(&downstream_id).unwrap();
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Err(Error::UnknownID(downstream_id as u64));
+        };
         downstream
             .downstream_data
-            .super_safe_lock(|data| data.extranonce1.clone())
+            .super_safe_lock(|data| Ok(data.extranonce1.clone()))
     }
 
     /// Sets the `extranonce2_size` field sent in the SV1 `mining.notify` message to the value
@@ -238,61 +245,76 @@ impl IsServer<'static> for Sv1Server {
         &mut self,
         client_id: Option<usize>,
         _extra_nonce2_size: Option<usize>,
-    ) -> usize {
+    ) -> Result<usize, Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
-        let downstream = self.downstreams.get(&downstream_id).unwrap();
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Err(Error::UnknownID(downstream_id as u64));
+        };
         downstream
             .downstream_data
-            .super_safe_lock(|data| data.extranonce2_len)
+            .super_safe_lock(|data| Ok(data.extranonce2_len))
     }
 
     /// Returns the `Downstream`'s `extranonce2_size` value.
-    fn extranonce2_size(&self, client_id: Option<usize>) -> usize {
+    fn extranonce2_size(&self, client_id: Option<usize>) -> Result<usize, Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
-        let downstream = self.downstreams.get(&downstream_id).unwrap();
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Err(Error::UnknownID(downstream_id as u64));
+        };
         downstream
             .downstream_data
-            .super_safe_lock(|data| data.extranonce2_len)
+            .super_safe_lock(|data| Ok(data.extranonce2_len))
     }
 
     /// Returns the version rolling mask.
-    fn version_rolling_mask(&self, client_id: Option<usize>) -> Option<HexU32Be> {
+    fn version_rolling_mask(
+        &self,
+        client_id: Option<usize>,
+    ) -> Result<Option<HexU32Be>, Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
-        let downstream = self.downstreams.get(&downstream_id)?;
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Err(Error::UnknownID(downstream_id as u64));
+        };
         downstream
             .downstream_data
-            .super_safe_lock(|data| data.version_rolling_mask.clone())
+            .super_safe_lock(|data| Ok(data.version_rolling_mask.clone()))
     }
 
     /// Sets the version rolling mask.
-    fn set_version_rolling_mask(&mut self, client_id: Option<usize>, mask: Option<HexU32Be>) {
+    fn set_version_rolling_mask(
+        &mut self,
+        client_id: Option<usize>,
+        mask: Option<HexU32Be>,
+    ) -> Result<(), Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
-        let downstream = self
-            .downstreams
-            .get(&downstream_id)
-            .expect("Downstream should exist");
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Err(Error::UnknownID(downstream_id as u64));
+        };
 
         downstream
             .downstream_data
-            .super_safe_lock(|data| data.version_rolling_mask = mask)
+            .super_safe_lock(|data| data.version_rolling_mask = mask);
+
+        Ok(())
     }
 
     /// Sets the minimum version rolling bit.
-    fn set_version_rolling_min_bit(&mut self, client_id: Option<usize>, mask: Option<HexU32Be>) {
+    fn set_version_rolling_min_bit(
+        &mut self,
+        client_id: Option<usize>,
+        mask: Option<HexU32Be>,
+    ) -> Result<(), Error<'static>> {
         let downstream_id = client_id.expect("Downstream id should exist");
-        let downstream = self
-            .downstreams
-            .get(&downstream_id)
-            .expect("Downstream should exist");
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Err(Error::UnknownID(downstream_id as u64));
+        };
         downstream
             .downstream_data
-            .super_safe_lock(|data| data.version_rolling_min_bit = mask)
+            .super_safe_lock(|data| data.version_rolling_min_bit = mask);
+        Ok(())
     }
 
-    fn notify(
-        &'_ mut self,
-        _client_id: Option<usize>,
-    ) -> Result<json_rpc::Message, stratum_apps::stratum_core::sv1_api::error::Error<'_>> {
+    fn notify(&'_ mut self, _client_id: Option<usize>) -> Result<json_rpc::Message, Error<'_>> {
         warn!("notify() called on Sv1Server - this method is not implemented for Sv1Server");
         Err(
             stratum_apps::stratum_core::sv1_api::error::Error::UnexpectedMessage(

--- a/pool-apps/Cargo.lock
+++ b/pool-apps/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "aes-gcm",
 ]
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -601,7 +601,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -797,7 +797,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 
 [[package]]
 name = "digest"
@@ -926,7 +926,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -987,7 +987,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1524,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -1644,7 +1644,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "8.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1808,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2467,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2534,7 +2534,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]

--- a/stratum-apps/Cargo.lock
+++ b/stratum-apps/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "aes-gcm",
 ]
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 
 [[package]]
 name = "digest"
@@ -698,7 +698,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1226,7 +1226,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "job_declaration_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -1331,7 +1331,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "8.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]
@@ -1371,7 +1371,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1480,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.2.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2080,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.2.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "stratum_translation"
 version = "0.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2121,8 +2121,8 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "sv1_api"
-version = "3.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+version = "4.0.0"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",
@@ -2190,7 +2190,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#38fe7a4a00812cc4b8543dcffbd4381a9958ed49"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#6556fb7f4e68643a8e25e187f5879ef2695e1a6b"
 dependencies = [
  "binary_sv2",
 ]


### PR DESCRIPTION
closes: #436 

We now have results in IsServer methods, so we can use it to propagate error.