### PR TITLE
Rename channel states to io

### DIFF
--- a/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
@@ -31,7 +31,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     channel_manager::{
-        ChannelManager, ChannelManagerChannel, SharesOrderedByDiff, SOLO_FULL_EXTRANONCE_SIZE,
+        ChannelManager, ChannelManagerIo, SharesOrderedByDiff, SOLO_FULL_EXTRANONCE_SIZE,
     },
     error::{self, JDCError, JDCErrorKind},
     utils::{add_share_to_cache, create_close_channel_msg},
@@ -106,11 +106,11 @@ impl RouteMessageTo<'_> {
     ///   template provider.
     pub async fn forward(
         self,
-        channel_manager_channel: &ChannelManagerChannel,
+        channel_manager_io: &ChannelManagerIo,
     ) -> Result<(), JDCErrorKind> {
         match self {
             RouteMessageTo::Downstream((downstream_id, message)) => {
-                let sender = channel_manager_channel
+                let sender = channel_manager_io
                     .downstream_sender
                     .super_safe_lock(|map| map.get(&downstream_id).cloned());
                 if let Some(sender) = sender {
@@ -122,19 +122,19 @@ impl RouteMessageTo<'_> {
             RouteMessageTo::Upstream(message) => {
                 let message_static = message.into_static();
                 let sv2_frame: Sv2Frame = AnyMessage::Mining(message_static).try_into()?;
-                channel_manager_channel
+                channel_manager_io
                     .upstream_sender
                     .send(sv2_frame)
                     .await?;
             }
             RouteMessageTo::JobDeclarator(message) => {
-                channel_manager_channel
+                channel_manager_io
                     .jd_sender
                     .send(message.into_static())
                     .await?;
             }
             RouteMessageTo::TemplateProvider(message) => {
-                channel_manager_channel
+                channel_manager_io
                     .tp_sender
                     .send(message.into_static())
                     .await?;
@@ -457,7 +457,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
         }
@@ -719,7 +719,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
         }
@@ -913,7 +913,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
         }
@@ -1153,7 +1153,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
         }
@@ -1416,7 +1416,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
         }

--- a/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
@@ -104,10 +104,7 @@ impl RouteMessageTo<'_> {
     /// - [`RouteMessageTo::JobDeclarator`] → Sends the job declaration message to the JDS.
     /// - [`RouteMessageTo::TemplateProvider`] → Sends the template distribution message to the
     ///   template provider.
