### PR TITLE
refactor(jd-client): robust error handling for initialization and retry logic

### DIFF
--- a/integration-tests/lib/mod.rs
+++ b/integration-tests/lib/mod.rs
@@ -274,7 +274,11 @@ pub fn start_jdc(
     );
     let ret = jd_client_sv2::JobDeclaratorClient::new(jd_client_proxy);
     let ret_clone = ret.clone();
-    tokio::spawn(async move { ret_clone.start().await });
+    tokio::spawn(async move {
+        if let Err(e) = ret_clone.start().await {
+            panic!("JDC failed to start: {e}");
+        }
+    });
     (ret, jdc_address, monitoring_address)
 }
 

--- a/miner-apps/jd-client/src/lib/error.rs
+++ b/miner-apps/jd-client/src/lib/error.rs
@@ -58,13 +58,16 @@ pub struct Upstream;
 pub struct Downstream;
 
 #[derive(Debug)]
+pub struct JobDeclaratorClient;
+
+#[derive(Debug)]
 pub struct JDCError<Owner> {
     pub kind: JDCErrorKind,
     pub action: Action,
     _owner: PhantomData<Owner>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Action {
     Log,
     Disconnect(DownstreamId),
@@ -84,12 +87,14 @@ impl CanDisconnect for ChannelManager {}
 impl CanFallback for Upstream {}
 impl CanFallback for JobDeclarator {}
 impl CanFallback for ChannelManager {}
+impl CanFallback for JobDeclaratorClient {}
 
 impl CanShutdown for ChannelManager {}
 impl CanShutdown for TemplateProvider {}
 impl CanShutdown for Downstream {}
 impl CanShutdown for Upstream {}
 impl CanShutdown for JobDeclarator {}
+impl CanShutdown for JobDeclaratorClient {}
 
 impl<O> JDCError<O> {
     pub fn log<E: Into<JDCErrorKind>>(kind: E) -> Self {
@@ -256,6 +261,10 @@ pub enum JDCErrorKind {
     InvalidKey,
     /// Upstream not found
     UpstreamNotFound,
+    /// JDC initialization error with details
+    InitializationError(String),
+    /// No upstream is available after all attempts have failed, fallback to solo mining.
+    NoUpstreamAvailable,
 }
 
 impl std::error::Error for JDCErrorKind {}
@@ -395,6 +404,12 @@ impl fmt::Display for JDCErrorKind {
             CouldNotInitiateSystem => write!(f, "Could not initiate subsystem"),
             InvalidKey => write!(f, "Invalid key used during noise handshake"),
             UpstreamNotFound => write!(f, "Upstream not found"),
+            InitializationError(ref err) => {
+                write!(f, "Cannot initialize JD client: {err:?}")
+            }
+            NoUpstreamAvailable => {
+                write!(f, "No upstream is available after all attempts have failed")
+            }
         }
     }
 }

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -22,7 +22,7 @@ use tracing::{debug, error, info, warn};
 use crate::{
     channel_manager::ChannelManager,
     config::JobDeclaratorClientConfig,
-    error::JDCErrorKind,
+    error::{Action, JDCError, JDCErrorKind, JDCResult},
     jd_mode::JDMode,
     job_declarator::JobDeclarator,
     template_receiver::{
@@ -68,7 +68,7 @@ impl JobDeclaratorClient {
     }
 
     /// Starts the Job Declarator Client (JDC) main loop.
-    pub async fn start(&self) {
+    pub async fn start(&self) -> JDCResult<(), error::JobDeclaratorClient> {
         info!(
             "Job declarator client starting... setting up subsystems, User Identity: {}",
             self.config.user_identity()
@@ -77,17 +77,28 @@ impl JobDeclaratorClient {
         let miner_coinbase_outputs = vec![self.config.get_txout()];
         let mut encoded_outputs = vec![];
         let mode = JDMode::new(self.config.mode);
+        let task_manager = Arc::new(TaskManager::new());
+        let mut bitcoin_core_sv2_join_handle: Option<JoinHandle<()>> = None;
+        let mut bitcoin_core_sv2_cancellation_token: Option<CancellationToken> = None;
 
-        if let Err(e) = miner_coinbase_outputs.consensus_encode(&mut encoded_outputs) {
-            error!(error = ?e, "Invalid coinbase output in config");
+        if miner_coinbase_outputs
+            .consensus_encode(&mut encoded_outputs)
+            .is_err()
+        {
             self.cancellation_token.cancel();
-            self.shutdown_notify.notify_waiters();
-            self.is_alive.store(false, Ordering::Relaxed);
-            return;
+            self.graceful_shutdown(
+                task_manager,
+                bitcoin_core_sv2_join_handle,
+                bitcoin_core_sv2_cancellation_token,
+            )
+            .await;
+
+            return Err(JDCError::shutdown(JDCErrorKind::InitializationError(
+                "Invalid coinbase output in config".to_string(),
+            )));
         }
 
         let mut fallback_coordinator = FallbackCoordinator::new();
-        let task_manager = Arc::new(TaskManager::new());
 
         let (channel_manager_to_upstream_sender, channel_manager_to_upstream_receiver) =
             unbounded();
@@ -123,11 +134,15 @@ impl JobDeclaratorClient {
         {
             Ok(channel_manager) => channel_manager,
             Err(e) => {
-                error!(error = ?e, "Failed to initialize channel manager");
                 self.cancellation_token.cancel();
-                self.shutdown_notify.notify_waiters();
-                self.is_alive.store(false, Ordering::Relaxed);
-                return;
+                self.graceful_shutdown(
+                    task_manager,
+                    bitcoin_core_sv2_join_handle,
+                    bitcoin_core_sv2_cancellation_token,
+                )
+                .await;
+
+                return Err(JDCError::shutdown(e.kind));
             }
         };
 
@@ -191,8 +206,6 @@ impl JobDeclaratorClient {
         }
 
         let initial_channel_manager = channel_manager.clone();
-        let mut bitcoin_core_sv2_join_handle: Option<JoinHandle<()>> = None;
-        let mut bitcoin_core_sv2_cancellation_token: Option<CancellationToken> = None;
 
         match self.config.template_provider_type().clone() {
             TemplateProviderType::Sv2Tp {
@@ -213,9 +226,14 @@ impl JobDeclaratorClient {
                     Err(e) => {
                         error!(error = ?e, "Failed to initialize SV2 template receiver");
                         self.cancellation_token.cancel();
-                        self.shutdown_notify.notify_waiters();
-                        self.is_alive.store(false, Ordering::Relaxed);
-                        return;
+                        self.graceful_shutdown(
+                            task_manager,
+                            bitcoin_core_sv2_join_handle,
+                            bitcoin_core_sv2_cancellation_token,
+                        )
+                        .await;
+
+                        return Err(JDCError::shutdown(e.kind));
                     }
                 };
 
@@ -228,9 +246,14 @@ impl JobDeclaratorClient {
                 {
                     error!(error = ?e, "Failed to start SV2 template receiver");
                     self.cancellation_token.cancel();
-                    self.shutdown_notify.notify_waiters();
-                    self.is_alive.store(false, Ordering::Relaxed);
-                    return;
+                    self.graceful_shutdown(
+                        task_manager,
+                        bitcoin_core_sv2_join_handle,
+                        bitcoin_core_sv2_cancellation_token,
+                    )
+                    .await;
+
+                    return Err(JDCError::shutdown(e.kind));
                 }
 
                 info!("Sv2 Template Provider setup done");
@@ -246,13 +269,15 @@ impl JobDeclaratorClient {
                 ) {
                     Some(unix_socket_path) => unix_socket_path,
                     None => {
-                        error!(
-                                "Could not determine Bitcoin data directory. Please set data_dir in config."
-                            );
                         self.cancellation_token.cancel();
-                        self.shutdown_notify.notify_waiters();
-                        self.is_alive.store(false, Ordering::Relaxed);
-                        return;
+                        self.graceful_shutdown(
+                            task_manager,
+                            bitcoin_core_sv2_join_handle,
+                            bitcoin_core_sv2_cancellation_token,
+                        )
+                        .await;
+
+                        return Err(JDCError::shutdown(JDCErrorKind::InitializationError("Could not determine Bitcoin data directory. Please set data_dir in config.".to_string())));
                     }
                 };
 
@@ -367,8 +392,22 @@ impl JobDeclaratorClient {
                     _ = initial_channel_manager.allocate_tokens(2).await;
                 }
                 Err(e) => {
-                    tracing::error!("Failed to initialize upstream: {:?}", e);
+                    error!("Failed to initialize upstream: {:?}", e);
+
+                    if e.action == Action::Shutdown {
+                        self.cancellation_token.cancel();
+                        self.graceful_shutdown(
+                            task_manager,
+                            bitcoin_core_sv2_join_handle,
+                            bitcoin_core_sv2_cancellation_token,
+                        )
+                        .await;
+
+                        return Err(e);
+                    }
+
                     mode.set_solo_mining();
+                    info!("Fallback to solo mining mode");
                 }
             };
         }
@@ -403,12 +442,12 @@ impl JobDeclaratorClient {
         info!("Spawning status listener task...");
         let mut fallback_token = fallback_coordinator.token();
 
-        loop {
+        let loop_error = loop {
             tokio::select! {
                 biased;
 
                 _ = self.cancellation_token.cancelled() => {
-                    break;
+                    break None;
                 }
                 _ = fallback_token.cancelled() => {
                     warn!("Upstream/Job Declarator connection dropped — attempting reconnection...");
@@ -456,7 +495,7 @@ impl JobDeclaratorClient {
                         Err(e) => {
                             error!(error = ?e, "Failed to initialize channel manager during fallback");
                             self.cancellation_token.cancel();
-                            break;
+                            break Some(JDCError::shutdown(e.kind));
                         }
                     };
 
@@ -511,7 +550,14 @@ impl JobDeclaratorClient {
                             _ = channel_manager.allocate_tokens(2).await;
                         }
                         Err(e) => {
-                            tracing::error!("Failed to initialize upstream: {:?}", e);
+                            error!("Failed to initialize upstream: {:?}", e);
+
+                            if e.action == Action::Shutdown {
+                                info!("Shutdown requested while initializing upstream during fallback, initiate graceful shutdown");
+                                self.cancellation_token.cancel();
+                                break Some(e);
+                            }
+
                             channel_manager
                                 .upstream_state
                                 .set(UpstreamState::SoloMining);
@@ -609,11 +655,31 @@ impl JobDeclaratorClient {
                 _ = tokio::signal::ctrl_c() => {
                     info!("Ctrl+C received — initiating graceful shutdown...");
                     self.cancellation_token.cancel();
-                    break;
+                    break None;
                 }
             }
+        };
+
+        self.graceful_shutdown(
+            task_manager,
+            bitcoin_core_sv2_join_handle,
+            bitcoin_core_sv2_cancellation_token,
+        )
+        .await;
+
+        if let Some(e) = loop_error {
+            return Err(e);
         }
 
+        Ok(())
+    }
+
+    async fn graceful_shutdown(
+        &self,
+        task_manager: Arc<TaskManager>,
+        bitcoin_core_sv2_join_handle: Option<JoinHandle<()>>,
+        bitcoin_core_sv2_cancellation_token: Option<CancellationToken>,
+    ) {
         if let Some(bitcoin_core_sv2_cancellation_token) = bitcoin_core_sv2_cancellation_token {
             bitcoin_core_sv2_cancellation_token.cancel();
         }
@@ -679,7 +745,7 @@ impl JobDeclaratorClient {
         fallback_coordinator: FallbackCoordinator,
         mode: JDMode,
         task_manager: Arc<TaskManager>,
-    ) -> Result<(Upstream, JobDeclarator), JDCErrorKind> {
+    ) -> JDCResult<(Upstream, JobDeclarator), error::JobDeclaratorClient> {
         const MAX_RETRIES: usize = 3;
         let upstream_len = upstreams.len();
         for (i, upstream_entry) in upstreams.iter_mut().enumerate() {
@@ -697,7 +763,9 @@ impl JobDeclaratorClient {
                 biased;
                 _ = cancellation_token.cancelled() => {
                     info!("Shutdown requested while waiting to initialize upstream, aborting retries");
-                    return Err(JDCErrorKind::CouldNotInitiateSystem);
+                    return Err(
+                        JDCError::shutdown(JDCErrorKind::CouldNotInitiateSystem)
+                    );
                 }
                 _ = tokio::time::sleep(Duration::from_secs(1)) => {}
             }
@@ -714,7 +782,7 @@ impl JobDeclaratorClient {
                     info!(
                         "Shutdown requested before upstream connection attempt, aborting retries"
                     );
-                    return Err(JDCErrorKind::CouldNotInitiateSystem);
+                    return Err(JDCError::shutdown(JDCErrorKind::CouldNotInitiateSystem));
                 }
 
                 info!("Connection attempt {}/{}...", attempt, MAX_RETRIES);
@@ -744,9 +812,18 @@ impl JobDeclaratorClient {
                             biased;
                             _ = cancellation_token.cancelled() => {
                                 info!("Shutdown requested after upstream initialization failure, aborting retries");
-                                return Err(JDCErrorKind::CouldNotInitiateSystem);
+                                return Err(
+                                    JDCError::shutdown(JDCErrorKind::CouldNotInitiateSystem)
+                                );
                             }
                             _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                        }
+
+                        // Stop retrying and fail immediately if a shutdown signal is encountered,
+                        // as retries are only intended for fallback scenarios.
+                        if e.action == Action::Shutdown {
+                            info!("Encountered a shutdown error during upstream initialization, aborting retries");
+                            return Err(e);
                         }
 
                         warn!(
@@ -775,7 +852,7 @@ impl JobDeclaratorClient {
         }
 
         tracing::error!("All upstreams failed after {} retries each", MAX_RETRIES);
-        Err(JDCErrorKind::CouldNotInitiateSystem)
+        Err(JDCError::fallback(JDCErrorKind::NoUpstreamAvailable))
     }
 }
 
@@ -793,7 +870,7 @@ async fn try_initialize_single(
     mode: JDMode,
     task_manager: Arc<TaskManager>,
     config: &JobDeclaratorClientConfig,
-) -> Result<(Upstream, JobDeclarator), JDCErrorKind> {
+) -> JDCResult<(Upstream, JobDeclarator), error::JobDeclaratorClient> {
     info!("Upstream connection in-progress at initialize single");
     let upstream = Upstream::new(
         upstream_entry,
@@ -805,7 +882,10 @@ async fn try_initialize_single(
         config.required_extensions().to_vec(),
     )
     .await
-    .map_err(|error| error.kind)?;
+    .map_err(|error| match error.action {
+        Action::Shutdown => JDCError::shutdown(error.kind),
+        _ => JDCError::fallback(error.kind),
+    })?;
 
     info!("Upstream connection done at initialize single");
 
@@ -819,7 +899,10 @@ async fn try_initialize_single(
         task_manager.clone(),
     )
     .await
-    .map_err(|error| error.kind)?;
+    .map_err(|error| match error.action {
+        Action::Shutdown => JDCError::shutdown(error.kind),
+        _ => JDCError::fallback(error.kind),
+    })?;
 
     Ok((upstream, job_declarator))
 }

--- a/miner-apps/jd-client/src/main.rs
+++ b/miner-apps/jd-client/src/main.rs
@@ -25,5 +25,8 @@ async fn inner_main() {
     });
 
     init_logging(jdc_config.log_file());
-    JobDeclaratorClient::new(jdc_config).start().await;
+    if let Err(e) = JobDeclaratorClient::new(jdc_config).start().await {
+        tracing::error!("Job Declarator Client failed to start: {e}");
+        std::process::exit(1);
+    };
 }


### PR DESCRIPTION
https://github.com/stratum-mining/sv2-apps/issues/168

This PR attempts to improve error handling for JDC by addressing some low-hanging improvements:
1. Replaces several `expect()` and `unwrap()` calls in `JobDeclaratorClient::start` with proper error propagation using `Result`.
2. Refactors the JDC error handling by making the upstream initialization logic "action-aware."

Changes:
- Updated `start()` signature to return `JDCError<JobDeclarationClient>`.
- Introduced `InitializationError(String)` variant to `JDCErrorKind` to preserve context from formerly panicking calls.
- Updated `main.rs` and integration tests to handle the new `Result` type
- `try_initialize_single` is updated to inspect the `Action` from sub-component errors and return a full `JDCError` with either a `Shutdown` or `Fallback` action.
- The retry loop in `initialize_jd` now checks `e.action`. It immediately propagates fatal `Shutdown` errors up to `start()` while continuing to retry on `Fallback` errors.
- The `Action` enum now derives `PartialEq` and `Eq` to enable this logic.
- Function signatures now consistently use the `JDCResult` type alias.