### PR TITLE
`stratum-apps::monitoring::server::{ServerExtendedChannelInfo,ServerStandardChannelInfo}` displays `SubmitShares.Error.error_code`

### DIFF
--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -465,7 +465,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -646,7 +646,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "aes-gcm",
 ]
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -855,7 +855,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -874,7 +874,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -1132,7 +1132,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 
 [[package]]
 name = "digest"
@@ -1272,7 +1272,7 @@ dependencies = [
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1964,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -2122,7 +2122,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "9.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -2175,7 +2175,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2331,7 +2331,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -3107,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -3130,7 +3130,7 @@ dependencies = [
 [[package]]
 name = "stratum_translation"
 version = "0.2.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -3155,7 +3155,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sv1_api"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",
@@ -3214,7 +3214,7 @@ dependencies = [
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]

--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -3079,7 +3079,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-channel 1.9.0",
  "axum",

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["stratum", "mining", "bitcoin", "protocol"]
 exclude = ["resources/high_diff_chain.tar.gz"]
 
 [dependencies]
-stratum-apps = { version = "0.3.0", path = "../stratum-apps", features = ["network", "config"] }
+stratum-apps = { version = "0.4.0", path = "../stratum-apps", features = ["network", "config"] }
 jd_client_sv2 = { version = "0.1.3", path = "../miner-apps/jd-client" }
 pool_sv2 = { version = "0.2.1", path = "../pool-apps/pool" }
 translator_sv2 = { version = "0.2.1", path = "../miner-apps/translator" }

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "aes-gcm",
 ]
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -610,7 +610,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -806,7 +806,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 
 [[package]]
 name = "digest"
@@ -935,7 +935,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -996,7 +996,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1534,7 +1534,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -1654,7 +1654,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "9.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2460,7 +2460,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2483,7 +2483,7 @@ dependencies = [
 [[package]]
 name = "stratum_translation"
 version = "0.2.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2508,7 +2508,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sv1_api"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",
@@ -2555,7 +2555,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -2432,7 +2432,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-channel",
  "axum",

--- a/miner-apps/jd-client/Cargo.toml
+++ b/miner-apps/jd-client/Cargo.toml
@@ -16,7 +16,7 @@ name = "jd_client_sv2"
 path = "src/lib/mod.rs"
 
 [dependencies]
-stratum-apps = { version = "0.3.0", path = "../../stratum-apps", features = ["jd_client"] }
+stratum-apps = { version = "0.4.0", path = "../../stratum-apps", features = ["jd_client"] }
 async-channel = "1.5.1"
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 tokio = { version = "1.44.1", features = ["full"] }

--- a/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
@@ -562,11 +562,12 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
         warn!("Received: {} ❌", msg);
+        let error_code = msg.error_code.as_utf8_or_hex();
 
         self.channel_manager_data.super_safe_lock(|data| {
             // if None, upstream is not currently available, so we skip accounting update
             if let Some(upstream_channel) = data.upstream_channel.as_mut() {
-                upstream_channel.on_share_rejection();
+                upstream_channel.on_share_rejection(error_code.clone());
             }
         });
 