-    pub async fn forward(
-        self,
-        channel_manager_io: &ChannelManagerIo,
-    ) -> Result<(), JDCErrorKind> {
+    pub async fn forward(self, channel_manager_io: &ChannelManagerIo) -> Result<(), JDCErrorKind> {
         match self {
             RouteMessageTo::Downstream((downstream_id, message)) => {
                 let sender = channel_manager_io
@@ -122,10 +119,7 @@ impl RouteMessageTo<'_> {
             RouteMessageTo::Upstream(message) => {
                 let message_static = message.into_static();
                 let sv2_frame: Sv2Frame = AnyMessage::Mining(message_static).try_into()?;
-                channel_manager_io
-                    .upstream_sender
-                    .send(sv2_frame)
-                    .await?;
+                channel_manager_io.upstream_sender.send(sv2_frame).await?;
             }
             RouteMessageTo::JobDeclarator(message) => {
                 channel_manager_io

--- a/miner-apps/jd-client/src/lib/channel_manager/extensions_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/extensions_message_handler.rs
@@ -145,7 +145,7 @@ impl HandleExtensionsFromServerAsync for ChannelManager {
                     .try_into()
                     .map_err(JDCError::shutdown)?;
 
-            self.channel_manager_channel
+            self.channel_manager_io
                 .upstream_sender
                 .send(sv2_frame)
                 .await

--- a/miner-apps/jd-client/src/lib/channel_manager/jd_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/jd_message_handler.rs
@@ -98,7 +98,7 @@ impl HandleJobDeclarationMessagesFromServerAsync for ChannelManager {
                     coinbase_output_max_additional_sigops: max_additional_sigops,
                 });
 
-            self.channel_manager_channel
+            self.channel_manager_io
                 .tp_sender
                 .send(coinbase_output_constraints_message)
                 .await
@@ -232,7 +232,7 @@ impl HandleJobDeclarationMessagesFromServerAsync for ChannelManager {
         let sv2_frame: Sv2Frame = AnyMessage::Mining(message)
             .try_into()
             .map_err(JDCError::shutdown)?;
-        self.channel_manager_channel
+        self.channel_manager_io
             .upstream_sender
             .send(sv2_frame)
             .await
@@ -302,7 +302,7 @@ impl HandleJobDeclarationMessagesFromServerAsync for ChannelManager {
         };
         let message = JobDeclaration::ProvideMissingTransactionsSuccess(response);
 
-        self.channel_manager_channel
+        self.channel_manager_io
             .jd_sender
             .send(message)
             .await

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -231,7 +231,7 @@ impl ChannelManagerData {
 
 /// Represents all communication channels managed by the Channel Manager.
 ///
-/// The `ChannelManagerChannel` holds all the asynchronous communication primitives
+/// The `ChannelManagerIo` holds all the asynchronous communication primitives
 /// required for message exchange between the **Channel Manager** and other subsystems.
 /// It ensures decoupled, structured communication between upstreams, downstreams,
 /// the Job Dispatcher Service (JDS), and the Template Provider (TP).
@@ -256,7 +256,7 @@ impl ChannelManagerData {
 ///      changes.
 
 #[derive(Clone)]
-pub struct ChannelManagerChannel {
+pub struct ChannelManagerIo {
     upstream_sender: Sender<Sv2Frame>,
     upstream_receiver: Receiver<Sv2Frame>,
     jd_sender: Sender<JobDeclaration<'static>>,
@@ -273,7 +273,7 @@ pub struct ChannelManagerChannel {
 #[derive(Clone)]
 pub struct ChannelManager {
     pub channel_manager_data: Arc<Mutex<ChannelManagerData>>,
-    channel_manager_channel: ChannelManagerChannel,
+    channel_manager_io: ChannelManagerIo,
     miner_tag_string: String,
     share_batch_size: SharesBatchSize,
     shares_per_minute: SharesPerMinute,
@@ -381,7 +381,7 @@ impl ChannelManager {
             cached_shares: HashMap::new(),
         }));
 
-        let channel_manager_channel = ChannelManagerChannel {
+        let channel_manager_io = ChannelManagerIo {
             upstream_sender,
             upstream_receiver,
             jd_sender,
@@ -394,7 +394,7 @@ impl ChannelManager {
 
         let channel_manager = ChannelManager {
             channel_manager_data,
-            channel_manager_channel,
+            channel_manager_io,
             share_batch_size: config.share_batch_size(),
             shares_per_minute: config.shares_per_minute(),
             miner_tag_string: config.jdc_signature().to_string(),
@@ -603,7 +603,7 @@ impl ChannelManager {
                                         required_extensions_inner,
                                     );
 
-                                    this.channel_manager_channel.downstream_sender.super_safe_lock(|map| map.insert(downstream_id, channel_manager_sender_downstream));
+                                    this.channel_manager_io.downstream_sender.super_safe_lock(|map| map.insert(downstream_id, channel_manager_sender_downstream));
 
                                     this.channel_manager_data.super_safe_lock(|data| {
                                         data.downstream.insert(downstream_id, downstream.clone());
@@ -769,7 +769,7 @@ impl ChannelManager {
                 .vardiff
                 .retain(|key, _| key.downstream_id != downstream_id);
         });
-        self.channel_manager_channel
+        self.channel_manager_io
             .downstream_sender
             .super_safe_lock(|map| map.remove(&downstream_id));
     }
@@ -781,7 +781,7 @@ impl ChannelManager {
     ///   message handler.
     /// - If the frame contains any unsupported message type, an error is returned.
     async fn handle_jds_message(&mut self) -> JDCResult<(), error::ChannelManager> {
-        if let Ok(message) = self.channel_manager_channel.jd_receiver.recv().await {
+        if let Ok(message) = self.channel_manager_io.jd_receiver.recv().await {
             self.handle_job_declaration_message_from_server(None, message, None)
                 .await?;
         }
@@ -795,7 +795,7 @@ impl ChannelManager {
     ///   handler.
     /// - If the frame contains any unsupported message type, an error is returned.
     async fn handle_pool_message_frame(&mut self) -> JDCResult<(), error::ChannelManager> {
-        if let Ok(mut sv2_frame) = self.channel_manager_channel.upstream_receiver.recv().await {
+        if let Ok(mut sv2_frame) = self.channel_manager_io.upstream_receiver.recv().await {
             let header = sv2_frame.get_header().ok_or_else(|| {
                 error!("SV2 frame missing header");
                 JDCError::fallback(framing_sv2::Error::MissingHeader)
@@ -831,7 +831,7 @@ impl ChannelManager {
     //   distribution message handler.
     // - If the frame contains any unsupported message type, an error is returned.
     async fn handle_template_provider_message(&mut self) -> JDCResult<(), error::ChannelManager> {
-        if let Ok(message) = self.channel_manager_channel.tp_receiver.recv().await {
+        if let Ok(message) = self.channel_manager_io.tp_receiver.recv().await {
             self.handle_template_distribution_message_from_server(None, message, None)
                 .await?;
         }
@@ -873,7 +873,7 @@ impl ChannelManager {
     //   mechanism and are sent directly to the mining handler.
     async fn handle_downstream_message(&mut self) -> JDCResult<(), error::ChannelManager> {
         if let Ok((downstream_id, message, tlvs)) = self
-            .channel_manager_channel
+            .channel_manager_io
             .downstream_receiver
             .recv()
             .await
@@ -924,7 +924,7 @@ impl ChannelManager {
                                 let sv2_frame: Sv2Frame = AnyMessage::Mining(upstream_message)
                                     .try_into()
                                     .map_err(JDCError::shutdown)?;
-                                self.channel_manager_channel
+                                self.channel_manager_io
                                     .upstream_sender
                                     .send(sv2_frame)
                                     .await
@@ -993,7 +993,7 @@ impl ChannelManager {
                                 let sv2_frame: Sv2Frame = AnyMessage::Mining(message)
                                     .try_into()
                                     .map_err(JDCError::shutdown)?;
-                                self.channel_manager_channel
+                                self.channel_manager_io
                                     .upstream_sender
                                     .send(sv2_frame)
                                     .await
@@ -1081,7 +1081,7 @@ impl ChannelManager {
                 request_id,
             });
 
-            self.channel_manager_channel
+            self.channel_manager_io
                 .jd_sender
                 .send(message)
                 .await
@@ -1298,7 +1298,7 @@ impl ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
         }
@@ -1322,7 +1322,7 @@ impl ChannelManager {
     ) -> JDCResult<(), error::ChannelManager> {
         let msg = coinbase_output_constraints_message(coinbase_outputs);
 
-        self.channel_manager_channel
+        self.channel_manager_io
             .tp_sender
             .send(TemplateDistribution::CoinbaseOutputConstraints(msg))
             .await

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -872,11 +872,8 @@ impl ChannelManager {
     // - After the upstream channel is established, all new downstream requests bypass the pending
     //   mechanism and are sent directly to the mining handler.
     async fn handle_downstream_message(&mut self) -> JDCResult<(), error::ChannelManager> {
-        if let Ok((downstream_id, message, tlvs)) = self
-            .channel_manager_io
-            .downstream_receiver
-            .recv()
-            .await
+        if let Ok((downstream_id, message, tlvs)) =
+            self.channel_manager_io.downstream_receiver.recv().await
         {
             match message {
                 Mining::OpenExtendedMiningChannel(downstream_channel_request) => {

--- a/miner-apps/jd-client/src/lib/channel_manager/template_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/template_message_handler.rs
@@ -68,7 +68,7 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
                     template_id: msg.template_id,
                 });
 
-            self.channel_manager_channel
+            self.channel_manager_io
                 .tp_sender
                 .send(tx_data_request)
                 .await
@@ -236,7 +236,7 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
         }
@@ -387,7 +387,7 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
 
         if let Some(declare_job) = declare_job {
             let message = JobDeclaration::DeclareMiningJob(declare_job);
-            _ = self.channel_manager_channel.jd_sender.send(message).await;
+            _ = self.channel_manager_io.jd_sender.send(message).await;
         }
 
         Ok(())
@@ -443,7 +443,7 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
             if let Some(Some(job)) = declare_job {
                 let message = JobDeclaration::DeclareMiningJob(job);
 
-                self.channel_manager_channel
+                self.channel_manager_io
                     .jd_sender
                     .send(message)
                     .await
@@ -614,7 +614,7 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
         }

--- a/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
@@ -259,7 +259,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
                         TemplateDistribution::RequestTransactionData(RequestTransactionData {
                             template_id: template.template_id,
                         });
-                    self.channel_manager_channel
+                    self.channel_manager_io
                         .tp_sender
                         .send(tx_data_request)
                         .await
@@ -273,7 +273,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
                     let sv2_frame: Sv2Frame = AnyMessage::Mining(set_custom_job)
                         .try_into()
                         .map_err(JDCError::shutdown)?;
-                    self.channel_manager_channel
+                    self.channel_manager_io
                         .upstream_sender
                         .send(sv2_frame)
                         .await
@@ -302,7 +302,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
             let sv2_frame: Sv2Frame = AnyMessage::Mining(close_channel)
                 .try_into()
                 .map_err(JDCError::shutdown)?;
-            self.channel_manager_channel
+            self.channel_manager_io
                 .upstream_sender
                 .send(sv2_frame)
                 .await
@@ -525,7 +525,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
         }
@@ -690,7 +690,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
         // endpoint has been dropped (e.g., during disconnect or shutdown).
         // Lifecycle and error handling are managed elsewhere.
         for msg in shares_to_submit_upstream {
-            _ = msg.forward(&self.channel_manager_channel).await;
+            _ = msg.forward(&self.channel_manager_io).await;
         }
 
         Ok(())

--- a/miner-apps/jd-client/src/lib/downstream/common_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/downstream/common_message_handler.rs
@@ -69,7 +69,7 @@ impl HandleCommonMessagesFromClientAsync for Downstream {
             let frame: Sv2Frame = AnyMessage::Common(response.into_static().into())
                 .try_into()
                 .map_err(JDCError::shutdown)?;
-            if let Err(e) = self.downstream_channel.downstream_sender.send(frame).await {
+            if let Err(e) = self.downstream_io.downstream_sender.send(frame).await {
                 error!(
                     "Failed to send SetupConnectionError to downstream {}: {e}",
                     self.downstream_id
@@ -94,7 +94,7 @@ impl HandleCommonMessagesFromClientAsync for Downstream {
             let frame: Sv2Frame = AnyMessage::Common(response.into_static().into())
                 .try_into()
                 .map_err(JDCError::shutdown)?;
-            if let Err(e) = self.downstream_channel.downstream_sender.send(frame).await {
+            if let Err(e) = self.downstream_io.downstream_sender.send(frame).await {
                 error!(
                     "Failed to send SetupConnectionError to downstream {}: {e}",
                     self.downstream_id
@@ -119,7 +119,7 @@ impl HandleCommonMessagesFromClientAsync for Downstream {
             .try_into()
             .map_err(JDCError::shutdown)?;
 
-        if let Err(e) = self.downstream_channel.downstream_sender.send(frame).await {
+        if let Err(e) = self.downstream_io.downstream_sender.send(frame).await {
             error!(
                 "Failed to send SetupConnectionSuccess to downstream {}: {e}",
                 self.downstream_id

--- a/miner-apps/jd-client/src/lib/downstream/extensions_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/downstream/extensions_message_handler.rs
@@ -89,7 +89,7 @@ impl HandleExtensionsFromClientAsync for Downstream {
             let frame: Sv2Frame = AnyMessage::Extensions(error.into())
                 .try_into()
                 .map_err(JDCError::shutdown)?;
-            if let Err(e) = self.downstream_channel.downstream_sender.send(frame).await {
+            if let Err(e) = self.downstream_io.downstream_sender.send(frame).await {
                 error!(
                     "Failed to send RequestExtensionsError to downstream {}: {e}",
                     self.downstream_id
@@ -130,7 +130,7 @@ impl HandleExtensionsFromClientAsync for Downstream {
             let frame: Sv2Frame = AnyMessage::Extensions(success.into())
                 .try_into()
                 .map_err(JDCError::shutdown)?;
-            if let Err(e) = self.downstream_channel.downstream_sender.send(frame).await {
+            if let Err(e) = self.downstream_io.downstream_sender.send(frame).await {
                 error!(
                     "Failed to send RequestExtensionsSuccess to downstream {}: {e}",
                     self.downstream_id

--- a/miner-apps/jd-client/src/lib/downstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/downstream/mod.rs
@@ -297,11 +297,7 @@ impl Downstream {
 
     // Handles messages sent from the channel manager to this downstream.
     async fn handle_channel_manager_message(self) -> JDCResult<(), error::Downstream> {
-        let (message, _tlv_fields) = match self
-            .downstream_io
-            .channel_manager_receiver
-            .recv()
-            .await
+        let (message, _tlv_fields) = match self.downstream_io.channel_manager_receiver.recv().await
         {
             Ok(msg) => msg,
             Err(e) => {

--- a/miner-apps/jd-client/src/lib/downstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/downstream/mod.rs
@@ -69,7 +69,7 @@ pub struct DownstreamData {
 /// - `downstream_sender`: sends frames to the downstream.
 /// - `downstream_receiver`: receives frames from the downstream.
 #[derive(Clone)]
-pub struct DownstreamChannel {
+pub struct DownstreamIo {
     channel_manager_sender: Sender<(DownstreamId, Mining<'static>, Option<Vec<Tlv>>)>,
     channel_manager_receiver: Receiver<(Mining<'static>, Option<Vec<Tlv>>)>,
     downstream_sender: Sender<Sv2Frame>,
@@ -80,7 +80,7 @@ pub struct DownstreamChannel {
 #[derive(Clone)]
 pub struct Downstream {
     pub downstream_data: Arc<Mutex<DownstreamData>>,
-    downstream_channel: DownstreamChannel,
+    downstream_io: DownstreamIo,
     pub downstream_id: DownstreamId,
     /// Per-connection cancellation token (child of the global token).
     /// Cancelled when this downstream's message loop exits, causing
@@ -167,7 +167,7 @@ impl Downstream {
             fallback_coordinator.clone(),
         );
 
-        let downstream_channel = DownstreamChannel {
+        let downstream_io = DownstreamIo {
             channel_manager_receiver,
             channel_manager_sender,
             downstream_sender: outbound_tx,
@@ -186,7 +186,7 @@ impl Downstream {
         }));
 
         Downstream {
-            downstream_channel,
+            downstream_io,
             downstream_data,
             downstream_id,
             downstream_cancellation_token,
@@ -278,7 +278,7 @@ impl Downstream {
     // Performs the initial handshake with a downstream peer.
     async fn setup_connection_with_downstream(&mut self) -> JDCResult<(), error::Downstream> {
         let mut frame = self
-            .downstream_channel
+            .downstream_io
             .downstream_receiver
             .recv()
             .await
@@ -298,7 +298,7 @@ impl Downstream {
     // Handles messages sent from the channel manager to this downstream.
     async fn handle_channel_manager_message(self) -> JDCResult<(), error::Downstream> {
         let (message, _tlv_fields) = match self
-            .downstream_channel
+            .downstream_io
             .channel_manager_receiver
             .recv()
             .await
@@ -319,7 +319,7 @@ impl Downstream {
         let message = AnyMessage::Mining(message);
         let sv2_frame: Sv2Frame = message.try_into().map_err(JDCError::shutdown)?;
 
-        self.downstream_channel
+        self.downstream_io
             .downstream_sender
             .send(sv2_frame)
             .await
@@ -334,7 +334,7 @@ impl Downstream {
     // Handles incoming messages from the downstream peer.
     async fn handle_downstream_message(mut self) -> JDCResult<(), error::Downstream> {
         let mut sv2_frame = self
-            .downstream_channel
+            .downstream_io
             .downstream_receiver
             .recv()
             .await
@@ -351,7 +351,7 @@ impl Downstream {
                 .map_err(|error| JDCError::disconnect(error, self.downstream_id))?;
         match any_message {
             AnyMessage::Mining(message) => {
-                self.downstream_channel
+                self.downstream_io
                     .channel_manager_sender
                     .send((self.downstream_id, message, tlv_fields))
                     .await

--- a/miner-apps/jd-client/src/lib/job_declarator/mod.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/mod.rs
@@ -3,7 +3,6 @@ use std::{net::SocketAddr, sync::Arc};
 use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
-    custom_mutex::Mutex,
     fallback_coordinator::FallbackCoordinator,
     network_helpers::{connect_with_noise, resolve_host},
     stratum_core::{
@@ -29,9 +28,6 @@ use crate::{
 
 mod message_handler;
 
-/// Shared state for Job Declarator
-pub struct JobDeclaratorData;
-
 /// Holds all channels required for Job Declarator communication.
 #[derive(Clone)]
 pub struct JobDeclaratorIo {
@@ -45,8 +41,6 @@ pub struct JobDeclaratorIo {
 #[allow(warnings)]
 #[derive(Clone)]
 pub struct JobDeclarator {
-    /// Internal state
-    job_declarator_data: Arc<Mutex<JobDeclaratorData>>,
     /// Messaging channels to/from the channel manager and JD.
     job_declarator_io: JobDeclaratorIo,
     /// Socket address of the Job Declarator server.
@@ -155,7 +149,7 @@ impl JobDeclarator {
             cancellation_token,
             fallback_coordinator,
         );
-        let job_declarator_data = Arc::new(Mutex::new(JobDeclaratorData));
+
         let job_declarator_io = JobDeclaratorIo {
             channel_manager_receiver,
             channel_manager_sender,
@@ -164,7 +158,6 @@ impl JobDeclarator {
         };
         Ok(JobDeclarator {
             job_declarator_io,
-            job_declarator_data,
             socket_address: addr,
             mode,
         })
@@ -296,12 +289,7 @@ impl JobDeclarator {
 
     // Handles messages coming from the Channel Manager and forwards them to the Job Declarator.
     async fn handle_channel_manager_message(&self) -> JDCResult<(), error::JobDeclarator> {
-        match self
-            .job_declarator_io
-            .channel_manager_receiver
-            .recv()
-            .await
-        {
+        match self.job_declarator_io.channel_manager_receiver.recv().await {
             Ok(msg) => {
                 debug!("Forwarding message from channel manager to JDS.");
                 let message = AnyMessage::JobDeclaration(msg);

--- a/miner-apps/jd-client/src/lib/job_declarator/mod.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/mod.rs
@@ -34,7 +34,7 @@ pub struct JobDeclaratorData;
 
 /// Holds all channels required for Job Declarator communication.
 #[derive(Clone)]
-pub struct JobDeclaratorChannel {
+pub struct JobDeclaratorIo {
     channel_manager_sender: Sender<JobDeclaration<'static>>,
     channel_manager_receiver: Receiver<JobDeclaration<'static>>,
     jds_sender: Sender<Sv2Frame>,
@@ -48,7 +48,7 @@ pub struct JobDeclarator {
     /// Internal state
     job_declarator_data: Arc<Mutex<JobDeclaratorData>>,
     /// Messaging channels to/from the channel manager and JD.
-    job_declarator_channel: JobDeclaratorChannel,
+    job_declarator_io: JobDeclaratorIo,
     /// Socket address of the Job Declarator server.
     socket_address: SocketAddr,
     /// Config JDC mode
@@ -156,14 +156,14 @@ impl JobDeclarator {
             fallback_coordinator,
         );
         let job_declarator_data = Arc::new(Mutex::new(JobDeclaratorData));
-        let job_declarator_channel = JobDeclaratorChannel {
+        let job_declarator_io = JobDeclaratorIo {
             channel_manager_receiver,
             channel_manager_sender,
             jds_sender: outbound_tx,
             jds_receiver: inbound_rx,
         };
         Ok(JobDeclarator {
-            job_declarator_channel,
+            job_declarator_io,
             job_declarator_data,
             socket_address: addr,
             mode,
@@ -262,14 +262,14 @@ impl JobDeclarator {
                 JDCError::shutdown(e)
             })?;
 
-        if let Err(e) = self.job_declarator_channel.jds_sender.send(sv2_frame).await {
+        if let Err(e) = self.job_declarator_io.jds_sender.send(sv2_frame).await {
             error!(error=?e, "Failed to send SetupConnection frame.");
             return Err(JDCError::fallback(JDCErrorKind::ChannelErrorSender));
         }
         debug!("SetupConnection frame sent successfully.");
 
         let mut incoming = self
-            .job_declarator_channel
+            .job_declarator_io
             .jds_receiver
             .recv()
             .await
@@ -297,7 +297,7 @@ impl JobDeclarator {
     // Handles messages coming from the Channel Manager and forwards them to the Job Declarator.
     async fn handle_channel_manager_message(&self) -> JDCResult<(), error::JobDeclarator> {
         match self
-            .job_declarator_channel
+            .job_declarator_io
             .channel_manager_receiver
             .recv()
             .await
@@ -306,7 +306,7 @@ impl JobDeclarator {
                 debug!("Forwarding message from channel manager to JDS.");
                 let message = AnyMessage::JobDeclaration(msg);
                 let sv2_frame: Sv2Frame = message.try_into().map_err(JDCError::shutdown)?;
-                self.job_declarator_channel
+                self.job_declarator_io
                     .jds_sender
                     .send(sv2_frame)
                     .await
@@ -329,7 +329,7 @@ impl JobDeclarator {
     // - Rejects unsupported message types.
     async fn handle_job_declarator_message(&mut self) -> JDCResult<(), error::JobDeclarator> {
         let mut sv2_frame = self
-            .job_declarator_channel
+            .job_declarator_io
             .jds_receiver
             .recv()
             .await
@@ -353,7 +353,7 @@ impl JobDeclarator {
                 let message = JobDeclaration::try_from((message_type, sv2_frame.payload()))
                     .map_err(JDCError::fallback)?
                     .into_static();
-                self.job_declarator_channel
+                self.job_declarator_io
                     .channel_manager_sender
                     .send(message)
                     .await

--- a/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
-    custom_mutex::Mutex,
     fallback_coordinator::FallbackCoordinator,
     key_utils::Secp256k1PublicKey,
     network_helpers::{self, connect_with_noise, resolve_host_port},
@@ -41,9 +40,6 @@ use crate::{
 };
 
 mod message_handler;
-
-/// Placeholder for future Sv2Tp–specific state.
-pub struct Sv2TpData;
 
 /// Holds communication channels between the Sv2Tp, channel manager,
 /// and upstream template provider.
@@ -71,8 +67,6 @@ pub struct Sv2TpIo {
 #[allow(warnings)]
 #[derive(Clone)]
 pub struct Sv2Tp {
-    /// Internal state
-    sv2_tp_data: Arc<Mutex<Sv2TpData>>,
     /// Messaging channels to/from the channel manager and TP.
     sv2_tp_io: Sv2TpIo,
     /// Address of the template provider (string form)
@@ -164,7 +158,6 @@ impl Sv2Tp {
                                         fallback_coordinator.clone(),
                                     );
 
-                                    let template_receiver_data = Arc::new(Mutex::new(Sv2TpData));
                                     let sv2_tp_io = Sv2TpIo {
                                         channel_manager_receiver,
                                         channel_manager_sender,
@@ -175,7 +168,6 @@ impl Sv2Tp {
                                     info!(attempt, "TemplateReceiver initialized successfully");
                                     return Ok(Sv2Tp {
                                         sv2_tp_io,
-                                        sv2_tp_data: template_receiver_data,
                                         tp_address,
                                     });
                                 }
@@ -359,14 +351,10 @@ impl Sv2Tp {
             .map_err(JDCError::shutdown)?;
 
         info!("Sending setup connection message to upstream");
-        self.sv2_tp_io
-            .tp_sender
-            .send(frame)
-            .await
-            .map_err(|_| {
-                error!("Failed to send setup connection message upstream");
-                JDCError::shutdown(JDCErrorKind::ChannelErrorSender)
-            })?;
+        self.sv2_tp_io.tp_sender.send(frame).await.map_err(|_| {
+            error!("Failed to send setup connection message upstream");
+            JDCError::shutdown(JDCErrorKind::ChannelErrorSender)
+        })?;
 
         info!("Waiting for upstream handshake response");
         let mut incoming: Sv2Frame = self.sv2_tp_io.tp_receiver.recv().await.map_err(|e| {

--- a/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
@@ -53,7 +53,7 @@ pub struct Sv2TpData;
 /// - `outbound_tx` → sends frames upstream to the template provider
 /// - `inbound_rx` → receives frames from the template provider
 #[derive(Clone)]
-pub struct Sv2TpChannel {
+pub struct Sv2TpIo {
     channel_manager_sender: Sender<TemplateDistribution<'static>>,
     channel_manager_receiver: Receiver<TemplateDistribution<'static>>,
     tp_sender: Sender<Sv2Frame>,
@@ -74,7 +74,7 @@ pub struct Sv2Tp {
     /// Internal state
     sv2_tp_data: Arc<Mutex<Sv2TpData>>,
     /// Messaging channels to/from the channel manager and TP.
-    sv2_tp_channel: Sv2TpChannel,
+    sv2_tp_io: Sv2TpIo,
     /// Address of the template provider (string form)
     tp_address: String,
 }
@@ -165,7 +165,7 @@ impl Sv2Tp {
                                     );
 
                                     let template_receiver_data = Arc::new(Mutex::new(Sv2TpData));
-                                    let template_receiver_channel = Sv2TpChannel {
+                                    let sv2_tp_io = Sv2TpIo {
                                         channel_manager_receiver,
                                         channel_manager_sender,
                                         tp_receiver: inbound_rx,
@@ -174,7 +174,7 @@ impl Sv2Tp {
 
                                     info!(attempt, "TemplateReceiver initialized successfully");
                                     return Ok(Sv2Tp {
-                                        sv2_tp_channel: template_receiver_channel,
+                                        sv2_tp_io,
                                         sv2_tp_data: template_receiver_data,
                                         tp_address,
                                     });
@@ -276,7 +276,7 @@ impl Sv2Tp {
         &mut self,
     ) -> JDCResult<(), error::TemplateProvider> {
         let mut sv2_frame = self
-            .sv2_tp_channel
+            .sv2_tp_io
             .tp_receiver
             .recv()
             .await
@@ -304,7 +304,7 @@ impl Sv2Tp {
                 let message = TemplateDistribution::try_from((message_type, sv2_frame.payload()))
                     .map_err(JDCError::shutdown)?
                     .into_static();
-                self.sv2_tp_channel
+                self.sv2_tp_io
                     .channel_manager_sender
                     .send(message)
                     .await
@@ -325,7 +325,7 @@ impl Sv2Tp {
     /// Forwards outbound frames upstream
     pub async fn handle_channel_manager_message(&self) -> JDCResult<(), error::TemplateProvider> {
         let msg = AnyMessage::TemplateDistribution(
-            self.sv2_tp_channel
+            self.sv2_tp_io
                 .channel_manager_receiver
                 .recv()
                 .await
@@ -333,7 +333,7 @@ impl Sv2Tp {
         );
         debug!("Forwarding message from channel manager to outbound_tx");
         let sv2_frame: Sv2Frame = msg.try_into().map_err(JDCError::shutdown)?;
-        self.sv2_tp_channel
+        self.sv2_tp_io
             .tp_sender
             .send(sv2_frame)
             .await
@@ -359,7 +359,7 @@ impl Sv2Tp {
             .map_err(JDCError::shutdown)?;
 
         info!("Sending setup connection message to upstream");
-        self.sv2_tp_channel
+        self.sv2_tp_io
             .tp_sender
             .send(frame)
             .await
@@ -369,7 +369,7 @@ impl Sv2Tp {
             })?;
 
         info!("Waiting for upstream handshake response");
-        let mut incoming: Sv2Frame = self.sv2_tp_channel.tp_receiver.recv().await.map_err(|e| {
+        let mut incoming: Sv2Frame = self.sv2_tp_io.tp_receiver.recv().await.map_err(|e| {
             error!(?e, "Upstream connection closed during handshake");
             JDCError::shutdown(noise_sv2::Error::ExpectedIncomingHandshakeMessage)
         })?;

--- a/miner-apps/jd-client/src/lib/upstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/upstream/mod.rs
@@ -48,7 +48,7 @@ pub struct UpstreamData;
 /// - `outbound_tx` → sends frames outbound to upstream
 /// - `inbound_rx` → receives frames inbound from upstream
 #[derive(Clone)]
-pub struct UpstreamChannel {
+pub struct UpstreamIo {
     channel_manager_sender: Sender<Sv2Frame>,
     channel_manager_receiver: Receiver<Sv2Frame>,
     upstream_sender: Sender<Sv2Frame>,
@@ -62,7 +62,7 @@ pub struct Upstream {
     /// Internal state
     upstream_data: Arc<Mutex<UpstreamData>>,
     /// Messaging channels to/from the channel manager and Upstream.
-    upstream_channel: UpstreamChannel,
+    upstream_io: UpstreamIo,
     /// Protocol extensions that the JDC requires
     required_extensions: Vec<u16>,
     /// Upstream address
@@ -174,7 +174,7 @@ impl Upstream {
 
         debug!("Noise setup done in upstream connection");
         let upstream_data = Arc::new(Mutex::new(UpstreamData));
-        let upstream_channel = UpstreamChannel {
+        let upstream_io = UpstreamIo {
             channel_manager_receiver,
             channel_manager_sender,
             upstream_sender: outbound_tx,
@@ -182,7 +182,7 @@ impl Upstream {
         };
         Ok(Upstream {
             upstream_data,
-            upstream_channel,
+            upstream_io,
             required_extensions,
             address: addr,
         })
@@ -207,13 +207,13 @@ impl Upstream {
         debug!(?sv2_frame, "Encoded `SetupConnection` frame");
 
         // Send SetupConnection
-        if let Err(e) = self.upstream_channel.upstream_sender.send(sv2_frame).await {
+        if let Err(e) = self.upstream_io.upstream_sender.send(sv2_frame).await {
             error!(?e, "Failed to send `SetupConnection` frame to upstream");
             return Err(JDCError::fallback(JDCErrorKind::ChannelErrorSender));
         }
         info!("Sent `SetupConnection` to upstream, awaiting response...");
 
-        let incoming_frame = match self.upstream_channel.upstream_receiver.recv().await {
+        let incoming_frame = match self.upstream_io.upstream_receiver.recv().await {
             Ok(frame) => {
                 debug!(?frame, "Received raw inbound frame during handshake");
                 frame
@@ -273,7 +273,7 @@ impl Upstream {
             .try_into()
             .map_err(JDCError::shutdown)?;
 
-        self.upstream_channel
+        self.upstream_io
             .upstream_sender
             .send(sv2_frame)
             .await
@@ -382,7 +382,7 @@ impl Upstream {
     async fn handle_pool_message_frame(&mut self) -> JDCResult<(), error::Upstream> {
         debug!("Received SV2 frame from upstream.");
         let mut sv2_frame = self
-            .upstream_channel
+            .upstream_io
             .upstream_receiver
             .recv()
             .await
@@ -401,7 +401,7 @@ impl Upstream {
                     .await?;
             }
             MessageType::Mining | MessageType::Extensions => {
-                self.upstream_channel
+                self.upstream_io
                     .channel_manager_sender
                     .send(sv2_frame)
                     .await
@@ -421,10 +421,10 @@ impl Upstream {
     //
     // Forwards messages upstream.
     async fn handle_channel_manager_message_frame(&mut self) -> JDCResult<(), error::Upstream> {
-        match self.upstream_channel.channel_manager_receiver.recv().await {
+        match self.upstream_io.channel_manager_receiver.recv().await {
             Ok(sv2_frame) => {
                 debug!("Received sv2 frame from channel manager, forwarding upstream.");
-                self.upstream_channel
+                self.upstream_io
                     .upstream_sender
                     .send(sv2_frame)
                     .await

--- a/miner-apps/jd-client/src/lib/upstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/upstream/mod.rs
@@ -14,7 +14,6 @@ use std::{net::SocketAddr, sync::Arc};
 use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
-    custom_mutex::Mutex,
     fallback_coordinator::FallbackCoordinator,
     network_helpers::{connect_with_noise, resolve_host},
     stratum_core::{
@@ -38,9 +37,6 @@ use crate::{
 
 mod message_handler;
 
-/// Placeholder for future upstream-specific data/state.
-pub struct UpstreamData;
-
 /// Holds channels for communication between upstream and channel manager.
 ///
 /// - `channel_manager_sender` → sends frames to channel manager
@@ -58,9 +54,6 @@ pub struct UpstreamIo {
 /// Represents an upstream connection (e.g., a pool).
 #[derive(Clone)]
 pub struct Upstream {
-    #[allow(dead_code)]
-    /// Internal state
-    upstream_data: Arc<Mutex<UpstreamData>>,
     /// Messaging channels to/from the channel manager and Upstream.
     upstream_io: UpstreamIo,
     /// Protocol extensions that the JDC requires
@@ -173,7 +166,6 @@ impl Upstream {
         );
 
         debug!("Noise setup done in upstream connection");
-        let upstream_data = Arc::new(Mutex::new(UpstreamData));
         let upstream_io = UpstreamIo {
             channel_manager_receiver,
             channel_manager_sender,
@@ -181,7 +173,6 @@ impl Upstream {
             upstream_receiver: inbound_rx,
         };
         Ok(Upstream {
-            upstream_data,
             upstream_io,
             required_extensions,
             address: addr,

--- a/pool-apps/jd-server/src/lib/job_declarator/downstream/mod.rs
+++ b/pool-apps/jd-server/src/lib/job_declarator/downstream/mod.rs
@@ -8,7 +8,11 @@ use super::{
     DownstreamJobDeclarationMessage, JobDeclarationMessage, ALLOCATED_TOKEN_TIMEOUT_SECS,
     JANITOR_INTERVAL_SECS,
 };
-use crate::{error, error::JDSResult, error::LoopControl, io_task::spawn_io_tasks};
+use crate::{
+    error,
+    error::{JDSResult, LoopControl},
+    io_task::spawn_io_tasks,
+};
 use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::job_declaration_protocol::CancellationToken;
 use dashmap::DashMap;

--- a/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
@@ -257,7 +257,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 error!("Failed to forward message {e:?}");
             }
         }
@@ -530,7 +530,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 error!("Failed to forward message {e:?}");
             }
         }
@@ -696,7 +696,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 error!("Failed to forward message {e:?}");
             }
         }
@@ -893,7 +893,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 error!("Failed to forward message {e:?}");
             }
         }
@@ -1053,7 +1053,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 error!("Failed to forward message {e:?}");
             }
         }
@@ -1083,7 +1083,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             let message: RouteMessageTo =
                 (downstream_id, Mining::SetCustomMiningJobError(error)).into();
             message
-                .forward(&self.channel_manager_channel)
+                .forward(&self.channel_manager_io)
                 .await
                 .map_err(|e| PoolError::disconnect(e, downstream_id))?;
             return Ok(());
@@ -1104,7 +1104,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             )
                 .into();
             message
-                .forward(&self.channel_manager_channel)
+                .forward(&self.channel_manager_io)
                 .await
                 .map_err(|e| PoolError::disconnect(e, downstream_id))?;
             return Ok(());
@@ -1157,7 +1157,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 })?;
 
         message
-            .forward(&self.channel_manager_channel)
+            .forward(&self.channel_manager_io)
             .await
             .map_err(|e| PoolError::disconnect(e, downstream_id))?;
 

--- a/pool-apps/pool/src/lib/channel_manager/mod.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mod.rs
@@ -89,7 +89,7 @@ pub struct ChannelManagerData {
 }
 
 #[derive(Clone)]
-pub struct ChannelManagerChannel {
+pub struct ChannelManagerIo {
     tp_sender: Sender<TemplateDistribution<'static>>,
     tp_receiver: Receiver<TemplateDistribution<'static>>,
     downstream_sender: Arc<Mutex<HashMap<DownstreamId, Sender<DownstreamMessage>>>>,
@@ -102,7 +102,7 @@ pub struct ChannelManagerChannel {
 #[derive(Clone)]
 pub struct ChannelManager {
     pub(crate) channel_manager_data: Arc<Mutex<ChannelManagerData>>,
-    channel_manager_channel: ChannelManagerChannel,
+    channel_manager_io: ChannelManagerIo,
     pool_tag_string: String,
     share_batch_size: usize,
     shares_per_minute: SharesPerMinute,
@@ -174,7 +174,7 @@ impl ChannelManager {
             last_new_prev_hash: None,
         }));
 
-        let channel_manager_channel = ChannelManagerChannel {
+        let channel_manager_io = ChannelManagerIo {
             tp_sender,
             tp_receiver,
             downstream_sender: Arc::new(Mutex::new(HashMap::new())),
@@ -183,7 +183,7 @@ impl ChannelManager {
 
         let channel_manager = ChannelManager {
             channel_manager_data,
-            channel_manager_channel,
+            channel_manager_io,
             share_batch_size: config.share_batch_size(),
             shares_per_minute: config.shares_per_minute(),
             pool_tag_string: config.pool_signature().to_string(),
@@ -358,7 +358,7 @@ impl ChannelManager {
                                         this.required_extensions.clone(),
                                     );
 
-                                    this.channel_manager_channel.downstream_sender.super_safe_lock(|map| map.insert(downstream_id, channel_manager_sender));
+                                    this.channel_manager_io.downstream_sender.super_safe_lock(|map| map.insert(downstream_id, channel_manager_sender));
 
                                     this.channel_manager_data.super_safe_lock(|data| {
                                         data.downstream.insert(downstream_id, downstream.clone());
@@ -456,7 +456,7 @@ impl ChannelManager {
                 .vardiff
                 .retain(|key, _| key.downstream_id != downstream_id);
         });
-        self.channel_manager_channel
+        self.channel_manager_io
             .downstream_sender
             .super_safe_lock(|map| map.remove(&downstream_id));
     }
@@ -468,7 +468,7 @@ impl ChannelManager {
     //   distribution message handler.
     // - If the frame contains any unsupported message type, an error is returned.
     async fn handle_template_provider_message(&mut self) -> PoolResult<(), error::ChannelManager> {
-        if let Ok(message) = self.channel_manager_channel.tp_receiver.recv().await {
+        if let Ok(message) = self.channel_manager_io.tp_receiver.recv().await {
             self.handle_template_distribution_message_from_server(None, message, None)
                 .await?;
         }
@@ -476,11 +476,8 @@ impl ChannelManager {
     }
 
     async fn handle_downstream_mining_message(&mut self) -> PoolResult<(), error::ChannelManager> {
-        if let Ok((downstream_id, message, tlv_fields)) = self
-            .channel_manager_channel
-            .downstream_receiver
-            .recv()
-            .await
+        if let Ok((downstream_id, message, tlv_fields)) =
+            self.channel_manager_io.downstream_receiver.recv().await
         {
             let tlv_slice = tlv_fields.as_deref();
             self.handle_mining_message_from_client(Some(downstream_id), message, tlv_slice)
@@ -641,7 +638,7 @@ impl ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 error!("Failed to forward message {e:?}");
             }
         }
@@ -665,7 +662,7 @@ impl ChannelManager {
     ) -> PoolResult<(), error::ChannelManager> {
         let msg = coinbase_output_constraints_message_with_offset(coinbase_outputs);
 
-        self.channel_manager_channel
+        self.channel_manager_io
             .tp_sender
             .send(TemplateDistribution::CoinbaseOutputConstraints(msg))
             .await
@@ -699,13 +696,10 @@ impl<'a> From<(DownstreamId, Mining<'a>)> for RouteMessageTo<'a> {
 }
 
 impl RouteMessageTo<'_> {
-    pub async fn forward(
-        self,
-        channel_manager_channel: &ChannelManagerChannel,
-    ) -> Result<(), PoolErrorKind> {
+    pub async fn forward(self, channel_manager_io: &ChannelManagerIo) -> Result<(), PoolErrorKind> {
         match self {
             RouteMessageTo::Downstream((downstream_id, message)) => {
-                let sender = channel_manager_channel
+                let sender = channel_manager_io
                     .downstream_sender
                     .super_safe_lock(|map| map.get(&downstream_id).cloned());
 
@@ -716,7 +710,7 @@ impl RouteMessageTo<'_> {
                 }
             }
             RouteMessageTo::TemplateProvider(message) => {
-                channel_manager_channel
+                channel_manager_io
                     .tp_sender
                     .send(message.into_static())
                     .await?;

--- a/pool-apps/pool/src/lib/channel_manager/template_distribution_message_handler.rs
+++ b/pool-apps/pool/src/lib/channel_manager/template_distribution_message_handler.rs
@@ -137,7 +137,7 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
         }
@@ -259,7 +259,7 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
             // A send can only fail if the receiver side of the channel is closed.
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
-            if let Err(e) = message.forward(&self.channel_manager_channel).await {
+            if let Err(e) = message.forward(&self.channel_manager_io).await {
                 tracing::error!("Failed to forward message {e:?}");
             }
         }

--- a/pool-apps/pool/src/lib/downstream/common_message_handler.rs
+++ b/pool-apps/pool/src/lib/downstream/common_message_handler.rs
@@ -54,7 +54,7 @@ impl HandleCommonMessagesFromClientAsync for Downstream {
             let frame: Sv2Frame = AnyMessage::Common(response.into_static().into())
                 .try_into()
                 .map_err(PoolError::shutdown)?;
-            self.downstream_channel
+            self.downstream_io
                 .downstream_sender
                 .send(frame)
                 .await
@@ -93,7 +93,7 @@ impl HandleCommonMessagesFromClientAsync for Downstream {
         let frame: Sv2Frame = AnyMessage::Common(response.into_static().into())
             .try_into()
             .map_err(PoolError::shutdown)?;
-        self.downstream_channel
+        self.downstream_io
             .downstream_sender
             .send(frame)
             .await

--- a/pool-apps/pool/src/lib/downstream/extensions_message_handler.rs
+++ b/pool-apps/pool/src/lib/downstream/extensions_message_handler.rs
@@ -87,7 +87,7 @@ impl HandleExtensionsFromClientAsync for Downstream {
             let frame: Sv2Frame = AnyMessage::Extensions(error.into_static().into())
                 .try_into()
                 .map_err(PoolError::shutdown)?;
-            self.downstream_channel
+            self.downstream_io
                 .downstream_sender
                 .send(frame)
                 .await
@@ -127,7 +127,7 @@ impl HandleExtensionsFromClientAsync for Downstream {
             let frame: Sv2Frame = AnyMessage::Extensions(success.into_static().into())
                 .try_into()
                 .map_err(PoolError::shutdown)?;
-            self.downstream_channel
+            self.downstream_io
                 .downstream_sender
                 .send(frame)
                 .await

--- a/pool-apps/pool/src/lib/downstream/mod.rs
+++ b/pool-apps/pool/src/lib/downstream/mod.rs
@@ -70,7 +70,7 @@ pub struct DownstreamData {
 /// - `downstream_sender`: sends frames to the downstream.
 /// - `downstream_receiver`: receives frames from the downstream.
 #[derive(Clone)]
-pub struct DownstreamChannel {
+pub struct DownstreamIo {
     channel_manager_sender: Sender<(DownstreamId, Mining<'static>, Option<Vec<Tlv>>)>,
     channel_manager_receiver: Receiver<(Mining<'static>, Option<Vec<Tlv>>)>,
     downstream_sender: Sender<Sv2Frame>,
@@ -81,7 +81,7 @@ pub struct DownstreamChannel {
 #[derive(Clone)]
 pub struct Downstream {
     pub downstream_data: Arc<Mutex<DownstreamData>>,
-    downstream_channel: DownstreamChannel,
+    downstream_io: DownstreamIo,
     pub downstream_id: usize,
     pub requires_standard_jobs: Arc<AtomicBool>,
     pub requires_custom_work: Arc<AtomicBool>,
@@ -163,7 +163,7 @@ impl Downstream {
             downstream_connection_token.clone(),
         );
 
-        let downstream_channel = DownstreamChannel {
+        let downstream_io = DownstreamIo {
             channel_manager_receiver,
             channel_manager_sender,
             downstream_sender: outbound_tx,
@@ -180,7 +180,7 @@ impl Downstream {
         }));
 
         Downstream {
-            downstream_channel,
+            downstream_io,
             downstream_data,
             downstream_id,
             requires_standard_jobs: Arc::new(AtomicBool::new(false)),
@@ -265,7 +265,7 @@ impl Downstream {
     // Performs the initial handshake with a downstream peer.
     async fn setup_connection_with_downstream(&mut self) -> PoolResult<(), error::Downstream> {
         let mut frame = self
-            .downstream_channel
+            .downstream_io
             .downstream_receiver
             .recv()
             .await
@@ -296,12 +296,7 @@ impl Downstream {
 
     // Handles messages sent from the channel manager to this downstream.
     async fn handle_channel_manager_message(self) -> PoolResult<(), error::Downstream> {
-        let (msg, _tlv_fields) = match self
-            .downstream_channel
-            .channel_manager_receiver
-            .recv()
-            .await
-        {
+        let (msg, _tlv_fields) = match self.downstream_io.channel_manager_receiver.recv().await {
             Ok(msg) => msg,
             Err(e) => {
                 warn!(
@@ -318,7 +313,7 @@ impl Downstream {
         let message = AnyMessage::Mining(msg);
         let std_frame: Sv2Frame = message.try_into().map_err(PoolError::shutdown)?;
 
-        self.downstream_channel
+        self.downstream_io
             .downstream_sender
             .send(std_frame)
             .await
@@ -333,7 +328,7 @@ impl Downstream {
     // Handles incoming messages from the downstream peer.
     async fn handle_downstream_message(&mut self) -> PoolResult<(), error::Downstream> {
         let mut sv2_frame = self
-            .downstream_channel
+            .downstream_io
             .downstream_receiver
             .recv()
             .await
@@ -368,7 +363,7 @@ impl Downstream {
                         ));
                     }
                 };
-                self.downstream_channel
+                self.downstream_io
                     .channel_manager_sender
                     .send((self.downstream_id, mining_message, tlv_fields))
                     .await

--- a/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 #[derive(Clone)]
-pub struct Sv2TpChannel {
+pub struct Sv2TpIo {
     channel_manager_sender: Sender<TemplateDistribution<'static>>,
     channel_manager_receiver: Receiver<TemplateDistribution<'static>>,
     tp_sender: Sender<Sv2Frame>,
@@ -35,7 +35,7 @@ pub struct Sv2TpChannel {
 
 #[derive(Clone)]
 pub struct Sv2Tp {
-    sv2_tp_channel: Sv2TpChannel,
+    sv2_tp_io: Sv2TpIo,
 }
 
 #[cfg_attr(not(test), hotpath::measure_all)]
@@ -112,7 +112,7 @@ impl Sv2Tp {
                                         cancellation_token.clone(),
                                     );
 
-                                    let template_receiver_channel = Sv2TpChannel {
+                                    let sv2_tp_io = Sv2TpIo {
                                         channel_manager_receiver,
                                         channel_manager_sender,
                                         tp_receiver: inbound_rx,
@@ -121,7 +121,7 @@ impl Sv2Tp {
 
                                     info!(attempt, "TemplateReceiver initialized successfully");
                                     return Ok(Sv2Tp {
-                                        sv2_tp_channel: template_receiver_channel,
+                                        sv2_tp_io,
                                     });
                                 }
                                 Err(network_helpers::Error::InvalidKey) => {
@@ -221,7 +221,7 @@ impl Sv2Tp {
         &mut self,
     ) -> PoolResult<(), error::TemplateProvider> {
         let mut sv2_frame = self
-            .sv2_tp_channel
+            .sv2_tp_io
             .tp_receiver
             .recv()
             .await
@@ -249,7 +249,7 @@ impl Sv2Tp {
                         .map_err(PoolError::shutdown)?
                         .into_static();
 
-                self.sv2_tp_channel
+                self.sv2_tp_io
                     .channel_manager_sender
                     .send(message)
                     .await
@@ -274,7 +274,7 @@ impl Sv2Tp {
     /// Forwards outbound frames upstream
     pub async fn handle_channel_manager_message(&self) -> PoolResult<(), error::TemplateProvider> {
         let msg = self
-            .sv2_tp_channel
+            .sv2_tp_io
             .channel_manager_receiver
             .recv()
             .await
@@ -283,7 +283,7 @@ impl Sv2Tp {
         let frame: Sv2Frame = message.try_into().map_err(PoolError::shutdown)?;
 
         debug!("Forwarding message from channel manager to outbound_tx");
-        self.sv2_tp_channel
+        self.sv2_tp_io
             .tp_sender
             .send(frame)
             .await
@@ -309,17 +309,13 @@ impl Sv2Tp {
             .map_err(PoolError::shutdown)?;
 
         info!("Sending SetupConnection message to the Template Provider");
-        self.sv2_tp_channel
-            .tp_sender
-            .send(frame)
-            .await
-            .map_err(|_| {
-                error!("Failed to send setup connection message upstream");
-                PoolError::shutdown(PoolErrorKind::ChannelErrorSender)
-            })?;
+        self.sv2_tp_io.tp_sender.send(frame).await.map_err(|_| {
+            error!("Failed to send setup connection message upstream");
+            PoolError::shutdown(PoolErrorKind::ChannelErrorSender)
+        })?;
 
         info!("Waiting for upstream handshake response");
-        let mut incoming: Sv2Frame = self.sv2_tp_channel.tp_receiver.recv().await.map_err(|e| {
+        let mut incoming: Sv2Frame = self.sv2_tp_io.tp_receiver.recv().await.map_err(|e| {
             error!(?e, "Upstream connection closed during handshake");
             PoolError::shutdown(e)
         })?;


### PR DESCRIPTION
We have `channel_state` defined for each subsystem in the pool and JDC. This PR renames them to the IO variant and removes some unused types in JDC.
