### PR TITLE
[Don't merge/review] Playground Prototype used for SV2 UI testing of asics rs 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 ###
 # ---- Builder Stage ----
 ###
-FROM rust:1.85-slim-bookworm AS builder
+FROM rust:1.88-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     capnproto libcapnp-dev curl && \

--- a/integration-tests/tests/monitoring_integration.rs
+++ b/integration-tests/tests/monitoring_integration.rs
@@ -17,7 +17,7 @@ use stratum_apps::stratum_core::mining_sv2::*;
 async fn pool_monitoring_with_sv2_mining_device() {
     start_tracing();
     let (_tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
-    let (_pool, pool_addr, pool_monitoring) =
+    let (pool, pool_addr, pool_monitoring) =
         start_pool(sv2_tp_config(tp_addr), vec![], vec![], true).await;
     let (sniffer, sniffer_addr) = start_sniffer("A", pool_addr, false, vec![], None);
     start_mining_device_sv2(sniffer_addr, None, None, None, 1, None, true);
@@ -57,6 +57,8 @@ async fn pool_monitoring_with_sv2_mining_device() {
 
     // Pool should see 1 SV2 client (the mining device) with a standard channel
     assert_metric_eq(&pool_metrics, "sv2_clients_total", 1.0);
+
+    shutdown_all!(pool);
 }
 
 // ---------------------------------------------------------------------------
@@ -68,10 +70,10 @@ async fn pool_monitoring_with_sv2_mining_device() {
 async fn pool_and_tproxy_monitoring_with_sv1_miner() {
     start_tracing();
     let (_tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
-    let (_pool, pool_addr, pool_monitoring) =
+    let (pool, pool_addr, pool_monitoring) =
         start_pool(sv2_tp_config(tp_addr), vec![], vec![], true).await;
     let (sniffer, sniffer_addr) = start_sniffer("0", pool_addr, false, vec![], None);
-    let (_tproxy, tproxy_addr, tproxy_monitoring) =
+    let (tproxy, tproxy_addr, tproxy_monitoring) =
         start_sv2_translator(&[sniffer_addr], false, vec![], vec![], None, true).await;
     let (_minerd_process, _minerd_addr) = start_minerd(tproxy_addr, None, None, false).await;
 
@@ -119,6 +121,8 @@ async fn pool_and_tproxy_monitoring_with_sv1_miner() {
     assert_metric_eq(&tproxy_metrics, "sv1_clients_total", 1.0);
     // tProxy has no SV2 downstreams
     assert_metric_not_present(&tproxy_metrics, "sv2_clients_total");
+
+    shutdown_all!(pool, tproxy);
 }
 
 // ---------------------------------------------------------------------------
@@ -129,11 +133,11 @@ async fn pool_and_tproxy_monitoring_with_sv1_miner() {
 async fn jd_aggregated_topology_monitoring() {
     start_tracing();
     let (tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
-    let (_pool, pool_addr, jds_addr, pool_monitoring) =
+    let (pool, pool_addr, jds_addr, pool_monitoring) =
         start_pool_with_jds(tp.bitcoin_core(), vec![], vec![], true).await;
     let (jdc_pool_sniffer, jdc_pool_sniffer_addr) =
         start_sniffer("0", pool_addr, false, vec![], None);
-    let (_jdc, jdc_addr, _jdc_monitoring) = start_jdc(
+    let (jdc, jdc_addr, _jdc_monitoring) = start_jdc(
         &[(jdc_pool_sniffer_addr, jds_addr)],
         sv2_tp_config(tp_addr),
         vec![],
@@ -143,7 +147,7 @@ async fn jd_aggregated_topology_monitoring() {
     );
     let (_tproxy_jdc_sniffer, tproxy_jdc_sniffer_addr) =
         start_sniffer("1", jdc_addr, false, vec![], None);
-    let (_tproxy, tproxy_addr, tproxy_monitoring) =
+    let (tproxy, tproxy_addr, tproxy_monitoring) =
         start_sv2_translator(&[tproxy_jdc_sniffer_addr], true, vec![], vec![], None, true).await;
 
     // Start two minerd processes
@@ -190,6 +194,8 @@ async fn jd_aggregated_topology_monitoring() {
     );
     assert_metric_eq(&tproxy_metrics, "sv1_clients_total", 2.0);
     assert_metric_not_present(&tproxy_metrics, "sv2_clients_total");
+
+    shutdown_all!(pool, jdc, tproxy);
 }
 
 // ---------------------------------------------------------------------------
@@ -202,13 +208,13 @@ async fn block_found_detected_in_pool_metrics() {
 
     start_tracing();
     let (tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
-    let (_pool, pool_addr, jds_addr, pool_monitoring) =
+    let (pool, pool_addr, jds_addr, pool_monitoring) =
         start_pool_with_jds(tp.bitcoin_core(), vec![], vec![], true).await;
 
     let (_jdc_jds_sniffer, jdc_jds_sniffer_addr) =
         start_sniffer("0", jds_addr, false, vec![], None);
     let (jdc_tp_sniffer, jdc_tp_sniffer_addr) = start_sniffer("1", tp_addr, false, vec![], None);
-    let (_jdc, jdc_addr, _) = start_jdc(
+    let (jdc, jdc_addr, _) = start_jdc(
         &[(pool_addr, jdc_jds_sniffer_addr)],
         sv2_tp_config(jdc_tp_sniffer_addr),
         vec![],
@@ -216,7 +222,7 @@ async fn block_found_detected_in_pool_metrics() {
         false,
         None,
     );
-    let (_tproxy, tproxy_addr, _) =
+    let (tproxy, tproxy_addr, _) =
         start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;
     let (_minerd_process, _minerd_addr) = start_minerd(tproxy_addr, None, None, false).await;
 
@@ -236,4 +242,6 @@ async fn block_found_detected_in_pool_metrics() {
     .await;
     assert_uptime(&pool_metrics);
     assert_metric_eq(&pool_metrics, "sv2_clients_total", 1.0);
+
+    shutdown_all!(pool, jdc, tproxy);
 }

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -71,6 +71,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,7 +115,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -117,8 +126,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arbitrary"
@@ -157,6 +172,377 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
+name = "asic-rs"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-firmwares-antminer",
+ "asic-rs-firmwares-auradine",
+ "asic-rs-firmwares-avalonminer",
+ "asic-rs-firmwares-bitaxe",
+ "asic-rs-firmwares-braiins",
+ "asic-rs-firmwares-epic",
+ "asic-rs-firmwares-luxminer",
+ "asic-rs-firmwares-marathon",
+ "asic-rs-firmwares-nerdaxe",
+ "asic-rs-firmwares-vnish",
+ "asic-rs-firmwares-whatsminer",
+ "asic-rs-makes-antminer",
+ "asic-rs-makes-auradine",
+ "asic-rs-makes-avalon",
+ "asic-rs-makes-bitaxe",
+ "asic-rs-makes-braiins",
+ "asic-rs-makes-epic",
+ "asic-rs-makes-marathon",
+ "asic-rs-makes-nerdaxe",
+ "asic-rs-makes-whatsminer",
+ "async-stream",
+ "futures",
+ "ipnet",
+ "measurements",
+ "pyo3-build-config",
+ "rand 0.10.1",
+ "rlimit",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "asic-rs-core"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "macaddr",
+ "measurements",
+ "reqwest",
+ "secrecy",
+ "semver",
+ "serde",
+ "serde_json",
+ "strum",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "asic-rs-firmwares-antminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "async-trait",
+ "chrono",
+ "crc32fast",
+ "diqwest",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-auradine"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-auradine",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-avalonminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-avalon",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "regex",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-bitaxe"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-bitaxe",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-braiins"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "asic-rs-makes-braiins",
+ "async-trait",
+ "chrono",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-epic"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "asic-rs-makes-epic",
+ "asic-rs-makes-whatsminer",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "asic-rs-firmwares-luxminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-marathon"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "asic-rs-makes-marathon",
+ "async-trait",
+ "diqwest",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+]
+
+[[package]]
+name = "asic-rs-firmwares-nerdaxe"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-nerdaxe",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-vnish"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-whatsminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "aes",
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-whatsminer",
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "ecb",
+ "hex",
+ "macaddr",
+ "md5",
+ "md5crypt",
+ "measurements",
+ "semver",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "asic-rs-makes-antminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-auradine"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-avalon"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-bitaxe"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-braiins"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-epic"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-marathon"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-nerdaxe"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-whatsminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +551,40 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -189,6 +609,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -417,6 +859,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,14 +955,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -521,7 +986,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -531,7 +1007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -548,6 +1024,19 @@ dependencies = [
  "primitive-types",
  "template_distribution_sv2",
  "tracing",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -608,6 +1097,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codec_sv2"
 version = "5.0.0"
 source = "git+https://github.com/stratum-mining/stratum?branch=main#ab5b17f23d567c41a128776f979a597327f0800c"
@@ -616,7 +1114,7 @@ dependencies = [
  "buffer_sv2",
  "framing_sv2",
  "noise_sv2",
- "rand",
+ "rand 0.8.5",
  "tracing",
 ]
 
@@ -632,7 +1130,17 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -642,6 +1150,23 @@ source = "git+https://github.com/stratum-mining/stratum?branch=main#ab5b17f23d56
 dependencies = [
  "binary_sv2",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -686,7 +1211,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
@@ -721,10 +1246,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -828,6 +1378,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest_auth"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3054f4e81d395e50822796c5e99ca522e6ba7be98947d6d4b0e5e61640bdb894"
+dependencies = [
+ "digest 0.10.7",
+ "hex",
+ "md-5",
+ "rand 0.8.5",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "diqwest"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d10611d0d3ed31b33e13ec3e31329aa2053aa4f773eb082b597f39a97e68360"
+dependencies = [
+ "digest_auth",
+ "reqwest",
+ "url",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,7 +1429,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -887,6 +1461,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -923,7 +1512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -963,7 +1552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -974,6 +1563,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -983,6 +1573,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1002,6 +1598,12 @@ dependencies = [
  "buffer_sv2",
  "noise_sv2",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -1114,8 +1716,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1152,6 +1784,15 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
 ]
 
 [[package]]
@@ -1326,6 +1967,22 @@ dependencies = [
  "pin-utils",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1334,13 +1991,45 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
+ "futures-channel",
+ "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1425,6 +2114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,7 +2184,24 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1500,7 +2212,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1532,11 +2244,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "job_declaration_sv2"
 version = "7.0.0"
 source = "git+https://github.com/stratum-mining/stratum?branch=main#ab5b17f23d567c41a128776f979a597327f0800c"
 dependencies = [
  "binary_sv2",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1567,10 +2333,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1603,6 +2381,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "mach2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +2415,41 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
+name = "md5crypt"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8db1a978f99f584f2e72601860f68bb2cea9c09f4408f5e83f805db3434fb0"
+dependencies = [
+ "md5",
+]
+
+[[package]]
+name = "measurements"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f72b38901c571007811f0483e64a7e215ac9e6e3688e9f83705a717621d81513"
+dependencies = [
+ "libm",
+ "serde",
+]
 
 [[package]]
 name = "memchr"
@@ -1688,7 +2516,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1698,7 +2526,7 @@ source = "git+https://github.com/stratum-mining/stratum?branch=main#ab5b17f23d56
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
- "rand",
+ "rand 0.8.5",
  "secp256k1 0.28.2",
 ]
 
@@ -1718,7 +2546,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1747,6 +2575,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -1902,7 +2736,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1914,7 +2748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1935,6 +2769,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -2001,6 +2845,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "pyo3-build-config"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
 name = "quanta"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2016,6 +2869,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,6 +2932,18 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -2037,8 +2958,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2048,7 +2990,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2057,8 +3009,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "raw-cpuid"
@@ -2084,7 +3051,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -2095,7 +3062,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
 ]
@@ -2128,6 +3095,68 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "ron"
@@ -2186,10 +3215,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -2213,6 +3323,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,7 +3344,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
  "bitcoin_hashes 0.13.0",
- "rand",
+ "rand 0.8.5",
  "secp256k1-sys 0.9.2",
 ]
 
@@ -2256,6 +3375,44 @@ checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2340,7 +3497,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -2352,7 +3509,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -2415,7 +3572,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2434,6 +3591,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stratum-apps"
 version = "0.3.0"
 dependencies = [
+ "asic-rs",
+ "asic-rs-core",
  "async-channel",
  "axum",
  "bs58",
@@ -2442,7 +3601,7 @@ dependencies = [
  "futures",
  "miniscript",
  "prometheus",
- "rand",
+ "rand 0.8.5",
  "rustversion",
  "secp256k1 0.28.2",
  "serde",
@@ -2500,6 +3659,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +3714,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2551,6 +3734,12 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "template_distribution_sv2"
@@ -2652,6 +3841,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,7 +3869,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2677,6 +3881,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2778,6 +4003,29 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "iri-string",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2885,6 +4133,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2947,6 +4201,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -3037,10 +4297,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -3053,6 +4340,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3088,6 +4389,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,6 +4430,25 @@ checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3119,7 +4473,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3129,10 +4483,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3142,6 +4576,192 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -3159,6 +4779,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/miner-apps/translator/Cargo.toml
+++ b/miner-apps/translator/Cargo.toml
@@ -35,7 +35,7 @@ dashmap = "6.1.0"
 
 [features]
 default = ["monitoring"]
-monitoring = ["stratum-apps/monitoring"]
+monitoring = ["stratum-apps/asic-monitoring"]
 hotpath = ["hotpath/hotpath"]
 hotpath-alloc = ["hotpath", "hotpath/hotpath-alloc"]
 

--- a/miner-apps/translator/src/lib/error.rs
+++ b/miner-apps/translator/src/lib/error.rs
@@ -29,7 +29,6 @@ use stratum_apps::{
         MessageType,
     },
 };
-use tokio::sync::broadcast;
 
 pub type TproxyResult<T, Owner> = Result<T, TproxyError<Owner>>;
 
@@ -158,10 +157,6 @@ pub enum TproxyErrorKind {
     ChannelErrorReceiver(async_channel::RecvError),
     /// Channel sender error
     ChannelErrorSender,
-    /// Broadcast channel receiver error
-    BroadcastChannelErrorReceiver(broadcast::error::RecvError),
-    /// Tokio channel receiver error
-    TokioChannelErrorRecv(tokio::sync::broadcast::error::RecvError),
     /// Error converting SetDifficulty to Message
     SetDifficultyToMessage(SetDifficulty),
     /// Received an unexpected message type
@@ -225,11 +220,7 @@ impl fmt::Display for TproxyErrorKind {
             ParseInt(ref e) => write!(f, "Bad convert from `String` to `int`: `{e:?}`"),
             PoisonLock => write!(f, "Poison Lock error"),
             ChannelErrorReceiver(ref e) => write!(f, "Channel receive error: `{e:?}`"),
-            BroadcastChannelErrorReceiver(ref e) => {
-                write!(f, "Broadcast channel receive error: {e:?}")
-            }
             ChannelErrorSender => write!(f, "Sender error"),
-            TokioChannelErrorRecv(ref e) => write!(f, "Channel receive error: `{e:?}`"),
             SetDifficultyToMessage(ref e) => {
                 write!(f, "Error converting SetDifficulty to Message: `{e:?}`")
             }
@@ -336,12 +327,6 @@ impl From<ConfigError> for TproxyErrorKind {
 impl From<async_channel::RecvError> for TproxyErrorKind {
     fn from(e: async_channel::RecvError) -> Self {
         TproxyErrorKind::ChannelErrorReceiver(e)
-    }
-}
-
-impl From<tokio::sync::broadcast::error::RecvError> for TproxyErrorKind {
-    fn from(e: tokio::sync::broadcast::error::RecvError) -> Self {
-        TproxyErrorKind::TokioChannelErrorRecv(e)
     }
 }
 

--- a/miner-apps/translator/src/lib/mod.rs
+++ b/miner-apps/translator/src/lib/mod.rs
@@ -193,7 +193,8 @@ impl TranslatorSv2 {
             )
             .expect("Failed to initialize monitoring server")
             .with_sv1_monitoring(sv1_server.clone()) // SV1 client connections
-            .expect("Failed to add SV1 monitoring");
+            .expect("Failed to add SV1 monitoring")
+            .with_asic_monitoring();
 
             // Create shutdown signal using cancellation token
             let cancellation_token_clone = cancellation_token.clone();
@@ -337,7 +338,8 @@ impl TranslatorSv2 {
                                     )
                                     .expect("Failed to initialize monitoring server")
                                     .with_sv1_monitoring(sv1_server.clone())
-                                    .expect("Failed to add SV1 monitoring");
+                                    .expect("Failed to add SV1 monitoring")
+                                    .with_asic_monitoring();
 
                                     let cancellation_token_clone = cancellation_token.clone();
                                     let fallback_coordinator_token = fallback_coordinator.token();

--- a/miner-apps/translator/src/lib/sv1/downstream/channel.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream/channel.rs
@@ -1,9 +1,5 @@
 use async_channel::{Receiver, Sender};
-use stratum_apps::{
-    stratum_core::sv1_api::json_rpc,
-    utils::types::{ChannelId, DownstreamId},
-};
-use tokio::sync::broadcast;
+use stratum_apps::{stratum_core::sv1_api::json_rpc, utils::types::DownstreamId};
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 
@@ -12,8 +8,7 @@ pub struct DownstreamChannelState {
     pub downstream_sv1_sender: Sender<json_rpc::Message>,
     pub downstream_sv1_receiver: Receiver<json_rpc::Message>,
     pub sv1_server_sender: Sender<(DownstreamId, json_rpc::Message)>,
-    pub sv1_server_broadcast:
-        broadcast::Sender<(ChannelId, Option<DownstreamId>, json_rpc::Message)>, /* channel_id, optional downstream_id, message */
+    pub sv1_server_receiver: Receiver<json_rpc::Message>,
     /// Per-connection cancellation token (child of the global token).
     /// Cancelled when this downstream's task loop exits, causing
     /// the associated SV1 I/O task to shut down.
@@ -26,17 +21,13 @@ impl DownstreamChannelState {
         downstream_sv1_sender: Sender<json_rpc::Message>,
         downstream_sv1_receiver: Receiver<json_rpc::Message>,
         sv1_server_sender: Sender<(DownstreamId, json_rpc::Message)>,
-        sv1_server_broadcast: broadcast::Sender<(
-            ChannelId,
-            Option<DownstreamId>,
-            json_rpc::Message,
-        )>,
+        sv1_server_receiver: Receiver<json_rpc::Message>,
         connection_token: CancellationToken,
     ) -> Self {
         Self {
             downstream_sv1_receiver,
             downstream_sv1_sender,
-            sv1_server_broadcast,
+            sv1_server_receiver,
             sv1_server_sender,
             connection_token,
         }

--- a/miner-apps/translator/src/lib/sv1/downstream/downstream.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream/downstream.rs
@@ -2,7 +2,6 @@ use crate::{
     error::{self, TproxyError, TproxyErrorKind, TproxyResult},
     status::{handle_error, StatusSender},
     sv1::downstream::{channel::DownstreamChannelState, data::DownstreamData},
-    utils::AGGREGATED_CHANNEL_ID,
 };
 use async_channel::{Receiver, Sender};
 use std::{
@@ -23,9 +22,8 @@ use stratum_apps::{
         },
     },
     task_manager::TaskManager,
-    utils::types::{ChannelId, DownstreamId, Hashrate},
+    utils::types::{DownstreamId, Hashrate},
 };
-use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -60,11 +58,7 @@ impl Downstream {
         downstream_sv1_sender: Sender<json_rpc::Message>,
         downstream_sv1_receiver: Receiver<json_rpc::Message>,
         sv1_server_sender: Sender<(DownstreamId, json_rpc::Message)>,
-        sv1_server_broadcast: broadcast::Sender<(
-            ChannelId,
-            Option<DownstreamId>,
-            json_rpc::Message,
-        )>,
+        sv1_server_receiver: Receiver<json_rpc::Message>,
         target: Target,
         hashrate: Option<Hashrate>,
         connection_token: CancellationToken,
@@ -74,7 +68,7 @@ impl Downstream {
             downstream_sv1_sender,
             downstream_sv1_receiver,
             sv1_server_sender,
-            sv1_server_broadcast,
+            sv1_server_receiver,
             connection_token,
         );
         Self {
@@ -103,10 +97,6 @@ impl Downstream {
         status_sender: StatusSender,
         task_manager: Arc<TaskManager>,
     ) {
-        let mut sv1_server_receiver = self
-            .downstream_channel_state
-            .sv1_server_broadcast
-            .subscribe();
         let downstream_id = self.downstream_id;
         task_manager.spawn(async move {
             // we just spawned a new task that's relevant to fallback coordination
@@ -138,7 +128,7 @@ impl Downstream {
                     }
 
                     // Handle server -> downstream message
-                    res = self.handle_sv1_server_message(&mut sv1_server_receiver) => {
+                    res = self.handle_sv1_server_message() => {
                         if let Err(e) = res {
                             error!("Downstream {downstream_id}: error in server message handler: {e:?}");
                             if handle_error(&status_sender, e).await {
@@ -178,25 +168,16 @@ impl Downstream {
     ///   complete
     /// - On handshake completion: sends cached messages in correct order (set_difficulty first,
     ///   then notify)
-    pub async fn handle_sv1_server_message(
-        &self,
-        sv1_server_receiver: &mut broadcast::Receiver<(
-            ChannelId,
-            Option<DownstreamId>,
-            json_rpc::Message,
-        )>,
-    ) -> TproxyResult<(), error::Downstream> {
-        match sv1_server_receiver.recv().await {
-            Ok((channel_id, downstream_id, message)) => {
-                let my_channel_id = self.downstream_data.super_safe_lock(|d| d.channel_id);
-                let my_downstream_id = self.downstream_id;
+    pub async fn handle_sv1_server_message(&self) -> TproxyResult<(), error::Downstream> {
+        match self
+            .downstream_channel_state
+            .sv1_server_receiver
+            .recv()
+            .await
+        {
+            Ok(message) => {
+                let downstream_id = self.downstream_id;
                 let handshake_complete = self.sv1_handshake_complete.load(Ordering::SeqCst);
-                let id_matches = (my_channel_id == Some(channel_id)
-                    || channel_id == AGGREGATED_CHANNEL_ID)
-                    && (downstream_id.is_none() || downstream_id == Some(my_downstream_id));
-                if !id_matches {
-                    return Ok(()); // Message not intended for this downstream
-                }
 
                 // Handle messages based on message type and handshake state
                 if let Message::Notification(notification) = &message {
@@ -259,7 +240,7 @@ impl Downstream {
                                                 "Down: Failed to send mining.set_difficulty to downstream: {:?}",
                                                 e
                                             );
-                                            TproxyError::disconnect(TproxyErrorKind::ChannelErrorSender, downstream_id.unwrap_or(0))
+                                            TproxyError::disconnect(TproxyErrorKind::ChannelErrorSender, downstream_id)
                                         })?;
                                 }
 
@@ -271,7 +252,7 @@ impl Downstream {
                                         .await
                                         .map_err(|e| {
                                             error!("Down: Failed to send mining.notify to downstream: {:?}", e);
-                                            TproxyError::disconnect(TproxyErrorKind::ChannelErrorSender, downstream_id.unwrap_or(0))
+                                            TproxyError::disconnect(TproxyErrorKind::ChannelErrorSender, downstream_id)
                                         })?;
                                 }
                                 return Ok(());
@@ -289,7 +270,7 @@ impl Downstream {
                                         );
                                         TproxyError::disconnect(
                                             TproxyErrorKind::ChannelErrorSender,
-                                            downstream_id.unwrap_or(0),
+                                            downstream_id,
                                         )
                                     })?;
                             }
@@ -326,12 +307,11 @@ impl Downstream {
                 }
             }
             Err(e) => {
-                let downstream_id = self.downstream_id;
                 error!(
                     "Sv1 message handler error for downstream {}: {:?}",
-                    downstream_id, e
+                    self.downstream_id, e
                 );
-                return Err(TproxyError::disconnect(e, downstream_id));
+                return Err(TproxyError::shutdown(e));
             }
         }
 

--- a/miner-apps/translator/src/lib/sv1/downstream/downstream.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream/downstream.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 use async_channel::{Receiver, Sender};
 use std::{
+    net::SocketAddr,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -43,6 +44,7 @@ use tracing::{debug, error, info, warn};
 #[derive(Clone, Debug)]
 pub struct Downstream {
     pub downstream_id: DownstreamId,
+    pub peer_addr: SocketAddr,
     pub downstream_data: Arc<Mutex<DownstreamData>>,
     pub downstream_channel_state: DownstreamChannelState,
     // Flag to track if SV1 handshake is complete (subscribe + authorize)
@@ -55,6 +57,7 @@ impl Downstream {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         downstream_id: DownstreamId,
+        peer_addr: SocketAddr,
         downstream_sv1_sender: Sender<json_rpc::Message>,
         downstream_sv1_receiver: Receiver<json_rpc::Message>,
         sv1_server_sender: Sender<(DownstreamId, json_rpc::Message)>,
@@ -73,6 +76,7 @@ impl Downstream {
         );
         Self {
             downstream_id,
+            peer_addr,
             downstream_data,
             downstream_channel_state,
             sv1_handshake_complete: Arc::new(AtomicBool::new(false)),

--- a/miner-apps/translator/src/lib/sv1/sv1_server/channel.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/channel.rs
@@ -1,16 +1,16 @@
 use async_channel::{unbounded, Receiver, Sender};
-use stratum_apps::stratum_core::parsers_sv2::{Mining, Tlv};
-
+use std::{collections::HashMap, sync::Arc};
 use stratum_apps::{
-    stratum_core::sv1_api::json_rpc,
-    utils::types::{ChannelId, DownstreamId},
+    custom_mutex::Mutex,
+    stratum_core::parsers_sv2::{Mining, Tlv},
 };
-use tokio::sync::broadcast;
+
+use stratum_apps::{stratum_core::sv1_api::json_rpc, utils::types::DownstreamId};
 
 #[derive(Clone)]
 pub struct Sv1ServerChannelState {
     pub sv1_server_to_downstream_sender:
-        broadcast::Sender<(ChannelId, Option<DownstreamId>, json_rpc::Message)>,
+        Arc<Mutex<HashMap<DownstreamId, Sender<json_rpc::Message>>>>,
     pub downstream_to_sv1_server_sender: Sender<(DownstreamId, json_rpc::Message)>,
     pub downstream_to_sv1_server_receiver: Receiver<(DownstreamId, json_rpc::Message)>,
     pub channel_manager_receiver: Receiver<(Mining<'static>, Option<Vec<Tlv>>)>,
@@ -23,11 +23,10 @@ impl Sv1ServerChannelState {
         channel_manager_receiver: Receiver<(Mining<'static>, Option<Vec<Tlv>>)>,
         channel_manager_sender: Sender<(Mining<'static>, Option<Vec<Tlv>>)>,
     ) -> Self {
-        let (sv1_server_to_downstream_sender, _) = broadcast::channel(1000);
         let (downstream_to_sv1_server_sender, downstream_to_sv1_server_receiver) = unbounded();
 
         Self {
-            sv1_server_to_downstream_sender,
+            sv1_server_to_downstream_sender: Arc::new(Mutex::new(HashMap::new())),
             downstream_to_sv1_server_receiver,
             downstream_to_sv1_server_sender,
             channel_manager_receiver,
@@ -40,7 +39,5 @@ impl Sv1ServerChannelState {
         self.channel_manager_sender.close();
         self.downstream_to_sv1_server_receiver.close();
         self.downstream_to_sv1_server_sender.close();
-        self.channel_manager_receiver.close();
-        self.channel_manager_sender.close();
     }
 }

--- a/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
@@ -151,24 +151,26 @@ impl Sv1Server {
         }
 
         // Process immediate set_difficulty updates (for new_target >= upstream_target)
-        for (channel_id, downstream_id, target) in immediate_updates {
+        for (_channel_id, downstream_id, target) in immediate_updates {
             // Send set_difficulty message immediately
             if let Ok(set_difficulty_msg) = build_sv1_set_difficulty_from_sv2_target(target) {
-                if let Err(e) = self
+                let downstream_id = downstream_id.unwrap_or(0);
+                if let Some(sender) = self
                     .sv1_server_channel_state
                     .sv1_server_to_downstream_sender
-                    .send((channel_id, downstream_id, set_difficulty_msg))
+                    .super_safe_lock(|downstream| downstream.get(&downstream_id).cloned())
                 {
-                    error!(
-                        "Failed to send immediate SetDifficulty message to downstream {}: {:?}",
-                        downstream_id.unwrap_or(0),
-                        e
-                    );
-                } else {
-                    trace!(
-                        "Sent immediate SetDifficulty to downstream {} (new_target >= upstream_target)",
-                        downstream_id.unwrap_or(0)
-                    );
+                    if let Err(e) = sender.send(set_difficulty_msg).await {
+                        error!(
+                            "Failed to send immediate SetDifficulty message to downstream {}: {:?}",
+                            downstream_id, e
+                        );
+                    } else {
+                        trace!(
+                            "Sent immediate SetDifficulty to downstream {} (new_target >= upstream_target)",
+                            downstream_id
+                        );
+                    }
                 }
             }
         }
@@ -347,22 +349,23 @@ impl Sv1Server {
             channel_id
         );
 
-        let affected = self.downstreams.iter().find(|downstream| {
-            downstream
-                .downstream_data
-                .super_safe_lock(|d| d.channel_id == Some(channel_id))
-        });
-
-        let Some(downstream) = affected else {
+        let Some(downstream_id) = self
+            .channel_id_to_downstream_id
+            .super_safe_lock(|map| map.get(&channel_id).cloned())
+        else {
             warn!("No downstream found for channel {}", channel_id);
             return;
         };
 
-        let downstream_id = downstream.downstream_id;
-
-        downstream.downstream_data.super_safe_lock(|d| {
-            d.set_upstream_target(new_upstream_target, downstream_id);
-        });
+        {
+            let Some(downstream) = self.downstreams.get(&downstream_id) else {
+                warn!("No downstream found for downstream_id {}", downstream_id);
+                return;
+            };
+            downstream.downstream_data.super_safe_lock(|d| {
+                d.set_upstream_target(new_upstream_target, downstream_id);
+            });
+        }
 
         trace!("Updated upstream target for downstream {}", downstream_id);
 
@@ -422,19 +425,6 @@ impl Sv1Server {
         difficulty_updates: Vec<PendingTargetUpdate>,
     ) {
         for update in difficulty_updates {
-            let channel_id = self
-                .downstreams
-                .get(&update.downstream_id)
-                .and_then(|ds| ds.downstream_data.super_safe_lock(|d| d.channel_id));
-
-            let Some(channel_id) = channel_id else {
-                trace!(
-                    "Skipping SetDifficulty for downstream {}: no channel_id yet",
-                    update.downstream_id
-                );
-                continue;
-            };
-
             let set_difficulty_msg =
                 match build_sv1_set_difficulty_from_sv2_target(update.new_target) {
                     Ok(msg) => msg,
@@ -447,17 +437,19 @@ impl Sv1Server {
                     }
                 };
 
-            if let Err(e) = self
+            if let Some(sender) = self
                 .sv1_server_channel_state
                 .sv1_server_to_downstream_sender
-                .send((channel_id, Some(update.downstream_id), set_difficulty_msg))
+                .super_safe_lock(|downstream| downstream.get(&update.downstream_id).cloned())
             {
-                error!(
-                    "Failed to send SetDifficulty to downstream {}: {:?}",
-                    update.downstream_id, e
-                );
-            } else {
-                trace!("Sent SetDifficulty to downstream {}", update.downstream_id);
+                if let Err(e) = sender.send(set_difficulty_msg).await {
+                    error!(
+                        "Failed to send SetDifficulty to downstream {}: {:?}",
+                        update.downstream_id, e
+                    );
+                } else {
+                    trace!("Sent SetDifficulty to downstream {}", update.downstream_id);
+                }
             }
         }
     }

--- a/miner-apps/translator/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/sv1_server.rs
@@ -75,6 +75,7 @@ pub struct Sv1Server {
     pub(crate) request_id_factory: Arc<AtomicU32>,
     pub(crate) downstreams: Arc<DashMap<DownstreamId, Downstream>>,
     pub(crate) request_id_to_downstream_id: Arc<DashMap<RequestId, DownstreamId>>,
+    pub(crate) channel_id_to_downstream_id: Arc<Mutex<HashMap<ChannelId, DownstreamId>>>,
     pub(crate) vardiff: Arc<DashMap<DownstreamId, Arc<Mutex<VardiffState>>>>,
     /// HashMap to store the SetNewPrevHash for each channel
     /// Used in both aggregated and non-aggregated mode
@@ -88,6 +89,56 @@ pub struct Sv1Server {
 
 #[cfg_attr(not(test), hotpath::measure_all)]
 impl Sv1Server {
+    /// Sends a message to downstream(s) for the given channel_id.
+    ///
+    /// In aggregated mode the channel manager rewrites the job's channel_id to
+    /// `AGGREGATED_CHANNEL_ID` before forwarding, which signals a broadcast: send to every
+    /// connected downstream.
+    async fn send_to_channel(
+        &self,
+        channel_id: ChannelId,
+        msg: stratum_apps::stratum_core::sv1_api::json_rpc::Message,
+    ) {
+        if channel_id == AGGREGATED_CHANNEL_ID {
+            let downstream_senders = self
+                .sv1_server_channel_state
+                .sv1_server_to_downstream_sender
+                .super_safe_lock(|downstream_channels| downstream_channels.clone());
+            // Broadcast to every connected downstream.
+            for (downstream_id, sender) in downstream_senders {
+                if let Err(e) = sender.send(msg.clone()).await {
+                    warn!(
+                        "Failed to send notify to downstream {}: channel closed: {}",
+                        downstream_id, e
+                    );
+                }
+            }
+        } else {
+            // Non-aggregated: send to the single downstream that owns this channel_id.
+            let downstream_id = match self
+                .channel_id_to_downstream_id
+                .super_safe_lock(|map| map.get(&channel_id).cloned())
+            {
+                Some(id) => id,
+                None => return,
+            };
+
+            let sender = self
+                .sv1_server_channel_state
+                .sv1_server_to_downstream_sender
+                .super_safe_lock(|ch| ch.get(&downstream_id).cloned());
+
+            let Some(sender) = sender else { return };
+
+            if let Err(e) = sender.send(msg).await {
+                warn!(
+                    "Failed to send notify to downstream {}: channel closed: {}",
+                    downstream_id, e
+                );
+            }
+        }
+    }
+
     /// Cleans up server state and closes communication channels.
     pub fn cleanup(&self) {
         self.prevhashes.clear();
@@ -96,6 +147,8 @@ impl Sv1Server {
             self.vardiff.clear();
         }
         self.downstreams.clear();
+        self.channel_id_to_downstream_id
+            .super_safe_lock(|map| map.clear());
         self.request_id_to_downstream_id.clear();
         self.pending_target_updates
             .safe_lock(|updates| updates.clear())
@@ -134,6 +187,7 @@ impl Sv1Server {
             request_id_factory: Arc::new(AtomicU32::new(1)),
             downstreams: Arc::new(DashMap::new()),
             request_id_to_downstream_id: Arc::new(DashMap::new()),
+            channel_id_to_downstream_id: Arc::new(Mutex::new(HashMap::new())),
             vardiff: Arc::new(DashMap::new()),
             prevhashes: Arc::new(DashMap::new()),
             pending_target_updates: Arc::new(Mutex::new(Vec::new())),
@@ -235,12 +289,15 @@ impl Sv1Server {
                                     connection_token.clone(),
                                 ).await;
                                 let downstream_id = self.downstream_id_factory.fetch_add(1, Ordering::Relaxed);
+                                let (sv1_server_sender, sv1_server_receiver) = async_channel::unbounded();
+                                self.sv1_server_channel_state.sv1_server_to_downstream_sender.super_safe_lock(|map| map.insert(downstream_id, sv1_server_sender));
+
                                 let downstream = Downstream::new(
                                     downstream_id,
                                     connection.sender().clone(),
                                     connection.receiver().clone(),
                                     self.sv1_server_channel_state.downstream_to_sv1_server_sender.clone(),
-                                    self.sv1_server_channel_state.sv1_server_to_downstream_sender.clone(),
+                                    sv1_server_receiver,
                                     first_target,
                                     Some(self.config.downstream_difficulty_config.min_individual_miner_hashrate),
                                     connection_token,
@@ -323,78 +380,79 @@ impl Sv1Server {
             .await
             .map_err(TproxyError::shutdown)?;
 
-        let downstream = self.downstreams.get(&downstream_id);
+        let Some(downstream) = self
+            .downstreams
+            .get(&downstream_id)
+            .map(|r| r.value().clone())
+        else {
+            return Ok(());
+        };
 
-        if let Some(downstream) = downstream {
-            let channel_id = downstream
+        let channel_id = downstream
+            .downstream_data
+            .super_safe_lock(|data| data.channel_id);
+        if channel_id.is_none() {
+            let is_first_message = downstream
                 .downstream_data
-                .super_safe_lock(|data| data.channel_id);
-            if channel_id.is_none() {
-                let is_first_message = downstream
-                    .downstream_data
-                    .super_safe_lock(|d| d.queued_sv1_handshake_messages.is_empty());
-                if is_first_message {
-                    self.handle_open_channel_request(downstream_id).await?;
-                    debug!(
-                        "Down: Sent OpenChannel request for downstream {}",
-                        downstream_id
-                    );
-                }
-                debug!("Down: Queuing Sv1 message until channel is established");
-                downstream.downstream_data.super_safe_lock(|data| {
-                    data.queued_sv1_handshake_messages
-                        .push(downstream_message.clone())
-                });
-                return Ok(());
+                .super_safe_lock(|d| d.queued_sv1_handshake_messages.is_empty());
+            if is_first_message {
+                self.handle_open_channel_request(downstream_id).await?;
+                debug!(
+                    "Down: Sent OpenChannel request for downstream {}",
+                    downstream_id
+                );
             }
+            debug!("Down: Queuing Sv1 message until channel is established");
+            downstream.downstream_data.super_safe_lock(|data| {
+                data.queued_sv1_handshake_messages
+                    .push(downstream_message.clone())
+            });
+            return Ok(());
+        }
 
-            let is_authorize = is_mining_authorize(&downstream_message);
+        let is_authorize = is_mining_authorize(&downstream_message);
 
-            let response = self
-                .clone()
-                .handle_message(Some(downstream_id), downstream_message);
+        let response = self
+            .clone()
+            .handle_message(Some(downstream_id), downstream_message);
 
-            match response {
-                Ok(Some(response_msg)) => {
-                    debug!("Down: Sending Sv1 message to downstream: {}", response_msg);
-                    downstream
-                        .downstream_channel_state
-                        .downstream_sv1_sender
-                        .send(response_msg.into())
-                        .await
-                        .map_err(|error| {
-                            error!("Down: Failed to send message to downstream: {error:?}");
-                            TproxyError::disconnect(
-                                TproxyErrorKind::ChannelErrorSender,
-                                downstream_id,
-                            )
-                        })?;
+        match response {
+            Ok(Some(response_msg)) => {
+                debug!("Down: Sending Sv1 message to downstream: {}", response_msg);
+                downstream
+                    .downstream_channel_state
+                    .downstream_sv1_sender
+                    .send(response_msg.into())
+                    .await
+                    .map_err(|error| {
+                        error!("Down: Failed to send message to downstream: {error:?}");
+                        TproxyError::disconnect(TproxyErrorKind::ChannelErrorSender, downstream_id)
+                    })?;
 
-                    // Check if this was an authorize message and handle sv1 handshake completion
-                    if is_authorize {
-                        info!("Down: Handling mining.authorize after handshake completion");
-                        if let Err(e) = downstream.handle_sv1_handshake_completion().await {
-                            error!("Down: Failed to handle handshake completion: {:?}", e);
-                            return Err(TproxyError::disconnect(e, downstream_id));
-                        }
+                // Check if this was an authorize message and handle sv1 handshake completion
+                if is_authorize {
+                    info!("Down: Handling mining.authorize after handshake completion");
+                    if let Err(e) = downstream.handle_sv1_handshake_completion().await {
+                        error!("Down: Failed to handle handshake completion: {:?}", e);
+                        return Err(TproxyError::disconnect(e, downstream_id));
                     }
                 }
-                Ok(None) => {
-                    // Message was handled but no response needed
-                }
-                Err(e) => {
-                    error!("Down: Error handling downstream message: {:?}", e);
-                    return Err(TproxyError::disconnect(e, downstream_id));
-                }
             }
+            Ok(None) => {
+                // Message was handled but no response needed
+            }
+            Err(e) => {
+                error!("Down: Error handling downstream message: {:?}", e);
+                return Err(TproxyError::disconnect(e, downstream_id));
+            }
+        }
 
-            // Check if there's a pending share to send to the Sv1Server
-            let pending_share = downstream
-                .downstream_data
-                .super_safe_lock(|d| d.pending_share.take());
-            if let Some(share) = pending_share {
-                self.handle_submit_shares(share).await?;
-            }
+        // Check if there's a pending share to send to the Sv1Server
+        let pending_share = downstream
+            .downstream_data
+            .super_safe_lock(|d| d.pending_share.take());
+        if let Some(share) = pending_share {
+            self.handle_submit_shares(share).await?;
         }
 
         Ok(())
@@ -453,11 +511,16 @@ impl Sv1Server {
 
         // Only add TLV fields with user identity in non-aggregated mode
         let tlv_fields = if is_non_aggregated() {
-            let Some(downstream) = self.downstreams.get(&message.downstream_id) else {
-                return Err(TproxyError::disconnect(
-                    TproxyErrorKind::DownstreamNotPresent(message.downstream_id),
-                    message.downstream_id,
-                ));
+            let Some(downstream) = self
+                .downstreams
+                .get(&message.downstream_id)
+                .map(|r| r.value().clone())
+            else {
+                warn!(
+                    "Downstream {} disconnected before share could be submitted, dropping share",
+                    message.downstream_id
+                );
+                return Ok(());
             };
             let user_identity = downstream
                 .downstream_data
@@ -577,13 +640,16 @@ impl Sv1Server {
                             d.set_upstream_target(initial_target, downstream_id);
                         })
                         .map_err(TproxyError::shutdown)?;
+                    self.channel_id_to_downstream_id
+                        .super_safe_lock(|map| map.insert(m.channel_id, downstream_id));
 
                     // Process all queued messages now that channel is established
-                    let queued_messages = downstream
-                        .downstream_data
-                        .safe_lock(|d| std::mem::take(&mut d.queued_sv1_handshake_messages))
-                        .ok();
-                    if let Some(queued_messages) = queued_messages {
+                    let queued_messages = downstream.downstream_data.super_safe_lock(|d| {
+                        let messages = d.queued_sv1_handshake_messages.clone();
+                        d.queued_sv1_handshake_messages.clear();
+                        messages
+                    });
+                    {
                         if !queued_messages.is_empty() {
                             info!(
                                 "Processing {} queued Sv1 messages for downstream {}",
@@ -647,10 +713,18 @@ impl Sv1Server {
                             ))
                         })?;
                     // send the set_difficulty message to the downstream
-                    self.sv1_server_channel_state
+                    if let Some(sender) = self
+                        .sv1_server_channel_state
                         .sv1_server_to_downstream_sender
-                        .send((m.channel_id, None, set_difficulty))
-                        .map_err(|_| TproxyError::shutdown(TproxyErrorKind::ChannelErrorSender))?;
+                        .super_safe_lock(|map| map.get(&downstream_id).cloned())
+                    {
+                        sender.send(set_difficulty).await.map_err(|_| {
+                            TproxyError::disconnect(
+                                TproxyErrorKind::ChannelErrorSender,
+                                downstream_id,
+                            )
+                        })?;
+                    }
                 } else {
                     error!("Downstream not found for downstream_id: {}", downstream_id);
                 }
@@ -661,7 +735,12 @@ impl Sv1Server {
                     "Received NewExtendedMiningJob for channel id: {}",
                     m.channel_id
                 );
-                if let Some(prevhash) = self.prevhashes.get(&m.channel_id) {
+                // Clone the prevhash immediately so the DashMap guard is not held across .await.
+                if let Some(prevhash) = self
+                    .prevhashes
+                    .get(&m.channel_id)
+                    .map(|r| r.value().clone())
+                {
                     let prevhash = prevhash.as_static();
                     let clean_jobs = m.job_id == prevhash.job_id;
                     let notify =
@@ -676,16 +755,18 @@ impl Sv1Server {
                         AGGREGATED_CHANNEL_ID
                     };
 
-                    let mut channel_jobs = self.valid_sv1_jobs.entry(job_channel_id).or_default();
-                    if clean_jobs {
-                        channel_jobs.clear();
+                    {
+                        let mut channel_jobs =
+                            self.valid_sv1_jobs.entry(job_channel_id).or_default();
+                        if clean_jobs {
+                            channel_jobs.clear();
+                        }
+                        channel_jobs.push(notify_parsed);
                     }
-                    channel_jobs.push(notify_parsed);
 
-                    let _ = self
-                        .sv1_server_channel_state
-                        .sv1_server_to_downstream_sender
-                        .send((m.channel_id, None, notify.into()));
+                    let notify_msg: stratum_apps::stratum_core::sv1_api::json_rpc::Message =
+                        notify.into();
+                    self.send_to_channel(job_channel_id, notify_msg).await;
                 }
             }
 
@@ -734,7 +815,17 @@ impl Sv1Server {
         downstream_id: DownstreamId,
     ) -> TproxyResult<(), error::Sv1Server> {
         let config = &self.config.downstream_difficulty_config;
-        let downstream = self.downstreams.get(&downstream_id).unwrap();
+        let Some(downstream) = self
+            .downstreams
+            .get(&downstream_id)
+            .map(|r| r.value().clone())
+        else {
+            warn!(
+                "Downstream {} disconnected before channel could be opened, skipping",
+                downstream_id
+            );
+            return Ok(());
+        };
 
         let hashrate = config.min_individual_miner_hashrate as f64;
         let shares_per_min = config.shares_per_minute as f64;
@@ -783,22 +874,6 @@ impl Sv1Server {
         Ok(())
     }
 
-    /// Retrieves a downstream connection by ID from the provided map.
-    ///
-    /// # Arguments
-    /// * `downstream_id` - The ID of the downstream connection to find
-    /// * `downstream` - HashMap containing downstream connections
-    ///
-    /// # Returns
-    /// * `Some(Downstream)` - If a downstream with the given ID exists
-    /// * `None` - If no downstream with the given ID is found
-    pub fn get_downstream(
-        downstream_id: DownstreamId,
-        downstream: HashMap<DownstreamId, Downstream>,
-    ) -> Option<Downstream> {
-        downstream.get(&downstream_id).cloned()
-    }
-
     /// Extracts the downstream ID from a Downstream instance.
     ///
     /// # Arguments
@@ -826,6 +901,10 @@ impl Sv1Server {
             // Only remove from vardiff map if vardiff is enabled
             self.vardiff.remove(&downstream_id);
         }
+        self.sv1_server_channel_state
+            .sv1_server_to_downstream_sender
+            .super_safe_lock(|map| map.remove(&downstream_id));
+
         let current_downstream = self.downstreams.remove(&downstream_id);
 
         if let Some((downstream_id, downstream)) = current_downstream {
@@ -838,6 +917,8 @@ impl Sv1Server {
 
             let channel_id = downstream.downstream_data.super_safe_lock(|d| d.channel_id);
             if let Some(channel_id) = channel_id {
+                self.channel_id_to_downstream_id
+                    .super_safe_lock(|map| map.remove(&channel_id));
                 if !self.config.aggregate_channels {
                     info!("Sending CloseChannel message: {channel_id} for downstream: {downstream_id}");
                     let reason_code =
@@ -922,31 +1003,36 @@ impl Sv1Server {
         target: Target,
         derived_hashrate: Option<f64>,
     ) -> TproxyResult<(), error::Sv1Server> {
-        for downstream in self.downstreams.iter() {
-            let downstream_id = downstream.key();
-            let downstream = downstream.value();
-            let channel_id = downstream.downstream_data.super_safe_lock(|d| {
-                let channel_id = d.channel_id?;
-
-                d.set_upstream_target(target, *downstream_id);
-                d.set_pending_target(target, *downstream_id);
-
-                // Update pending hashrate derived from the upstream target
-                if let Some(hr) = derived_hashrate {
-                    d.set_pending_hashrate(Some(hr as f32), *downstream_id);
+        let tasks: Vec<(DownstreamId, _)> = self
+            .downstreams
+            .iter()
+            .filter_map(|entry| {
+                let downstream_id = *entry.key();
+                let has_channel = entry.value().downstream_data.super_safe_lock(|d| {
+                    let channel_id = d.channel_id?;
+                    d.set_upstream_target(target, downstream_id);
+                    d.set_pending_target(target, downstream_id);
+                    if let Some(hr) = derived_hashrate {
+                        d.set_pending_hashrate(Some(hr as f32), downstream_id);
+                    }
+                    Some(channel_id)
+                });
+                if has_channel.is_none() {
+                    trace!(
+                        "Skipping downstream {}: no channel_id set (vardiff disabled)",
+                        downstream_id
+                    );
+                    return None;
                 }
+                let sender = self
+                    .sv1_server_channel_state
+                    .sv1_server_to_downstream_sender
+                    .super_safe_lock(|map| map.get(&downstream_id).cloned())?;
+                Some((downstream_id, sender))
+            })
+            .collect();
 
-                Some(channel_id)
-            });
-
-            let Some(channel_id) = channel_id else {
-                trace!(
-                    "Skipping downstream {}: no channel_id set (vardiff disabled)",
-                    downstream_id
-                );
-                continue;
-            };
-
+        for (downstream_id, sender) in tasks {
             let set_difficulty_msg = match build_sv1_set_difficulty_from_sv2_target(target) {
                 Ok(msg) => msg,
                 Err(e) => {
@@ -957,12 +1043,7 @@ impl Sv1Server {
                     return Err(TproxyError::shutdown(e));
                 }
             };
-
-            if let Err(e) = self
-                .sv1_server_channel_state
-                .sv1_server_to_downstream_sender
-                .send((channel_id, Some(*downstream_id), set_difficulty_msg))
-            {
+            if let Err(e) = sender.send(set_difficulty_msg).await {
                 error!(
                     "Failed to send SetDifficulty to downstream {}: {:?}",
                     downstream_id, e
@@ -987,13 +1068,10 @@ impl Sv1Server {
         target: Target,
         derived_hashrate: Option<f64>,
     ) -> TproxyResult<(), error::Sv1Server> {
-        let affected = self.downstreams.iter().find(|downstream| {
-            downstream
-                .downstream_data
-                .super_safe_lock(|d| d.channel_id == Some(channel_id))
-        });
-
-        let Some(downstream) = affected else {
+        let Some(downstream_id) = self
+            .channel_id_to_downstream_id
+            .super_safe_lock(|map| map.get(&channel_id).cloned())
+        else {
             warn!(
                 "No downstream found for channel {} when vardiff is disabled",
                 channel_id
@@ -1016,16 +1094,15 @@ impl Sv1Server {
             ));
         };
 
-        let downstream_id = downstream.key();
-        let downstream = downstream.value();
-
+        let Some(downstream) = self.downstreams.get(&downstream_id) else {
+            return Ok(());
+        };
         downstream.downstream_data.super_safe_lock(|d| {
-            d.set_upstream_target(target, *downstream_id);
-            d.set_pending_target(target, *downstream_id);
-
+            d.set_upstream_target(target, downstream_id);
+            d.set_pending_target(target, downstream_id);
             // Update pending hashrate derived from the upstream target
             if let Some(hr) = derived_hashrate {
-                d.set_pending_hashrate(Some(hr as f32), *downstream_id);
+                d.set_pending_hashrate(Some(hr as f32), downstream_id);
             }
         });
 
@@ -1040,21 +1117,24 @@ impl Sv1Server {
             }
         };
 
-        if let Err(e) = self
+        let sender = self
             .sv1_server_channel_state
             .sv1_server_to_downstream_sender
-            .send((channel_id, Some(*downstream_id), set_difficulty_msg))
-        {
-            error!(
-                "Failed to send SetDifficulty to downstream {}: {:?}",
-                downstream_id, e
-            );
-            return Err(TproxyError::shutdown(TproxyErrorKind::ChannelErrorSender));
-        } else {
-            debug!(
-                "Sent SetDifficulty to downstream {} for channel {} (vardiff disabled)",
-                downstream_id, channel_id
-            );
+            .super_safe_lock(|map| map.get(&downstream_id).cloned());
+
+        if let Some(sender) = sender {
+            if let Err(e) = sender.send(set_difficulty_msg).await {
+                error!(
+                    "Failed to send SetDifficulty to downstream {}: {:?}",
+                    downstream_id, e
+                );
+                return Err(TproxyError::shutdown(TproxyErrorKind::ChannelErrorSender));
+            } else {
+                debug!(
+                    "Sent SetDifficulty to downstream {} for channel {} (vardiff disabled)",
+                    downstream_id, channel_id
+                );
+            }
         }
         Ok(())
     }
@@ -1169,14 +1249,18 @@ impl Sv1Server {
                         downstream_id, notify.job_id, notify.time.0
                     );
 
-                    if let Err(e) = self
+                    let sent = match self
                         .sv1_server_channel_state
                         .sv1_server_to_downstream_sender
-                        .send((channel_id.unwrap_or(0), Some(downstream_id), notify.into()))
+                        .super_safe_lock(|map| map.get(&downstream_id).cloned())
                     {
+                        Some(sender) => sender.send(notify.into()).await.is_ok(),
+                        None => false,
+                    };
+                    if !sent {
                         warn!(
-                            "Failed to send keepalive job to downstream {}: {:?}",
-                            downstream_id, e
+                            "Failed to send keepalive job to downstream {}",
+                            downstream_id
                         );
                     } else if let Some(downstream) = self.downstreams.get(&downstream_id) {
                         downstream.downstream_data.super_safe_lock(|d| {
@@ -1263,7 +1347,7 @@ mod tests {
     use super::*;
     use crate::config::{DownstreamDifficultyConfig, TranslatorConfig, Upstream};
     use async_channel::unbounded;
-    use std::{collections::HashMap, str::FromStr};
+    use std::str::FromStr;
     use stratum_apps::key_utils::Secp256k1PublicKey;
 
     fn create_test_config() -> TranslatorConfig {
@@ -1321,15 +1405,6 @@ mod tests {
         let server = Sv1Server::new(addr, cm_receiver, cm_sender, config);
 
         assert!(server.config.downstream_difficulty_config.enable_vardiff);
-    }
-
-    #[test]
-    fn test_get_downstream_basic() {
-        let downstreams = HashMap::new();
-
-        // Test non-existing downstream
-        let not_found = Sv1Server::get_downstream(999, downstreams);
-        assert!(not_found.is_none());
     }
 
     #[tokio::test]

--- a/miner-apps/translator/src/lib/sv1/sv1_server/sv1_server.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/sv1_server.rs
@@ -294,6 +294,7 @@ impl Sv1Server {
 
                                 let downstream = Downstream::new(
                                     downstream_id,
+                                    addr,
                                     connection.sender().clone(),
                                     connection.receiver().clone(),
                                     self.sv1_server_channel_state.downstream_to_sv1_server_sender.clone(),

--- a/miner-apps/translator/src/lib/sv1_monitoring.rs
+++ b/miner-apps/translator/src/lib/sv1_monitoring.rs
@@ -12,6 +12,9 @@ fn downstream_to_sv1_client_info(downstream: &Downstream) -> Option<Sv1ClientInf
         .safe_lock(|dd| Sv1ClientInfo {
             client_id: downstream.downstream_id,
             channel_id: dd.channel_id,
+            peer_ip: Some(downstream.peer_addr.ip().to_string()),
+            peer_port: Some(downstream.peer_addr.port()),
+            asic: None,
             authorized_worker_name: dd.authorized_worker_name.clone(),
             user_identity: dd.user_identity.clone(),
             target_hex: hex::encode(dd.target.to_be_bytes()),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.88.0"
 components = [ "rustfmt", "clippy", "rust-analyzer" ]

--- a/stratum-apps/Cargo.lock
+++ b/stratum-apps/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -71,6 +71,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +107,377 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "asic-rs"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-firmwares-antminer",
+ "asic-rs-firmwares-auradine",
+ "asic-rs-firmwares-avalonminer",
+ "asic-rs-firmwares-bitaxe",
+ "asic-rs-firmwares-braiins",
+ "asic-rs-firmwares-epic",
+ "asic-rs-firmwares-luxminer",
+ "asic-rs-firmwares-marathon",
+ "asic-rs-firmwares-nerdaxe",
+ "asic-rs-firmwares-vnish",
+ "asic-rs-firmwares-whatsminer",
+ "asic-rs-makes-antminer",
+ "asic-rs-makes-auradine",
+ "asic-rs-makes-avalon",
+ "asic-rs-makes-bitaxe",
+ "asic-rs-makes-braiins",
+ "asic-rs-makes-epic",
+ "asic-rs-makes-marathon",
+ "asic-rs-makes-nerdaxe",
+ "asic-rs-makes-whatsminer",
+ "async-stream",
+ "futures",
+ "ipnet",
+ "measurements",
+ "pyo3-build-config",
+ "rand 0.10.1",
+ "rlimit",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "asic-rs-core"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "futures",
+ "macaddr",
+ "measurements",
+ "reqwest",
+ "secrecy",
+ "semver",
+ "serde",
+ "serde_json",
+ "strum",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "asic-rs-firmwares-antminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "async-trait",
+ "chrono",
+ "crc32fast",
+ "diqwest",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-auradine"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-auradine",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-avalonminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-avalon",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "regex",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-bitaxe"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-bitaxe",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-braiins"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "asic-rs-makes-braiins",
+ "async-trait",
+ "chrono",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-epic"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "asic-rs-makes-epic",
+ "asic-rs-makes-whatsminer",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "asic-rs-firmwares-luxminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-marathon"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "asic-rs-makes-marathon",
+ "async-trait",
+ "diqwest",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+]
+
+[[package]]
+name = "asic-rs-firmwares-nerdaxe"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-nerdaxe",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-vnish"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-antminer",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-whatsminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "aes",
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-whatsminer",
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "ecb",
+ "hex",
+ "macaddr",
+ "md5",
+ "md5crypt",
+ "measurements",
+ "semver",
+ "serde_json",
+ "sha2 0.10.9",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "asic-rs-makes-antminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-auradine"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-avalon"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-bitaxe"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-braiins"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-epic"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-marathon"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-nerdaxe"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-whatsminer"
+version = "0.5.0"
+source = "git+https://github.com/256foundation/asic-rs.git?tag=v0.5.0#cd9ee51c6c7de6a069539d7bdb7757c9074d90ab"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +486,40 @@ dependencies = [
  "concurrent-queue",
  "event-listener",
  "futures-core",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -118,6 +538,34 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -321,6 +769,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bs58"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,14 +825,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -385,7 +856,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -395,7 +877,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -415,6 +897,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +921,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codec_sv2"
 version = "5.0.0"
 source = "git+https://github.com/stratum-mining/stratum?branch=main#ab5b17f23d567c41a128776f979a597327f0800c"
@@ -434,8 +938,18 @@ dependencies = [
  "buffer_sv2",
  "framing_sv2",
  "noise_sv2",
- "rand",
+ "rand 0.8.5",
  "tracing",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -445,6 +959,23 @@ source = "git+https://github.com/stratum-mining/stratum?branch=main#ab5b17f23d56
 dependencies = [
  "binary_sv2",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -489,7 +1020,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
 ]
@@ -534,6 +1065,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +1085,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -624,6 +1174,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest_auth"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3054f4e81d395e50822796c5e99ca522e6ba7be98947d6d4b0e5e61640bdb894"
+dependencies = [
+ "digest 0.10.7",
+ "hex",
+ "md-5",
+ "rand 0.8.5",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "diqwest"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d10611d0d3ed31b33e13ec3e31329aa2053aa4f773eb082b597f39a97e68360"
+dependencies = [
+ "digest_auth",
+ "reqwest",
+ "url",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +1236,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ecb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -716,7 +1305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -727,6 +1316,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
+ "crc32fast",
  "miniz_oxide",
  "zlib-rs",
 ]
@@ -736,6 +1326,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -755,6 +1351,12 @@ dependencies = [
  "buffer_sv2",
  "noise_sv2",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -867,8 +1469,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -928,6 +1560,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -940,6 +1581,12 @@ checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1043,6 +1690,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1728,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1150,6 +1836,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,14 +1900,25 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "itoa"
@@ -1224,11 +1927,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "job_declaration_sv2"
 version = "7.0.0"
 source = "git+https://github.com/stratum-mining/stratum?branch=main#ab5b17f23d567c41a128776f979a597327f0800c"
 dependencies = [
  "binary_sv2",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1249,10 +2018,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "libc"
-version = "0.2.182"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1286,6 +2067,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +2095,41 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
+name = "md5crypt"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8db1a978f99f584f2e72601860f68bb2cea9c09f4408f5e83f805db3434fb0"
+dependencies = [
+ "md5",
+]
+
+[[package]]
+name = "measurements"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f72b38901c571007811f0483e64a7e215ac9e6e3688e9f83705a717621d81513"
+dependencies = [
+ "libm",
+ "serde",
+]
 
 [[package]]
 name = "memchr"
@@ -1359,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1375,7 +2206,7 @@ source = "git+https://github.com/stratum-mining/stratum?branch=main#ab5b17f23d56
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
- "rand",
+ "rand 0.8.5",
  "secp256k1 0.28.2",
 ]
 
@@ -1399,6 +2230,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +2249,12 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
@@ -1564,7 +2410,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1576,7 +2422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1597,6 +2443,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1650,6 +2506,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "pyo3-build-config"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,6 +2578,18 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -1671,8 +2604,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1682,7 +2636,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1691,8 +2655,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1709,7 +2688,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
 ]
@@ -1742,6 +2721,68 @@ name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rlimit"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "ron"
@@ -1800,10 +2841,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc-hex"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
+
+[[package]]
+name = "rustls"
+version = "0.23.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -1827,6 +2949,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,7 +2970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
  "bitcoin_hashes 0.13.0",
- "rand",
+ "rand 0.8.5",
  "secp256k1-sys 0.9.2",
 ]
 
@@ -1870,6 +3001,44 @@ checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1954,7 +3123,7 @@ checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -1966,7 +3135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
 ]
 
@@ -2024,12 +3193,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2048,6 +3217,8 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stratum-apps"
 version = "0.3.0"
 dependencies = [
+ "asic-rs",
+ "asic-rs-core",
  "async-channel",
  "axum",
  "base64 0.21.7",
@@ -2061,7 +3232,7 @@ dependencies = [
  "hyper-util",
  "miniscript",
  "prometheus",
- "rand",
+ "rand 0.8.5",
  "rustversion",
  "secp256k1 0.28.2",
  "serde",
@@ -2114,6 +3285,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +3340,9 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -2167,7 +3362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2186,6 +3381,12 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "template_distribution_sv2"
@@ -2264,10 +3465,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.49.0"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -2282,13 +3498,34 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -2389,6 +3626,29 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "async-compression",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "iri-string",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2541,6 +3801,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,12 +3904,183 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2683,11 +4120,29 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -2701,20 +4156,63 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2724,9 +4222,33 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2736,9 +4258,27 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2748,15 +4288,51 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2771,6 +4347,100 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/stratum-apps/Cargo.toml
+++ b/stratum-apps/Cargo.toml
@@ -51,6 +51,8 @@ axum = { version = "0.8.7", optional = true }
 prometheus = { version = "0.13", optional = true }
 utoipa = { version = "5.4.0", features = ["axum_extras"], optional = true }
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"], optional = true }
+asic-rs = { git = "https://github.com/256foundation/asic-rs.git", tag = "v0.5.0", optional = true }
+asic-rs-core = { git = "https://github.com/256foundation/asic-rs.git", tag = "v0.5.0", optional = true }
 
 # Common external dependencies that roles always need
 ext-config = { version = "0.14.0", features = ["toml"], package = "config" }
@@ -64,6 +66,7 @@ network = ["tokio-util", "core"]
 config = []
 rpc = ["serde_json", "hex", "base64", "hyper", "hyper-util", "http-body-util"]
 monitoring = ["serde_json", "axum", "prometheus", "utoipa", "utoipa-swagger-ui"]
+asic-monitoring = ["monitoring", "asic-rs", "asic-rs-core"]
 std = ["bs58/std", "secp256k1/rand-std", "rand/std", "rand/std_rng"]
 core = ["stratum-core"]
 

--- a/stratum-apps/src/monitoring/asic.rs
+++ b/stratum-apps/src/monitoring/asic.rs
@@ -1,0 +1,573 @@
+//! Optional `asic-rs` integration for miner discovery, telemetry, and control.
+
+use std::{
+    collections::HashMap,
+    net::{IpAddr, Ipv4Addr},
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use asic_rs::MinerFactory;
+use asic_rs_core::{
+    config::pools::{PoolConfig, PoolGroupConfig},
+    data::{
+        hashrate::{HashRate, HashRateUnit},
+        miner::MinerData,
+        pool::PoolURL,
+    },
+    traits::miner::{Miner, MinerAuth},
+};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, Semaphore};
+use utoipa::ToSchema;
+
+use super::{
+    AsicDiscoveredMiner, AsicFanTelemetry, AsicHashboardTelemetry, AsicMinerCapabilities,
+    AsicMinerMessage, AsicMinerTelemetry, AsicPoolConfig, AsicPoolData, AsicPoolGroupConfig,
+    AsicPoolGroupData, AsicScanError, AsicScanResponse,
+};
+
+const DEFAULT_OPERATION_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_SCAN_TIMEOUT: Duration = Duration::from_secs(3);
+const DEFAULT_SCAN_CONCURRENCY: usize = 32;
+const MAX_SCAN_CONCURRENCY: usize = 64;
+const MAX_SCAN_TARGETS: usize = 4096;
+
+type MinerHandle = Arc<Mutex<Box<dyn Miner>>>;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicCredentials {
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicScanRequest {
+    /// IPv4 addresses or CIDR blocks to scan. Example: ["192.168.1.0/24"].
+    #[serde(default)]
+    pub targets: Vec<String>,
+    /// Per-host discovery timeout in milliseconds.
+    pub timeout_ms: Option<u64>,
+    /// Maximum number of concurrent discovery probes.
+    pub concurrency: Option<usize>,
+    /// Optional miner API credentials used for probes that require auth.
+    pub auth: Option<AsicCredentials>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicUpdatePoolsRequest {
+    pub pool_groups: Vec<AsicPoolGroupConfig>,
+    /// Optional miner API credentials, not mining pool credentials.
+    pub auth: Option<AsicCredentials>,
+}
+
+#[derive(Clone)]
+pub struct AsicMonitor {
+    factory: Arc<MinerFactory>,
+    miners: Arc<Mutex<HashMap<IpAddr, MinerHandle>>>,
+}
+
+impl Default for AsicMonitor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AsicMonitor {
+    pub fn new() -> Self {
+        Self {
+            factory: Arc::new(MinerFactory::new()),
+            miners: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub async fn telemetry(
+        &self,
+        ip: IpAddr,
+        auth: Option<AsicCredentials>,
+    ) -> Result<AsicMinerTelemetry, String> {
+        let handle = self.miner_for_ip(ip, auth).await?;
+        let guard = handle.lock().await;
+        let data = tokio::time::timeout(DEFAULT_OPERATION_TIMEOUT, guard.get_data())
+            .await
+            .map_err(|_| format!("Timed out reading telemetry from {ip}"))?;
+
+        Ok(miner_data_to_telemetry(data, guard.as_ref()))
+    }
+
+    pub async fn pools(
+        &self,
+        ip: IpAddr,
+        auth: Option<AsicCredentials>,
+    ) -> Result<Vec<AsicPoolGroupConfig>, String> {
+        let handle = self.miner_for_ip(ip, auth).await?;
+        let guard = handle.lock().await;
+        if !guard.supports_pools_config() {
+            return Err("Miner does not support pool configuration".to_string());
+        }
+
+        let pools = tokio::time::timeout(DEFAULT_OPERATION_TIMEOUT, guard.get_pools_config())
+            .await
+            .map_err(|_| format!("Timed out reading pools from {ip}"))?
+            .map_err(|error| format!("Failed reading pools from {ip}: {error}"))?;
+
+        Ok(pools.into_iter().map(pool_group_config_from_asic).collect())
+    }
+
+    pub async fn update_pools(
+        &self,
+        ip: IpAddr,
+        request: AsicUpdatePoolsRequest,
+    ) -> Result<(), String> {
+        let handle = self.miner_for_ip(ip, request.auth).await?;
+        let guard = handle.lock().await;
+        if !guard.supports_pools_config() {
+            return Err("Miner does not support pool configuration".to_string());
+        }
+
+        let pools = request
+            .pool_groups
+            .into_iter()
+            .map(pool_group_config_to_asic)
+            .collect::<Vec<_>>();
+
+        let ok = tokio::time::timeout(DEFAULT_OPERATION_TIMEOUT, guard.set_pools_config(pools))
+            .await
+            .map_err(|_| format!("Timed out updating pools on {ip}"))?
+            .map_err(|error| format!("Failed updating pools on {ip}: {error}"))?;
+
+        if ok {
+            Ok(())
+        } else {
+            Err("Miner rejected pool configuration update".to_string())
+        }
+    }
+
+    pub async fn action(
+        &self,
+        ip: IpAddr,
+        action: &str,
+        auth: Option<AsicCredentials>,
+    ) -> Result<(), String> {
+        let handle = self.miner_for_ip(ip, auth).await?;
+        let guard = handle.lock().await;
+
+        let result = match action {
+            "blink" | "blink_led" | "identify" => {
+                if !guard.supports_set_fault_light() {
+                    return Err("Miner does not support blink LED".to_string());
+                }
+                tokio::time::timeout(DEFAULT_OPERATION_TIMEOUT, guard.set_fault_light(true))
+                    .await
+                    .map_err(|_| format!("Timed out blinking LED on {ip}"))?
+            }
+            "reboot" | "restart" => {
+                if !guard.supports_restart() {
+                    return Err("Miner does not support reboot".to_string());
+                }
+                tokio::time::timeout(DEFAULT_OPERATION_TIMEOUT, guard.restart())
+                    .await
+                    .map_err(|_| format!("Timed out rebooting {ip}"))?
+            }
+            "pause" | "stop" | "stop_mining" => {
+                if !guard.supports_pause() {
+                    return Err("Miner does not support stop mining".to_string());
+                }
+                tokio::time::timeout(DEFAULT_OPERATION_TIMEOUT, guard.pause(None))
+                    .await
+                    .map_err(|_| format!("Timed out stopping mining on {ip}"))?
+            }
+            "resume" | "start" | "start_mining" => {
+                if !guard.supports_resume() {
+                    return Err("Miner does not support start mining".to_string());
+                }
+                tokio::time::timeout(DEFAULT_OPERATION_TIMEOUT, guard.resume(None))
+                    .await
+                    .map_err(|_| format!("Timed out starting mining on {ip}"))?
+            }
+            other => return Err(format!("Unsupported miner action: {other}")),
+        }
+        .map_err(|error| format!("Miner action failed on {ip}: {error}"))?;
+
+        if result {
+            Ok(())
+        } else {
+            Err(format!("Miner action {action} returned false on {ip}"))
+        }
+    }
+
+    pub async fn scan(&self, request: AsicScanRequest) -> Result<AsicScanResponse, String> {
+        let targets = expand_targets(&request.targets)?;
+        let total_targets = targets.len();
+        let timeout = request
+            .timeout_ms
+            .map(Duration::from_millis)
+            .unwrap_or(DEFAULT_SCAN_TIMEOUT)
+            .max(Duration::from_millis(250));
+        let concurrency = request
+            .concurrency
+            .unwrap_or(DEFAULT_SCAN_CONCURRENCY)
+            .clamp(1, MAX_SCAN_CONCURRENCY);
+        let semaphore = Arc::new(Semaphore::new(concurrency));
+
+        let mut handles = Vec::with_capacity(targets.len());
+        for ip in targets {
+            let permit = semaphore.clone().acquire_owned().await;
+            let monitor = self.clone();
+            let auth = request.auth.clone();
+            handles.push(tokio::spawn(async move {
+                let _permit = permit.map_err(|error| scan_error(ip, error.to_string()))?;
+                monitor.discover(ip, timeout, auth).await
+            }));
+        }
+
+        let mut found = Vec::new();
+        let mut errors = Vec::new();
+        for handle in handles {
+            match handle.await.map_err(|error| error.to_string())? {
+                Ok(miner) => found.push(miner),
+                Err(error) => errors.push(error),
+            }
+        }
+
+        Ok(AsicScanResponse {
+            total_targets,
+            found,
+            errors,
+        })
+    }
+
+    async fn discover(
+        &self,
+        ip: IpAddr,
+        timeout: Duration,
+        auth: Option<AsicCredentials>,
+    ) -> Result<AsicDiscoveredMiner, AsicScanError> {
+        let miner = tokio::time::timeout(timeout, self.factory.get_miner(ip))
+            .await
+            .map_err(|_| scan_error(ip, "discovery timed out"))?
+            .map_err(|error| scan_error(ip, format!("discovery failed: {error}")))?
+            .ok_or_else(|| scan_error(ip, "no asic-rs supported miner found"))?;
+
+        let handle = Arc::new(Mutex::new(miner));
+        apply_auth(&handle, auth).await;
+
+        let guard = handle.lock().await;
+        let trait_info = guard.get_device_info();
+        let mut discovered = AsicDiscoveredMiner {
+            ip: ip.to_string(),
+            port: canonical_port(&trait_info.make),
+            make: trait_info.make,
+            model: trait_info.model,
+            firmware: trait_info.firmware,
+            firmware_version: None,
+            serial_number: None,
+            mac_address: None,
+            hostname: None,
+            capabilities: capabilities_from_miner(guard.as_ref()),
+        };
+
+        if let Ok(data) = tokio::time::timeout(timeout, guard.get_data()).await {
+            discovered.make = data.device_info.make.clone();
+            discovered.model = data.device_info.model.clone();
+            discovered.firmware = data.device_info.firmware.clone();
+            discovered.firmware_version = data.firmware_version.clone();
+            discovered.serial_number = data.serial_number.clone();
+            discovered.mac_address = data.mac.map(|mac| mac.to_string());
+            discovered.hostname = data.hostname.clone();
+            discovered.port = canonical_port(&data.device_info.make);
+        }
+        drop(guard);
+
+        self.miners.lock().await.insert(ip, handle);
+        Ok(discovered)
+    }
+
+    async fn miner_for_ip(
+        &self,
+        ip: IpAddr,
+        auth: Option<AsicCredentials>,
+    ) -> Result<MinerHandle, String> {
+        if let Some(handle) = self.miners.lock().await.get(&ip).cloned() {
+            apply_auth(&handle, auth).await;
+            return Ok(handle);
+        }
+
+        let miner = tokio::time::timeout(DEFAULT_OPERATION_TIMEOUT, self.factory.get_miner(ip))
+            .await
+            .map_err(|_| format!("Timed out connecting to miner at {ip}"))?
+            .map_err(|error| format!("Failed connecting to miner at {ip}: {error}"))?
+            .ok_or_else(|| format!("No asic-rs supported miner found at {ip}"))?;
+
+        let handle = Arc::new(Mutex::new(miner));
+        apply_auth(&handle, auth).await;
+        self.miners.lock().await.insert(ip, handle.clone());
+        Ok(handle)
+    }
+}
+
+async fn apply_auth(handle: &MinerHandle, auth: Option<AsicCredentials>) {
+    if let Some(auth) = auth {
+        let mut guard = handle.lock().await;
+        guard.set_auth(MinerAuth::new(&auth.username, &auth.password));
+    }
+}
+
+fn scan_error(ip: IpAddr, error: impl Into<String>) -> AsicScanError {
+    AsicScanError {
+        target: ip.to_string(),
+        error: error.into(),
+    }
+}
+
+fn expand_targets(targets: &[String]) -> Result<Vec<IpAddr>, String> {
+    let mut expanded = Vec::new();
+    for target in targets {
+        let target = target.trim();
+        if target.is_empty() {
+            continue;
+        }
+        if target.contains('/') {
+            expanded.extend(expand_ipv4_cidr(target)?);
+        } else {
+            expanded.push(
+                target
+                    .parse::<IpAddr>()
+                    .map_err(|_| format!("Invalid scan target: {target}"))?,
+            );
+        }
+
+        if expanded.len() > MAX_SCAN_TARGETS {
+            return Err(format!(
+                "Scan target limit exceeded; maximum is {MAX_SCAN_TARGETS} hosts"
+            ));
+        }
+    }
+    Ok(expanded)
+}
+
+fn expand_ipv4_cidr(target: &str) -> Result<Vec<IpAddr>, String> {
+    let (base, prefix) = target
+        .split_once('/')
+        .ok_or_else(|| format!("Invalid CIDR target: {target}"))?;
+    let base = base
+        .parse::<Ipv4Addr>()
+        .map_err(|_| format!("Invalid IPv4 CIDR address: {target}"))?;
+    let prefix = prefix
+        .parse::<u32>()
+        .map_err(|_| format!("Invalid CIDR prefix: {target}"))?;
+    if prefix > 32 {
+        return Err(format!("Invalid CIDR prefix: {target}"));
+    }
+
+    let host_count = 1usize
+        .checked_shl(32 - prefix)
+        .ok_or_else(|| format!("Invalid CIDR target: {target}"))?;
+    if host_count > MAX_SCAN_TARGETS {
+        return Err(format!(
+            "CIDR target {target} expands to {host_count} hosts; maximum is {MAX_SCAN_TARGETS}"
+        ));
+    }
+
+    let mask = if prefix == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix)
+    };
+    let network = u32::from(base) & mask;
+    let first = if prefix <= 30 { network + 1 } else { network };
+    let last = if prefix <= 30 {
+        network + host_count as u32 - 2
+    } else {
+        network + host_count as u32 - 1
+    };
+
+    Ok((first..=last)
+        .map(|addr| IpAddr::V4(Ipv4Addr::from(addr)))
+        .collect())
+}
+
+fn miner_data_to_telemetry(data: MinerData, miner: &dyn Miner) -> AsicMinerTelemetry {
+    AsicMinerTelemetry {
+        ip: data.ip.to_string(),
+        make: data.device_info.make,
+        model: data.device_info.model,
+        firmware: data.device_info.firmware,
+        firmware_version: data.firmware_version,
+        serial_number: data.serial_number,
+        mac_address: data.mac.map(|mac| mac.to_string()),
+        hostname: data.hostname,
+        api_version: data.api_version,
+        control_board_version: data
+            .control_board_version
+            .map(|version| version.to_string()),
+        hashrate_hs: data.hashrate.as_ref().map(hashrate_as_hs),
+        expected_hashrate_hs: data.expected_hashrate.as_ref().map(hashrate_as_hs),
+        power_w: data.wattage.as_ref().map(|power| power.as_watts()),
+        efficiency_j_th: data.efficiency,
+        average_temperature_c: data
+            .average_temperature
+            .as_ref()
+            .map(|temperature| temperature.as_celsius()),
+        fluid_temperature_c: data
+            .fluid_temperature
+            .as_ref()
+            .map(|temperature| temperature.as_celsius()),
+        uptime_secs: data.uptime.map(|duration| duration.as_secs()),
+        is_mining: data.is_mining,
+        light_flashing: data.light_flashing,
+        expected_hashboards: data.expected_hashboards,
+        expected_chips: data.expected_chips,
+        total_chips: data.total_chips,
+        expected_fans: data.expected_fans,
+        hashboards: data
+            .hashboards
+            .into_iter()
+            .map(|board| AsicHashboardTelemetry {
+                position: board.position,
+                hashrate_hs: board.hashrate.as_ref().map(hashrate_as_hs),
+                expected_hashrate_hs: board.expected_hashrate.as_ref().map(hashrate_as_hs),
+                board_temperature_c: board
+                    .board_temperature
+                    .as_ref()
+                    .map(|temperature| temperature.as_celsius()),
+                intake_temperature_c: board
+                    .intake_temperature
+                    .as_ref()
+                    .map(|temperature| temperature.as_celsius()),
+                outlet_temperature_c: board
+                    .outlet_temperature
+                    .as_ref()
+                    .map(|temperature| temperature.as_celsius()),
+                expected_chips: board.expected_chips,
+                working_chips: board.working_chips,
+                serial_number: board.serial_number,
+                voltage_v: board.voltage.as_ref().map(|voltage| voltage.as_volts()),
+                frequency_mhz: board
+                    .frequency
+                    .as_ref()
+                    .map(|frequency| frequency.as_megahertz()),
+                tuned: board.tuned,
+                active: board.active,
+            })
+            .collect(),
+        fans: data
+            .fans
+            .into_iter()
+            .map(|fan| AsicFanTelemetry {
+                position: fan.position,
+                rpm: fan.rpm.as_ref().map(|rpm| rpm.as_rpm()),
+            })
+            .collect(),
+        psu_fans: data
+            .psu_fans
+            .into_iter()
+            .map(|fan| AsicFanTelemetry {
+                position: fan.position,
+                rpm: fan.rpm.as_ref().map(|rpm| rpm.as_rpm()),
+            })
+            .collect(),
+        pools: data
+            .pools
+            .into_iter()
+            .map(pool_group_data_from_asic)
+            .collect(),
+        messages: data
+            .messages
+            .into_iter()
+            .map(|message| AsicMinerMessage {
+                timestamp: message.timestamp,
+                code: message.code,
+                message: message.message,
+                severity: message.severity.to_string(),
+            })
+            .collect(),
+        capabilities: capabilities_from_miner(miner),
+        last_updated_at: unix_now(),
+    }
+}
+
+fn capabilities_from_miner(miner: &dyn Miner) -> AsicMinerCapabilities {
+    AsicMinerCapabilities {
+        telemetry: true,
+        restart: miner.supports_restart(),
+        pause: miner.supports_pause(),
+        resume: miner.supports_resume(),
+        blink_led: miner.supports_set_fault_light(),
+        pools_config: miner.supports_pools_config(),
+        power_limit: miner.supports_set_power_limit(),
+        tuning_config: miner.supports_tuning_config(),
+    }
+}
+
+fn pool_group_data_from_asic(group: asic_rs_core::data::pool::PoolGroupData) -> AsicPoolGroupData {
+    AsicPoolGroupData {
+        name: group.name,
+        quota: group.quota,
+        pools: group
+            .pools
+            .into_iter()
+            .map(|pool| AsicPoolData {
+                position: pool.position,
+                url: pool.url.map(|url| url.to_string()),
+                accepted_shares: pool.accepted_shares,
+                rejected_shares: pool.rejected_shares,
+                active: pool.active,
+                alive: pool.alive,
+                user: pool.user,
+            })
+            .collect(),
+    }
+}
+
+fn pool_group_config_from_asic(group: PoolGroupConfig) -> AsicPoolGroupConfig {
+    AsicPoolGroupConfig {
+        name: group.name,
+        quota: group.quota,
+        pools: group
+            .pools
+            .into_iter()
+            .map(|pool| AsicPoolConfig {
+                url: pool.url.to_string(),
+                username: pool.username,
+                password: pool.password,
+            })
+            .collect(),
+    }
+}
+
+fn pool_group_config_to_asic(group: AsicPoolGroupConfig) -> PoolGroupConfig {
+    PoolGroupConfig {
+        name: group.name,
+        quota: group.quota,
+        pools: group
+            .pools
+            .into_iter()
+            .map(|pool| PoolConfig {
+                url: PoolURL::from(pool.url),
+                username: pool.username,
+                password: pool.password,
+            })
+            .collect(),
+    }
+}
+
+fn hashrate_as_hs(hashrate: &HashRate) -> f64 {
+    hashrate.clone().as_unit(HashRateUnit::Hash).value
+}
+
+fn canonical_port(make: &str) -> Option<u16> {
+    let make = make.to_ascii_lowercase();
+    if make.contains("whats") || make.contains("avalon") {
+        Some(4028)
+    } else {
+        Some(80)
+    }
+}
+
+fn unix_now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}

--- a/stratum-apps/src/monitoring/asic_types.rs
+++ b/stratum-apps/src/monitoring/asic_types.rs
@@ -1,0 +1,143 @@
+//! ASIC miner monitoring response types.
+//!
+//! These are plain API schemas. The `asic-rs` integration that populates them
+//! lives behind the `asic-monitoring` feature.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct AsicMinerCapabilities {
+    pub telemetry: bool,
+    pub restart: bool,
+    pub pause: bool,
+    pub resume: bool,
+    pub blink_led: bool,
+    pub pools_config: bool,
+    pub power_limit: bool,
+    pub tuning_config: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicHashboardTelemetry {
+    pub position: u8,
+    pub hashrate_hs: Option<f64>,
+    pub expected_hashrate_hs: Option<f64>,
+    pub board_temperature_c: Option<f64>,
+    pub intake_temperature_c: Option<f64>,
+    pub outlet_temperature_c: Option<f64>,
+    pub expected_chips: Option<u16>,
+    pub working_chips: Option<u16>,
+    pub serial_number: Option<String>,
+    pub voltage_v: Option<f64>,
+    pub frequency_mhz: Option<f64>,
+    pub tuned: Option<bool>,
+    pub active: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicFanTelemetry {
+    pub position: i16,
+    pub rpm: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicMinerMessage {
+    pub timestamp: u32,
+    pub code: u64,
+    pub message: String,
+    pub severity: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicPoolData {
+    pub position: Option<u16>,
+    pub url: Option<String>,
+    pub accepted_shares: Option<u64>,
+    pub rejected_shares: Option<u64>,
+    pub active: Option<bool>,
+    pub alive: Option<bool>,
+    pub user: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicPoolGroupData {
+    pub name: String,
+    pub quota: u32,
+    pub pools: Vec<AsicPoolData>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicPoolConfig {
+    pub url: String,
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicPoolGroupConfig {
+    pub name: String,
+    pub quota: u32,
+    pub pools: Vec<AsicPoolConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicMinerTelemetry {
+    pub ip: String,
+    pub make: String,
+    pub model: String,
+    pub firmware: String,
+    pub firmware_version: Option<String>,
+    pub serial_number: Option<String>,
+    pub mac_address: Option<String>,
+    pub hostname: Option<String>,
+    pub api_version: Option<String>,
+    pub control_board_version: Option<String>,
+    pub hashrate_hs: Option<f64>,
+    pub expected_hashrate_hs: Option<f64>,
+    pub power_w: Option<f64>,
+    pub efficiency_j_th: Option<f64>,
+    pub average_temperature_c: Option<f64>,
+    pub fluid_temperature_c: Option<f64>,
+    pub uptime_secs: Option<u64>,
+    pub is_mining: bool,
+    pub light_flashing: Option<bool>,
+    pub expected_hashboards: Option<u8>,
+    pub expected_chips: Option<u16>,
+    pub total_chips: Option<u16>,
+    pub expected_fans: Option<u8>,
+    pub hashboards: Vec<AsicHashboardTelemetry>,
+    pub fans: Vec<AsicFanTelemetry>,
+    pub psu_fans: Vec<AsicFanTelemetry>,
+    pub pools: Vec<AsicPoolGroupData>,
+    pub messages: Vec<AsicMinerMessage>,
+    pub capabilities: AsicMinerCapabilities,
+    pub last_updated_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicDiscoveredMiner {
+    pub ip: String,
+    pub port: Option<u16>,
+    pub make: String,
+    pub model: String,
+    pub firmware: String,
+    pub firmware_version: Option<String>,
+    pub serial_number: Option<String>,
+    pub mac_address: Option<String>,
+    pub hostname: Option<String>,
+    pub capabilities: AsicMinerCapabilities,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicScanError {
+    pub target: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AsicScanResponse {
+    pub total_targets: usize,
+    pub found: Vec<AsicDiscoveredMiner>,
+    pub errors: Vec<AsicScanError>,
+}

--- a/stratum-apps/src/monitoring/http_server.rs
+++ b/stratum-apps/src/monitoring/http_server.rs
@@ -11,8 +11,11 @@ use super::{
     },
     snapshot_cache::SnapshotCache,
     sv1::{Sv1ClientInfo, Sv1ClientsMonitoring, Sv1ClientsSummary},
-    GlobalInfo,
+    AsicDiscoveredMiner, AsicMinerCapabilities, AsicMinerTelemetry, AsicPoolConfig, AsicPoolData,
+    AsicPoolGroupConfig, AsicPoolGroupData, AsicScanError, AsicScanResponse, GlobalInfo,
 };
+#[cfg(feature = "asic-monitoring")]
+use axum::routing::post;
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -20,8 +23,12 @@ use axum::{
     routing::get,
     Router,
 };
+#[cfg(feature = "asic-monitoring")]
+use futures::future::join_all;
 use prometheus::{Encoder, TextEncoder};
 use serde::Deserialize;
+#[cfg(feature = "asic-monitoring")]
+use std::net::IpAddr;
 use std::{
     future::Future,
     net::SocketAddr,
@@ -63,6 +70,15 @@ use utoipa_swagger_ui::SwaggerUi;
         StandardChannelInfo,
         Sv1ClientInfo,
         Sv1ClientsSummary,
+        AsicMinerCapabilities,
+        AsicMinerTelemetry,
+        AsicDiscoveredMiner,
+        AsicPoolData,
+        AsicPoolGroupData,
+        AsicPoolConfig,
+        AsicPoolGroupConfig,
+        AsicScanError,
+        AsicScanResponse,
         HealthResponse,
         ErrorResponse,
         ServerResponse,
@@ -88,6 +104,8 @@ struct ServerState {
     cache: Arc<SnapshotCache>,
     start_time: u64,
     metrics: PrometheusMetrics,
+    #[cfg(feature = "asic-monitoring")]
+    asic_monitor: Option<Arc<super::AsicMonitor>>,
 }
 
 const DEFAULT_LIMIT: usize = 25;
@@ -101,6 +119,10 @@ struct Pagination {
     /// Limit for pagination (default: 25, max: 100)
     #[serde(default)]
     limit: Option<usize>,
+    /// Include ASIC telemetry where available (SV1 endpoints only).
+    #[cfg_attr(not(feature = "asic-monitoring"), allow(dead_code))]
+    #[serde(default)]
+    include_asic: bool,
 }
 
 impl Pagination {
@@ -180,6 +202,8 @@ impl MonitoringServer {
                 cache,
                 start_time,
                 metrics,
+                #[cfg(feature = "asic-monitoring")]
+                asic_monitor: None,
             },
         })
     }
@@ -211,6 +235,13 @@ impl MonitoringServer {
         self.state.cache = cache;
 
         Ok(self)
+    }
+
+    /// Enable ASIC miner discovery, telemetry, and control endpoints via `asic-rs`.
+    #[cfg(feature = "asic-monitoring")]
+    pub fn with_asic_monitoring(mut self) -> Self {
+        self.state.asic_monitor = Some(Arc::new(super::AsicMonitor::new()));
+        self
     }
 
     /// Run the monitoring server until the shutdown signal completes
@@ -252,6 +283,25 @@ impl MonitoringServer {
             .route("/clients/{client_id}/channels", get(handle_client_channels))
             .route("/sv1/clients", get(handle_sv1_clients))
             .route("/sv1/clients/{client_id}", get(handle_sv1_client_by_id));
+
+        #[cfg(feature = "asic-monitoring")]
+        let api_v1 = api_v1
+            .route("/asic/scan", post(handle_asic_scan))
+            .route("/asic/{ip}/telemetry", get(handle_asic_telemetry))
+            .route(
+                "/asic/{ip}/pools",
+                get(handle_asic_pools).put(handle_asic_update_pools),
+            )
+            .route("/asic/{ip}/actions/{action}", post(handle_asic_action))
+            .route("/sv1/clients/{client_id}/asic", get(handle_sv1_client_asic))
+            .route(
+                "/sv1/clients/{client_id}/pools",
+                get(handle_sv1_client_pools).put(handle_sv1_client_update_pools),
+            )
+            .route(
+                "/sv1/clients/{client_id}/actions/{action}",
+                post(handle_sv1_client_action),
+            );
 
         let app = Router::new()
             .route("/", get(handle_root))
@@ -670,6 +720,14 @@ async fn handle_sv1_clients(
     match snapshot.sv1_clients {
         Some(ref sv1_clients) => {
             let (total, items) = paginate(sv1_clients, &params);
+            #[cfg(feature = "asic-monitoring")]
+            let items = {
+                let mut items = items;
+                if params.include_asic {
+                    enrich_sv1_clients_with_asic(&state, &mut items).await;
+                }
+                items
+            };
 
             Json(Sv1ClientsResponse {
                 offset: params.offset,
@@ -722,7 +780,16 @@ async fn handle_sv1_client_by_id(
     };
 
     match sv1_clients.iter().find(|c| c.client_id == client_id) {
-        Some(client) => Json(client.clone()).into_response(),
+        Some(client) => {
+            let client = client.clone();
+            #[cfg(feature = "asic-monitoring")]
+            let client = {
+                let mut client = client;
+                enrich_sv1_client_with_asic(&state, &mut client).await;
+                client
+            };
+            Json(client).into_response()
+        }
         None => (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
@@ -731,6 +798,267 @@ async fn handle_sv1_client_by_id(
         )
             .into_response(),
     }
+}
+
+#[cfg(feature = "asic-monitoring")]
+async fn handle_asic_scan(
+    State(state): State<ServerState>,
+    Json(request): Json<super::AsicScanRequest>,
+) -> Response {
+    let Some(monitor) = state.asic_monitor.as_ref() else {
+        return monitoring_error(StatusCode::NOT_FOUND, "ASIC monitoring not available");
+    };
+
+    match monitor.scan(request).await {
+        Ok(scan) => Json(scan).into_response(),
+        Err(error) => monitoring_error(StatusCode::BAD_REQUEST, error),
+    }
+}
+
+#[cfg(feature = "asic-monitoring")]
+async fn handle_asic_telemetry(
+    Path(ip): Path<String>,
+    State(state): State<ServerState>,
+) -> Response {
+    let Some(monitor) = state.asic_monitor.as_ref() else {
+        return monitoring_error(StatusCode::NOT_FOUND, "ASIC monitoring not available");
+    };
+    let ip = match parse_ip(&ip) {
+        Ok(ip) => ip,
+        Err(response) => return response,
+    };
+
+    match monitor.telemetry(ip, None).await {
+        Ok(telemetry) => Json(telemetry).into_response(),
+        Err(error) => monitoring_error(StatusCode::BAD_GATEWAY, error),
+    }
+}
+
+#[cfg(feature = "asic-monitoring")]
+async fn handle_asic_pools(Path(ip): Path<String>, State(state): State<ServerState>) -> Response {
+    let Some(monitor) = state.asic_monitor.as_ref() else {
+        return monitoring_error(StatusCode::NOT_FOUND, "ASIC monitoring not available");
+    };
+    let ip = match parse_ip(&ip) {
+        Ok(ip) => ip,
+        Err(response) => return response,
+    };
+
+    match monitor.pools(ip, None).await {
+        Ok(pools) => Json(pools).into_response(),
+        Err(error) => monitoring_error(StatusCode::BAD_GATEWAY, error),
+    }
+}
+
+#[cfg(feature = "asic-monitoring")]
+async fn handle_asic_update_pools(
+    Path(ip): Path<String>,
+    State(state): State<ServerState>,
+    Json(request): Json<super::AsicUpdatePoolsRequest>,
+) -> Response {
+    let Some(monitor) = state.asic_monitor.as_ref() else {
+        return monitoring_error(StatusCode::NOT_FOUND, "ASIC monitoring not available");
+    };
+    let ip = match parse_ip(&ip) {
+        Ok(ip) => ip,
+        Err(response) => return response,
+    };
+
+    match monitor.update_pools(ip, request).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => monitoring_error(StatusCode::BAD_GATEWAY, error),
+    }
+}
+
+#[cfg(feature = "asic-monitoring")]
+#[derive(Deserialize)]
+struct AsicActionRequest {
+    auth: Option<super::asic::AsicCredentials>,
+}
+
+#[cfg(feature = "asic-monitoring")]
+async fn handle_asic_action(
+    Path((ip, action)): Path<(String, String)>,
+    State(state): State<ServerState>,
+    Json(request): Json<AsicActionRequest>,
+) -> Response {
+    let Some(monitor) = state.asic_monitor.as_ref() else {
+        return monitoring_error(StatusCode::NOT_FOUND, "ASIC monitoring not available");
+    };
+    let ip = match parse_ip(&ip) {
+        Ok(ip) => ip,
+        Err(response) => return response,
+    };
+
+    match monitor.action(ip, &action, request.auth).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => monitoring_error(StatusCode::BAD_GATEWAY, error),
+    }
+}
+
+#[cfg(feature = "asic-monitoring")]
+async fn handle_sv1_client_asic(
+    Path(client_id): Path<usize>,
+    State(state): State<ServerState>,
+) -> Response {
+    let Some(monitor) = state.asic_monitor.as_ref() else {
+        return monitoring_error(StatusCode::NOT_FOUND, "ASIC monitoring not available");
+    };
+    let ip = match sv1_client_ip(&state, client_id) {
+        Ok(ip) => ip,
+        Err(response) => return response,
+    };
+
+    match monitor.telemetry(ip, None).await {
+        Ok(telemetry) => Json(telemetry).into_response(),
+        Err(error) => monitoring_error(StatusCode::BAD_GATEWAY, error),
+    }
+}
+
+#[cfg(feature = "asic-monitoring")]
+async fn handle_sv1_client_pools(
+    Path(client_id): Path<usize>,
+    State(state): State<ServerState>,
+) -> Response {
+    let Some(monitor) = state.asic_monitor.as_ref() else {
+        return monitoring_error(StatusCode::NOT_FOUND, "ASIC monitoring not available");
+    };
+    let ip = match sv1_client_ip(&state, client_id) {
+        Ok(ip) => ip,
+        Err(response) => return response,
+    };
+
+    match monitor.pools(ip, None).await {
+        Ok(pools) => Json(pools).into_response(),
+        Err(error) => monitoring_error(StatusCode::BAD_GATEWAY, error),
+    }
+}
+
+#[cfg(feature = "asic-monitoring")]
+async fn handle_sv1_client_update_pools(
+    Path(client_id): Path<usize>,
+    State(state): State<ServerState>,
+    Json(request): Json<super::AsicUpdatePoolsRequest>,
+) -> Response {
+    let Some(monitor) = state.asic_monitor.as_ref() else {
+        return monitoring_error(StatusCode::NOT_FOUND, "ASIC monitoring not available");
+    };
+    let ip = match sv1_client_ip(&state, client_id) {
+        Ok(ip) => ip,
+        Err(response) => return response,
+    };
+
+    match monitor.update_pools(ip, request).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => monitoring_error(StatusCode::BAD_GATEWAY, error),
+    }
+}
+
+#[cfg(feature = "asic-monitoring")]
+async fn handle_sv1_client_action(
+    Path((client_id, action)): Path<(usize, String)>,
+    State(state): State<ServerState>,
+    Json(request): Json<AsicActionRequest>,
+) -> Response {
+    let Some(monitor) = state.asic_monitor.as_ref() else {
+        return monitoring_error(StatusCode::NOT_FOUND, "ASIC monitoring not available");
+    };
+    let ip = match sv1_client_ip(&state, client_id) {
+        Ok(ip) => ip,
+        Err(response) => return response,
+    };
+
+    match monitor.action(ip, &action, request.auth).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(error) => monitoring_error(StatusCode::BAD_GATEWAY, error),
+    }
+}
+
+#[cfg(feature = "asic-monitoring")]
+async fn enrich_sv1_clients_with_asic(state: &ServerState, clients: &mut [Sv1ClientInfo]) {
+    let Some(monitor) = state.asic_monitor.as_ref().cloned() else {
+        return;
+    };
+    let futures = clients
+        .iter()
+        .enumerate()
+        .filter_map(|(index, client)| {
+            let ip = client.peer_ip.as_ref()?.parse::<IpAddr>().ok()?;
+            let monitor = monitor.clone();
+            Some(async move { (index, monitor.telemetry(ip, None).await.ok()) })
+        })
+        .collect::<Vec<_>>();
+
+    for (index, telemetry) in join_all(futures).await {
+        if let Some(telemetry) = telemetry {
+            clients[index].asic = Some(telemetry);
+        }
+    }
+}
+
+#[cfg(feature = "asic-monitoring")]
+async fn enrich_sv1_client_with_asic(state: &ServerState, client: &mut Sv1ClientInfo) {
+    let Some(monitor) = state.asic_monitor.as_ref() else {
+        return;
+    };
+    let Some(ip) = client
+        .peer_ip
+        .as_ref()
+        .and_then(|peer_ip| peer_ip.parse::<IpAddr>().ok())
+    else {
+        return;
+    };
+
+    if let Ok(telemetry) = monitor.telemetry(ip, None).await {
+        client.asic = Some(telemetry);
+    }
+}
+
+#[cfg(feature = "asic-monitoring")]
+fn sv1_client_ip(state: &ServerState, client_id: usize) -> Result<IpAddr, Response> {
+    let snapshot = state.cache.get_snapshot();
+    let Some(clients) = snapshot.sv1_clients else {
+        return Err(monitoring_error(
+            StatusCode::NOT_FOUND,
+            "Sv1 client monitoring not available",
+        ));
+    };
+    let Some(client) = clients.iter().find(|client| client.client_id == client_id) else {
+        return Err(monitoring_error(
+            StatusCode::NOT_FOUND,
+            format!("Sv1 client {client_id} not found"),
+        ));
+    };
+    let Some(peer_ip) = client.peer_ip.as_ref() else {
+        return Err(monitoring_error(
+            StatusCode::BAD_REQUEST,
+            format!("Sv1 client {client_id} has no peer IP"),
+        ));
+    };
+
+    peer_ip.parse::<IpAddr>().map_err(|_| {
+        monitoring_error(
+            StatusCode::BAD_REQUEST,
+            format!("Sv1 client {client_id} peer IP is invalid: {peer_ip}"),
+        )
+    })
+}
+
+#[cfg(feature = "asic-monitoring")]
+fn parse_ip(ip: &str) -> Result<IpAddr, Response> {
+    ip.parse::<IpAddr>()
+        .map_err(|_| monitoring_error(StatusCode::BAD_REQUEST, format!("Invalid IP: {ip}")))
+}
+
+#[cfg(feature = "asic-monitoring")]
+fn monitoring_error(status: StatusCode, error: impl Into<String>) -> Response {
+    (
+        status,
+        Json(ErrorResponse {
+            error: error.into(),
+        }),
+    )
+        .into_response()
 }
 
 /// Handler for Prometheus metrics endpoint
@@ -1027,6 +1355,9 @@ mod tests {
         Sv1ClientInfo {
             client_id: id,
             channel_id: Some(id as u32),
+            peer_ip: Some("192.0.2.10".into()),
+            peer_port: Some(4028),
+            asic: None,
             authorized_worker_name: format!("worker-{}", id),
             user_identity: format!("miner-{}", id),
             target_hex: "00ff".into(),
@@ -1094,6 +1425,8 @@ mod tests {
             cache,
             start_time,
             metrics,
+            #[cfg(feature = "asic-monitoring")]
+            asic_monitor: None,
         };
 
         let api_v1 = Router::new()
@@ -1134,6 +1467,7 @@ mod tests {
         let p = Pagination {
             offset: 0,
             limit: None,
+            include_asic: false,
         };
         assert_eq!(p.effective_limit(), DEFAULT_LIMIT);
     }
@@ -1143,6 +1477,7 @@ mod tests {
         let p = Pagination {
             offset: 0,
             limit: Some(500),
+            include_asic: false,
         };
         assert_eq!(p.effective_limit(), MAX_LIMIT);
     }
@@ -1152,6 +1487,7 @@ mod tests {
         let p = Pagination {
             offset: 0,
             limit: Some(5),
+            include_asic: false,
         };
         assert_eq!(p.effective_limit(), 5);
     }
@@ -1162,6 +1498,7 @@ mod tests {
         let params = Pagination {
             offset: 0,
             limit: Some(10),
+            include_asic: false,
         };
         let (total, result) = paginate(&items, &params);
         assert_eq!(total, 0);
@@ -1174,6 +1511,7 @@ mod tests {
         let params = Pagination {
             offset: 10,
             limit: Some(5),
+            include_asic: false,
         };
         let (total, result) = paginate(&items, &params);
         assert_eq!(total, 50);
@@ -1186,6 +1524,7 @@ mod tests {
         let params = Pagination {
             offset: 100,
             limit: Some(10),
+            include_asic: false,
         };
         let (total, result) = paginate(&items, &params);
         assert_eq!(total, 3);
@@ -1198,6 +1537,7 @@ mod tests {
         let params = Pagination {
             offset: 3,
             limit: Some(10),
+            include_asic: false,
         };
         let (total, result) = paginate(&items, &params);
         assert_eq!(total, 5);

--- a/stratum-apps/src/monitoring/mod.rs
+++ b/stratum-apps/src/monitoring/mod.rs
@@ -9,6 +9,9 @@
 //! - **Clients**: Downstream connections (miners) - multiple per app
 //! - **SV1 clients**: Legacy SV1 connections (Translator only)
 
+#[cfg(feature = "asic-monitoring")]
+pub mod asic;
+pub mod asic_types;
 pub mod client;
 pub mod http_server;
 pub mod prometheus_metrics;
@@ -16,6 +19,13 @@ pub mod server;
 pub mod snapshot_cache;
 pub mod sv1;
 
+#[cfg(feature = "asic-monitoring")]
+pub use asic::{AsicMonitor, AsicScanRequest, AsicUpdatePoolsRequest};
+pub use asic_types::{
+    AsicDiscoveredMiner, AsicFanTelemetry, AsicHashboardTelemetry, AsicMinerCapabilities,
+    AsicMinerMessage, AsicMinerTelemetry, AsicPoolConfig, AsicPoolData, AsicPoolGroupConfig,
+    AsicPoolGroupData, AsicScanError, AsicScanResponse,
+};
 pub use client::{
     ExtendedChannelInfo, StandardChannelInfo, Sv2ClientInfo, Sv2ClientMetadata,
     Sv2ClientsMonitoring, Sv2ClientsSummary,

--- a/stratum-apps/src/monitoring/sv1.rs
+++ b/stratum-apps/src/monitoring/sv1.rs
@@ -6,11 +6,16 @@
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use super::AsicMinerTelemetry;
+
 /// Information about a single SV1 client connection
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Sv1ClientInfo {
     pub client_id: usize,
     pub channel_id: Option<u32>,
+    pub peer_ip: Option<String>,
+    pub peer_port: Option<u16>,
+    pub asic: Option<AsicMinerTelemetry>,
     pub authorized_worker_name: String,
     pub user_identity: String,
     pub target_hex: String,
@@ -62,6 +67,9 @@ mod tests {
         Sv1ClientInfo {
             client_id: id,
             channel_id: Some(id as u32),
+            peer_ip: Some("192.0.2.10".into()),
+            peer_port: Some(4028),
+            asic: None,
             authorized_worker_name: format!("worker-{}", id),
             user_identity: format!("miner-{}", id),
             target_hex: "00ff".into(),


### PR DESCRIPTION
## Summary

This is a work-in-progress prototype for exposing ASIC monitoring data from `stratum-apps` through the existing monitoring HTTP server.

It depends on the matching sv2-ui PR #[TBD] and is intended only for prototype/testing use. The goal is to show engineers how ASIC telemetry and control data could be surfaced to the UI, and to exercise the dashboard/add-miner/manage-miner flows end to end.

## Scope

- Adds optional `asic-rs` integration behind the existing monitoring feature path.
- Exposes ASIC discovery through the monitoring API.
- Exposes per-miner telemetry lookup by management IP.
- Exposes SV1-client ASIC telemetry lookup using the client peer endpoint.
- Adds ASIC action endpoints for supported miner operations.
- Adds API response types for miner identity, telemetry, hashboards, fans, pools, messages, and capabilities.
- Keeps the integration scoped to monitoring APIs rather than adding miner-control logic to sv2-ui’s Node server.

## Notes

This is not intended to ship as-is. It is a prototype integration point for review and local testing while the sv2-ui UX is developed in parallel.

Known limitations:
- Rented/proxied hashpower usually cannot expose ASIC telemetry because only the SV1 stratum connection is visible.
- Docker Desktop can mask real miner peer IPs, so local testing may require explicit scan targets or Docker network setup.
- Discovery/control depends on what `asic-rs` supports for the target miner or simulator.