--- a/miner-apps/jd-client/src/lib/monitoring.rs
+++ b/miner-apps/jd-client/src/lib/monitoring.rs
@@ -26,6 +26,7 @@ impl ServerMonitoring for ChannelManager {
                     let extranonce_prefix = upstream_channel.get_extranonce_prefix();
                     let user_identity = upstream_channel.get_user_identity();
                     let share_accounting = upstream_channel.get_share_accounting();
+                    let shares_rejected = share_accounting.get_rejected_shares().clone();
 
                     extended_channels.push(ServerExtendedChannelInfo {
                         channel_id,
@@ -38,7 +39,7 @@ impl ServerMonitoring for ChannelManager {
                         version_rolling: upstream_channel.is_version_rolling(),
                         shares_acknowledged: share_accounting.get_acknowledged_shares(),
                         shares_submitted: share_accounting.get_validated_shares(),
-                        shares_rejected: share_accounting.get_rejected_shares(),
+                        shares_rejected,
                         share_work_sum: share_accounting.get_share_work_sum(),
                         best_diff: share_accounting.get_best_diff(),
                         blocks_found: share_accounting.get_blocks_found(),

--- a/miner-apps/translator/Cargo.toml
+++ b/miner-apps/translator/Cargo.toml
@@ -20,7 +20,7 @@ name = "translator_sv2"
 path = "src/main.rs"
 
 [dependencies]
-stratum-apps = { version = "0.3.0", path = "../../stratum-apps", features = ["translator"] }
+stratum-apps = { version = "0.4.0", path = "../../stratum-apps", features = ["translator"] }
 async-channel = "1.5.1"
 serde = { version = "1.0.89", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.64", default-features = false, features = ["alloc"] }

--- a/miner-apps/translator/src/lib/monitoring.rs
+++ b/miner-apps/translator/src/lib/monitoring.rs
@@ -45,7 +45,7 @@ impl ServerMonitoring for ChannelManager {
                         version_rolling,
                         shares_acknowledged: share_accounting.get_acknowledged_shares(),
                         shares_submitted: share_accounting.get_validated_shares(),
-                        shares_rejected: share_accounting.get_rejected_shares(),
+                        shares_rejected: share_accounting.get_rejected_shares().clone(),
                         share_work_sum: share_accounting.get_share_work_sum(),
                         best_diff: share_accounting.get_best_diff(),
                         blocks_found: share_accounting.get_blocks_found(),
@@ -63,6 +63,7 @@ impl ServerMonitoring for ChannelManager {
                     let extranonce_prefix = extended_channel.get_extranonce_prefix();
                     let user_identity = extended_channel.get_user_identity();
                     let share_accounting = extended_channel.get_share_accounting();
+                    let shares_rejected = share_accounting.get_rejected_shares().clone();
 
                     extended_channels.push(ServerExtendedChannelInfo {
                         channel_id,
@@ -79,7 +80,7 @@ impl ServerMonitoring for ChannelManager {
                         version_rolling: extended_channel.is_version_rolling(),
                         shares_acknowledged: share_accounting.get_acknowledged_shares(),
                         shares_submitted: share_accounting.get_validated_shares(),
-                        shares_rejected: share_accounting.get_rejected_shares(),
+                        shares_rejected,
                         share_work_sum: share_accounting.get_share_work_sum(),
                         best_diff: share_accounting.get_best_diff(),
                         blocks_found: share_accounting.get_blocks_found(),

--- a/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
@@ -513,6 +513,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
         warn!("Received: {} ❌", m);
+        let error_code = m.error_code.as_utf8_or_hex();
 
         let key = if self.mode.is_aggregated() {
             AGGREGATED_CHANNEL_ID
@@ -522,7 +523,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
 
         // if None, the channel may be closed/missing, so we ignore this accounting update
         if let Some(mut ch) = self.extended_channels.get_mut(&key) {
-            ch.on_share_rejection();
+            ch.on_share_rejection(error_code);
         }
 
         Ok(())

--- a/pool-apps/Cargo.lock
+++ b/pool-apps/Cargo.lock
@@ -2439,7 +2439,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-channel",
  "axum",

--- a/pool-apps/Cargo.lock
+++ b/pool-apps/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -419,7 +419,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "aes-gcm",
 ]
@@ -531,7 +531,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -601,7 +601,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -797,7 +797,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 
 [[package]]
 name = "digest"
@@ -926,7 +926,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -987,7 +987,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1122,7 +1122,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1524,7 +1524,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -1644,7 +1644,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "9.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -1684,7 +1684,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1808,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2467,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2534,7 +2534,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]

--- a/pool-apps/jd-server/Cargo.toml
+++ b/pool-apps/jd-server/Cargo.toml
@@ -16,7 +16,7 @@ name = "jd_server_sv2"
 path = "src/lib/mod.rs"
 
 [dependencies]
-stratum-apps = { version = "0.3.0", path = "../../stratum-apps", features = ["jd_server"] }
+stratum-apps = { version = "0.4.0", path = "../../stratum-apps", features = ["jd_server"] }
 async-channel = "1.5.1"
 
 bitcoin_core_sv2 = { version = "0.1.0", path = "../../bitcoin-core-sv2" }

--- a/pool-apps/pool/Cargo.toml
+++ b/pool-apps/pool/Cargo.toml
@@ -17,7 +17,7 @@ name = "pool_sv2"
 path = "src/lib/mod.rs"
 
 [dependencies]
-stratum-apps = { version = "0.3.0", path = "../../stratum-apps", features = ["pool"] }
+stratum-apps = { version = "0.4.0", path = "../../stratum-apps", features = ["pool"] }
 async-channel = "1.5.1"
 serde = { version = "1.0.89", features = ["derive", "alloc"], default-features = false }
 tokio = { version = "1.44.1", features = ["full"] }

--- a/stratum-apps/Cargo.lock
+++ b/stratum-apps/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "5.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -332,7 +332,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "aes-gcm",
 ]
@@ -404,7 +404,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -428,7 +428,7 @@ dependencies = [
 [[package]]
 name = "codec_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -441,7 +441,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -602,7 +602,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 
 [[package]]
 name = "digest"
@@ -698,7 +698,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.1.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -749,7 +749,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "6.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -903,7 +903,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1226,7 +1226,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 [[package]]
 name = "job_declaration_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -1331,7 +1331,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "9.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]
@@ -1371,7 +1371,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1480,7 +1480,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2080,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.3.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "stratum_translation"
 version = "0.2.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2122,7 +2122,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sv1_api"
 version = "4.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
  "bitcoin_hashes 0.3.2",
@@ -2190,7 +2190,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "template_distribution_sv2"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#2bd3073c7241a6a4355de30a120bea1b2bc69fa3"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#3567f825df682f485076daa36a915ce8f6f5be32"
 dependencies = [
  "binary_sv2",
 ]

--- a/stratum-apps/Cargo.lock
+++ b/stratum-apps/Cargo.lock
@@ -2046,7 +2046,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stratum-apps"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "async-channel",
  "axum",

--- a/stratum-apps/Cargo.toml
+++ b/stratum-apps/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stratum-apps"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 readme = "README.md"

--- a/stratum-apps/src/coinbase_output_constraints.rs
+++ b/stratum-apps/src/coinbase_output_constraints.rs
@@ -73,8 +73,9 @@ pub fn coinbase_output_constraints_message(
 
 /// Creates a CoinbaseOutputConstraints message with safety margins (offsets) applied.
 ///
-/// This function first calculates the exact constraints using [`coinbase_output_constraints_message`],
-/// then adds safety margins to account for address type variation in solo mining scenarios.
+/// This function first calculates the exact constraints using
+/// [`coinbase_output_constraints_message`], then adds safety margins to account for address type
+/// variation in solo mining scenarios.
 ///
 /// The offsets ensure that the coinbase can accommodate the largest possible address types
 /// (p2tr for size, p2pkh for sigops) even when the actual mining address differs from what
@@ -114,7 +115,8 @@ mod tests {
     /// sizes and sigop counts. Run with `--nocapture` to see the output.
     ///
     /// The offsets were determined by finding the worst-case address types:
-    /// - **Size**: p2tr (Taproot) produces the largest coinbase output (43 bytes larger than others)
+    /// - **Size**: p2tr (Taproot) produces the largest coinbase output (43 bytes larger than
+    ///   others)
     /// - **Sigops**: p2pkh has higher sigop count than modern address types (4 sigops)
     ///
     /// Since the pool cannot know in advance which address type the miner will use,

--- a/stratum-apps/src/monitoring/http_server.rs
+++ b/stratum-apps/src/monitoring/http_server.rs
@@ -931,6 +931,7 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use http_body_util::BodyExt;
+    use std::collections::HashMap;
     use tower::ServiceExt;
 
     // ── helpers ──────────────────────────────────────────────────────
@@ -997,7 +998,7 @@ mod tests {
             rollable_extranonce_size: 4,
             version_rolling: true,
             shares_acknowledged: 10,
-            shares_rejected: 0,
+            shares_rejected: HashMap::new(),
             share_work_sum: 100.0,
             shares_submitted: 12,
             best_diff: 50.0,
@@ -1017,7 +1018,7 @@ mod tests {
             extranonce_prefix_hex: "bb".into(),
             shares_acknowledged: 20,
             shares_submitted: 22,
-            shares_rejected: 1,
+            shares_rejected: HashMap::from([("duplicate-share".to_string(), 1)]),
             share_work_sum: 200.0,
             best_diff: 80.0,
             blocks_found: 0,

--- a/stratum-apps/src/monitoring/server.rs
+++ b/stratum-apps/src/monitoring/server.rs
@@ -4,6 +4,7 @@
 //! An app typically has one server connection with one or more channels.
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use utoipa::ToSchema;
 
 /// Information about an extended channel opened with the server
@@ -20,7 +21,7 @@ pub struct ServerExtendedChannelInfo {
     pub version_rolling: bool,
     pub shares_acknowledged: u32,
     pub shares_submitted: u32,
-    pub shares_rejected: u32,
+    pub shares_rejected: HashMap<String, u32>,
     pub share_work_sum: f64,
     pub best_diff: f64,
     pub blocks_found: u32,
@@ -37,7 +38,7 @@ pub struct ServerStandardChannelInfo {
     pub extranonce_prefix_hex: String,
     pub shares_acknowledged: u32,
     pub shares_submitted: u32,
-    pub shares_rejected: u32,
+    pub shares_rejected: HashMap<String, u32>,
     pub share_work_sum: f64,
     pub best_diff: f64,
     pub blocks_found: u32,
@@ -117,7 +118,7 @@ mod tests {
             rollable_extranonce_size: 4,
             version_rolling: true,
             shares_acknowledged: 10,
-            shares_rejected: 0,
+            shares_rejected: HashMap::new(),
             share_work_sum: 100.0,
             shares_submitted: 12,
             best_diff: 50.0,
@@ -137,7 +138,7 @@ mod tests {
             extranonce_prefix_hex: "bb".into(),
             shares_acknowledged: 20,
             shares_submitted: 22,
-            shares_rejected: 1,
+            shares_rejected: HashMap::from([("duplicate-share".to_string(), 1)]),
             share_work_sum: 200.0,
             best_diff: 80.0,
             blocks_found: 0,


### PR DESCRIPTION
close #423 

companion https://github.com/stratum-mining/stratum/pull/2139

blocked by #462

---

the affected endpoint is `GET /api/v1/server/channels`

before, each channel would have:
```
"shares_rejected": 2
```

now, it gets:
```
"shares_rejected": {
  "duplicate-share": 1,
  "difficulty-too-low": 1
}
```

and if there's no rejected shares:
```
"shares_rejected": {}
```