### PR TITLE
Fix jdc fallback

### DIFF
--- a/bitcoin-core-sv2/src/template_distribution_protocol/handlers.rs
+++ b/bitcoin-core-sv2/src/template_distribution_protocol/handlers.rs
@@ -17,34 +17,18 @@ impl BitcoinCoreSv2TDP {
     ) -> Result<(), BitcoinCoreSv2TDPError> {
         tracing::debug!("handle_coinbase_output_constraints() called");
 
-        // break the loop in monitor_ipc_templates() and spawn a new one at the end of this function
-        // that's because we no longer care about templates created under previous constraints
+        // Break the loop in monitor_ipc_templates() and spawn a new one after bootstrapping the
+        // new template IPC client. We no longer care about templates created under previous
+        // constraints for future template monitoring.
         tracing::debug!("Cancelling template_ipc_client_cancellation_token");
         self.template_ipc_client_cancellation_token.cancel();
 
-        tracing::debug!("Creating new template IPC client with new constraints");
-        let template_ipc_client = self
-            .new_template_ipc_client(
-                coinbase_output_constraints.coinbase_output_max_additional_size,
-                coinbase_output_constraints.coinbase_output_max_additional_sigops,
-            )
-            .await
-            .map_err(|e| {
-                tracing::error!("Failed to create new template IPC client: {:?}", e);
-                e
-            })?;
-
-        {
-            let mut current_template_ipc_client_guard =
-                self.current_template_ipc_client.borrow_mut();
-            *current_template_ipc_client_guard = Some(template_ipc_client);
-        }
-        tracing::debug!("Updated current_template_ipc_client");
-
-        self.template_ipc_client_cancellation_token = CancellationToken::new();
-        tracing::debug!("Created new template_ipc_client_cancellation_token");
-
-        // Wait for the old monitor_ipc_templates task to finish before spawning a new one
+        // Wait for the old monitor_ipc_templates task to finish before bootstrapping a new
+        // template IPC client.
+        //
+        // This keeps template monitoring scoped to one coinbase-output constraint set at a time:
+        // the old monitor interrupts its own in-flight waitNext request and exits before the
+        // replacement client is published and monitored.
         tracing::debug!("Waiting for current monitor_ipc_templates() task to finish");
         let handle = self.monitor_ipc_templates_handle.borrow_mut().take();
         #[allow(clippy::collapsible_if)]
@@ -54,6 +38,19 @@ impl BitcoinCoreSv2TDP {
                 return Err(BitcoinCoreSv2TDPError::FailedToWaitForMonitorIpcTemplatesTask);
             }
         }
+
+        self.template_ipc_client_cancellation_token = CancellationToken::new();
+        tracing::debug!("Created new template_ipc_client_cancellation_token");
+
+        tracing::debug!("Bootstrapping new template IPC client with new constraints");
+        self.bootstrap_template_ipc_client_from_coinbase_output_constraints(
+            coinbase_output_constraints,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to bootstrap new template IPC client: {:?}", e);
+            e
+        })?;
 
         tracing::debug!("Spawning new monitor_ipc_templates() task");
         self.monitor_ipc_templates();

--- a/bitcoin-core-sv2/src/template_distribution_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/template_distribution_protocol/mod.rs
@@ -28,6 +28,7 @@ use stratum_core::{
     binary_sv2::U256,
     bitcoin::{Transaction, block::Header, consensus::deserialize},
     parsers_sv2::TemplateDistribution,
+    template_distribution_sv2::CoinbaseOutputConstraints,
 };
 
 use std::sync::RwLock;
@@ -212,24 +213,28 @@ impl BitcoinCoreSv2TDP {
                                 coinbase_output_constraints.coinbase_output_max_additional_size,
                                 coinbase_output_constraints.coinbase_output_max_additional_sigops);
 
-                            let template_ipc_client = match self.new_template_ipc_client(coinbase_output_constraints.coinbase_output_max_additional_size, coinbase_output_constraints.coinbase_output_max_additional_sigops).await {
-                                Ok(template_ipc_client) => {
-                                    tracing::debug!("Successfully created initial template IPC client");
-                                    template_ipc_client
-                                },
+                            match self
+                                .bootstrap_template_ipc_client_from_coinbase_output_constraints(
+                                    coinbase_output_constraints,
+                                )
+                                .await
+                            {
+                                Ok(()) => {
+                                    tracing::debug!(
+                                        "Successfully bootstrapped initial template IPC client"
+                                    );
+                                    break;
+                                }
                                 Err(e) => {
-                                    tracing::error!("Failed to create new template IPC client: {:?}", e);
+                                    tracing::error!(
+                                        "Failed to bootstrap initial template IPC client: {:?}",
+                                        e
+                                    );
                                     tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
                                     self.global_cancellation_token.cancel();
                                     return;
                                 }
-                            };
-
-                            let mut current_template_ipc_client_guard = self.current_template_ipc_client.borrow_mut();
-                            *current_template_ipc_client_guard = Some(template_ipc_client);
-                            tracing::debug!("Set current_template_ipc_client to initial template");
-
-                            break;
+                            }
                         }
                         _ => {
                             tracing::warn!("Received unexpected message: {:?}", message);
@@ -239,113 +244,6 @@ impl BitcoinCoreSv2TDP {
                     }
                 }
             }
-        }
-
-        // bootstrap the first template
-        {
-            tracing::debug!("Bootstrapping first template...");
-            let template_data = match self
-                .fetch_template_data(self.thread_ipc_client.clone())
-                .await
-            {
-                Ok(template_data) => {
-                    tracing::debug!(
-                        "Successfully fetched initial template data - template_id: {}",
-                        template_data.get_template_id()
-                    );
-                    template_data
-                }
-                Err(e) => {
-                    tracing::error!("Failed to fetch template data: {:?}", e);
-                    tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                    self.global_cancellation_token.cancel();
-                    return;
-                }
-            };
-
-            // send the future NewTemplate message
-            let future_template = match template_data.get_new_template_message(true) {
-                Ok(future_template) => future_template,
-                Err(e) => {
-                    tracing::error!("Failed to get future template message: {:?}", e);
-                    tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                    self.global_cancellation_token.cancel();
-                    return;
-                }
-            };
-
-            tracing::debug!(
-                "Sending initial NewTemplate (future=true) with template_id: {}",
-                template_data.get_template_id()
-            );
-
-            match self
-                .outgoing_messages
-                .send(TemplateDistribution::NewTemplate(future_template.clone()))
-                .await
-            {
-                Ok(_) => {
-                    tracing::debug!("Successfully sent initial NewTemplate message");
-                }
-                Err(e) => {
-                    tracing::error!("Failed to send future template message: {:?}", e);
-                    tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                    self.global_cancellation_token.cancel();
-                    return;
-                }
-            }
-
-            // send the SetNewPrevHash message
-            let set_new_prev_hash = template_data.get_set_new_prev_hash_message();
-            tracing::debug!(
-                "Sending initial SetNewPrevHash with prev_hash: {}",
-                template_data.get_prev_hash()
-            );
-
-            match self
-                .outgoing_messages
-                .send(TemplateDistribution::SetNewPrevHash(
-                    set_new_prev_hash.clone(),
-                ))
-                .await
-            {
-                Ok(_) => {
-                    tracing::debug!("Successfully sent initial SetNewPrevHash message");
-                }
-                Err(e) => {
-                    tracing::error!("Failed to send set new prev hash message: {:?}", e);
-                    tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                    self.global_cancellation_token.cancel();
-                    return;
-                }
-            }
-
-            // save the template data
-            let mut template_data_guard = match self.template_data.write() {
-                Ok(guard) => guard,
-                Err(e) => {
-                    tracing::error!("Failed to acquire write lock on template_data: {:?}", e);
-                    tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                    self.global_cancellation_token.cancel();
-                    return;
-                }
-            };
-            template_data_guard.insert(template_data.get_template_id(), template_data.clone());
-            tracing::debug!(
-                "Saved initial template data with template_id: {}",
-                template_data.get_template_id()
-            );
-
-            // save the current prev hash
-            self.current_prev_hash
-                .replace(Some(template_data.get_prev_hash()));
-            tracing::debug!(
-                "Set current_prev_hash to: {}",
-                template_data.get_prev_hash()
-            );
-
-            // save last_sent_template_instant
-            self.last_sent_template_instant = Some(std::time::Instant::now());
         }
 
         // spawn the monitoring tasks
@@ -382,6 +280,7 @@ impl BitcoinCoreSv2TDP {
 
     async fn fetch_template_data(
         &self,
+        template_ipc_client: BlockTemplateIpcClient,
         thread_ipc_client: ThreadIpcClient,
     ) -> Result<TemplateData, BitcoinCoreSv2TDPError> {
         tracing::debug!("Fetching template data over IPC");
@@ -390,17 +289,6 @@ impl BitcoinCoreSv2TDP {
             "fetch_template_data() - assigned template_id: {}",
             template_id
         );
-
-        // clone the current template IPC client so it's stored in the template data HashMap
-        // this is important in case we need to submit a solution relative to this specific template
-        // by the time self.current_template_ipc_client might have already changed
-        let template_ipc_client = match self.current_template_ipc_client.borrow().clone() {
-            Some(template_ipc_client) => template_ipc_client,
-            None => {
-                tracing::error!("Template IPC client not found");
-                return Err(BitcoinCoreSv2TDPError::TemplateIpcClientNotFound);
-            }
-        };
 
         let mut template_header_request = template_ipc_client.get_block_header_request();
         template_header_request
@@ -487,15 +375,138 @@ impl BitcoinCoreSv2TDP {
         Ok(thread_ipc_client)
     }
 
-    async fn new_template_ipc_client(
+    fn set_current_template_ipc_client(&self, template_ipc_client: BlockTemplateIpcClient) {
+        let mut current_template_ipc_client_guard = self.current_template_ipc_client.borrow_mut();
+        *current_template_ipc_client_guard = Some(template_ipc_client);
+        tracing::debug!("Updated current_template_ipc_client");
+    }
+
+    fn current_template_ipc_client(
         &self,
-        coinbase_output_max_additional_size: u32,
-        coinbase_output_max_additional_sigops: u16,
     ) -> Result<BlockTemplateIpcClient, BitcoinCoreSv2TDPError> {
+        match self.current_template_ipc_client.borrow().clone() {
+            Some(template_ipc_client) => Ok(template_ipc_client),
+            None => {
+                tracing::error!("Template IPC client not found");
+                Err(BitcoinCoreSv2TDPError::TemplateIpcClientNotFound)
+            }
+        }
+    }
+
+    fn store_template_data(
+        &self,
+        template_data: &TemplateData,
+    ) -> Result<(), BitcoinCoreSv2TDPError> {
+        let mut template_data_guard = self.template_data.write().map_err(|e| {
+            tracing::error!("Failed to acquire write lock on template_data: {:?}", e);
+            BitcoinCoreSv2TDPError::FailedToSendNewTemplateMessage
+        })?;
+
+        template_data_guard.insert(template_data.get_template_id(), template_data.clone());
         tracing::debug!(
-            "new_template_ipc_client() called - max_size: {}, max_sigops: {}",
-            coinbase_output_max_additional_size,
-            coinbase_output_max_additional_sigops
+            "Saved template data with template_id: {}",
+            template_data.get_template_id()
+        );
+
+        Ok(())
+    }
+
+    fn current_template_ids(&self) -> Result<HashSet<u64>, BitcoinCoreSv2TDPError> {
+        let template_data_guard = self.template_data.read().map_err(|e| {
+            tracing::error!("Failed to acquire read lock on template_data: {:?}", e);
+            BitcoinCoreSv2TDPError::FailedToSendNewTemplateMessage
+        })?;
+
+        Ok(template_data_guard.keys().copied().collect())
+    }
+
+    async fn publish_template(
+        &mut self,
+        template_data: TemplateData,
+        future_template: bool,
+        send_set_new_prev_hash: bool,
+        update_last_sent_template_instant: bool,
+    ) -> Result<(), BitcoinCoreSv2TDPError> {
+        let new_template = template_data
+            .get_new_template_message(future_template)
+            .map_err(|e| {
+                tracing::error!("Failed to get NewTemplate message: {:?}", e);
+                BitcoinCoreSv2TDPError::FailedToSendNewTemplateMessage
+            })?;
+        let set_new_prev_hash = if send_set_new_prev_hash {
+            Some(template_data.get_set_new_prev_hash_message())
+        } else {
+            None
+        };
+
+        self.store_template_data(&template_data)?;
+
+        if send_set_new_prev_hash {
+            self.current_prev_hash
+                .replace(Some(template_data.get_prev_hash()));
+            tracing::debug!(
+                "Set current_prev_hash to: {}",
+                template_data.get_prev_hash()
+            );
+        }
+
+        tracing::debug!(
+            "Sending NewTemplate (future={}) with template_id: {}",
+            future_template,
+            template_data.get_template_id()
+        );
+        self.outgoing_messages
+            .send(TemplateDistribution::NewTemplate(new_template))
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to send NewTemplate message: {:?}", e);
+                BitcoinCoreSv2TDPError::FailedToSendNewTemplateMessage
+            })?;
+        tracing::debug!("Successfully sent NewTemplate message");
+
+        if let Some(set_new_prev_hash) = set_new_prev_hash {
+            tracing::debug!(
+                "Sending SetNewPrevHash with prev_hash: {}",
+                template_data.get_prev_hash()
+            );
+            self.outgoing_messages
+                .send(TemplateDistribution::SetNewPrevHash(set_new_prev_hash))
+                .await
+                .map_err(|e| {
+                    tracing::error!("Failed to send SetNewPrevHash message: {:?}", e);
+                    BitcoinCoreSv2TDPError::FailedToSendSetNewPrevHashMessage
+                })?;
+            tracing::debug!("Successfully sent SetNewPrevHash message");
+        }
+
+        if update_last_sent_template_instant {
+            self.last_sent_template_instant = Some(Instant::now());
+        }
+
+        Ok(())
+    }
+
+    /// Creates a fresh Bitcoin Core Template IPC client from the given
+    /// [`CoinbaseOutputConstraints`] and immediately sends a `NewTemplate` + `SetNewPrevHash`.
+    ///
+    /// This method intentionally couples these operations because every constraints update should
+    /// make a newly constrained template visible to the Sv2 side right away. On success, it:
+    ///
+    /// - creates a new `BlockTemplateIpcClient` configured with the provided constraints
+    /// - fetches the corresponding `TemplateData`
+    /// - stores the fetched `TemplateData`
+    /// - sends `NewTemplate(future_template = true)`
+    /// - sends the matching `SetNewPrevHash`
+    /// - updates `current_prev_hash` and `last_sent_template_instant`
+    /// - stores the client as `current_template_ipc_client`
+    async fn bootstrap_template_ipc_client_from_coinbase_output_constraints(
+        &mut self,
+        coinbase_output_constraints: CoinbaseOutputConstraints,
+    ) -> Result<(), BitcoinCoreSv2TDPError> {
+        tracing::debug!(
+            "bootstrap_template_ipc_client_from_coinbase_output_constraints() called - max_size: {}, max_sigops: {}",
+            coinbase_output_constraints.coinbase_output_max_additional_size,
+            coinbase_output_constraints.coinbase_output_max_additional_sigops
         );
 
         let mut template_ipc_client_request = self.mining_ipc_client.create_new_block_request();
@@ -507,12 +518,13 @@ impl BitcoinCoreSv2TDP {
                 e
             })?;
 
-        let coinbase_weight = (coinbase_output_max_additional_size * WEIGHT_FACTOR) as u64;
+        let coinbase_weight = (coinbase_output_constraints.coinbase_output_max_additional_size
+            * WEIGHT_FACTOR) as u64;
         let block_reserved_weight = coinbase_weight.max(MIN_BLOCK_RESERVED_WEIGHT); // 2000 is the minimum block reserved weight
         tracing::debug!("Setting block_reserved_weight: {block_reserved_weight}");
         template_ipc_client_request_options.set_block_reserved_weight(block_reserved_weight);
         template_ipc_client_request_options.set_coinbase_output_max_additional_sigops(
-            coinbase_output_max_additional_sigops as u64,
+            coinbase_output_constraints.coinbase_output_max_additional_sigops as u64,
         );
         template_ipc_client_request_options.set_use_mempool(true);
 
@@ -536,18 +548,26 @@ impl BitcoinCoreSv2TDP {
             e
         })?;
 
-        Ok(template_ipc_client)
+        tracing::debug!("Fetching template data from bootstrapped template IPC client");
+        let template_data = self
+            .fetch_template_data(template_ipc_client.clone(), self.thread_ipc_client.clone())
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to fetch template data: {:?}", e);
+                e
+            })?;
+
+        self.publish_template(template_data, true, true, true)
+            .await?;
+        self.set_current_template_ipc_client(template_ipc_client);
+
+        Ok(())
     }
 
-    async fn interrupt_wait_request(&self) -> Result<(), BitcoinCoreSv2TDPError> {
-        let template_ipc_client = match self.current_template_ipc_client.borrow().clone() {
-            Some(template_ipc_client) => template_ipc_client,
-            None => {
-                tracing::error!("Template IPC client not found");
-                return Err(BitcoinCoreSv2TDPError::TemplateIpcClientNotFound);
-            }
-        };
-
+    async fn interrupt_wait_request(
+        &self,
+        template_ipc_client: &BlockTemplateIpcClient,
+    ) -> Result<(), BitcoinCoreSv2TDPError> {
         let interrupt_wait_request = template_ipc_client.interrupt_wait_request();
         if let Err(e) = interrupt_wait_request.send().promise.await {
             tracing::error!("Failed to send interrupt wait request: {}", e);
@@ -559,16 +579,9 @@ impl BitcoinCoreSv2TDP {
 
     async fn new_wait_next_request(
         &self,
+        template_ipc_client: &BlockTemplateIpcClient,
         thread_ipc_client: ThreadIpcClient,
     ) -> Result<Request<WaitNextParams, WaitNextResults>, BitcoinCoreSv2TDPError> {
-        let template_ipc_client = match self.current_template_ipc_client.borrow().clone() {
-            Some(template_ipc_client) => template_ipc_client,
-            None => {
-                tracing::error!("Template IPC client not found");
-                return Err(BitcoinCoreSv2TDPError::TemplateIpcClientNotFound);
-            }
-        };
-
         let mut wait_next_request = template_ipc_client.wait_next_request();
 
         match wait_next_request.get().get_context() {

--- a/bitcoin-core-sv2/src/template_distribution_protocol/monitors.rs
+++ b/bitcoin-core-sv2/src/template_distribution_protocol/monitors.rs
@@ -1,6 +1,5 @@
 use crate::template_distribution_protocol::BitcoinCoreSv2TDP;
 
-use std::collections::HashSet;
 use stratum_core::parsers_sv2::TemplateDistribution;
 use tracing::info;
 
@@ -35,13 +34,23 @@ impl BitcoinCoreSv2TDP {
                 }
             };
 
+            let mut template_ipc_client = match self_clone.current_template_ipc_client() {
+                Ok(template_ipc_client) => template_ipc_client,
+                Err(e) => {
+                    tracing::error!("Failed to get current template IPC client: {:?}", e);
+                    tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
+                    self_clone.global_cancellation_token.cancel();
+                    return;
+                }
+            };
+
             tracing::debug!("monitor_ipc_templates() entering main loop");
             loop {
                 tracing::debug!("monitor_ipc_templates() loop iteration start");
 
                 // Create a new request for each iteration
                 let wait_next_request = match self_clone
-                    .new_wait_next_request(blocking_thread_ipc_client.clone())
+                    .new_wait_next_request(&template_ipc_client, blocking_thread_ipc_client.clone())
                     .await
                 {
                     Ok(wait_next_request) => wait_next_request,
@@ -56,13 +65,15 @@ impl BitcoinCoreSv2TDP {
                 tokio::select! {
                     _ = self_clone.global_cancellation_token.cancelled() => {
                         tracing::debug!("Interrupting waitNext request");
-                        self_clone.interrupt_wait_request().await.expect("Failed to interrupt waitNext request");
+                        if let Err(e) = self_clone.interrupt_wait_request(&template_ipc_client).await {
+                            tracing::error!("Failed to interrupt waitNext request during shutdown: {:?}", e);
+                        }
                         tracing::warn!("Exiting mempool change monitoring loop");
                         break;
                     }
                     _ = self_clone.template_ipc_client_cancellation_token.cancelled() => {
                         tracing::debug!("Interrupting waitNext request");
-                        if let Err(e) = self_clone.interrupt_wait_request().await {
+                        if let Err(e) = self_clone.interrupt_wait_request(&template_ipc_client).await {
                             tracing::error!("Failed to interrupt waitNext request: {:?}", e);
                             tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
                             self_clone.global_cancellation_token.cancel();
@@ -106,14 +117,11 @@ impl BitcoinCoreSv2TDP {
                                     }
                                 };
 
-                                {
-                                    let mut current_template_ipc_client_guard = self_clone.current_template_ipc_client.borrow_mut();
-                                    *current_template_ipc_client_guard = Some(new_template_ipc_client);
-                                    tracing::debug!("Updated current_template_ipc_client with new template");
-                                }
-
                                 tracing::debug!("Fetching new template data...");
-                                let new_template_data = match self_clone.fetch_template_data(blocking_thread_ipc_client.clone()).await {
+                                let new_template_data = match self_clone.fetch_template_data(
+                                    new_template_ipc_client.clone(),
+                                    blocking_thread_ipc_client.clone(),
+                                ).await {
                                     Ok(new_template_data) => new_template_data,
                                     Err(e) => {
                                         tracing::error!("Failed to fetch template data: {:?}", e);
@@ -137,66 +145,32 @@ impl BitcoinCoreSv2TDP {
                                 if new_prev_hash != current_prev_hash {
                                     info!("⛓️ Chain Tip changed! New prev_hash: {}", new_prev_hash);
                                     tracing::debug!("CHAIN TIP CHANGE DETECTED - old: {}, new: {}", current_prev_hash, new_prev_hash);
-                                    self_clone.current_prev_hash.replace(Some(new_prev_hash));
 
-                                    // save stale template ids, cleanup and save the new template data
-                                    let stale_template_ids = {
-                                        let mut template_data_guard = match self_clone.template_data.write() {
-                                            Ok(guard) => guard,
-                                            Err(e) => {
-                                                tracing::error!("Failed to acquire write lock on template_data: {:?}", e);
-                                                tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                                                self_clone.global_cancellation_token.cancel();
-                                                break;
-                                            }
-                                        };
-
-                                        let stale_template_ids: HashSet<_> = template_data_guard.clone().into_keys().collect();
-
-                                        // save the new template data while we still have the lock
-                                        tracing::debug!("Saving new template data with template_id: {}", new_template_data.get_template_id());
-                                        template_data_guard.insert(new_template_data.get_template_id(), new_template_data.clone());
-
-                                        stale_template_ids
+                                    let stale_template_ids = match self_clone.current_template_ids() {
+                                        Ok(stale_template_ids) => stale_template_ids,
+                                        Err(e) => {
+                                            tracing::error!("Failed to collect stale template ids: {:?}", e);
+                                            tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
+                                            self_clone.global_cancellation_token.cancel();
+                                            break;
+                                        }
                                     };
+
+                                    match self_clone.publish_template(new_template_data, true, true, false).await {
+                                        Ok(()) => {
+                                            self_clone.set_current_template_ipc_client(new_template_ipc_client.clone());
+                                            template_ipc_client = new_template_ipc_client;
+                                        }
+                                        Err(e) => {
+                                            tracing::error!("Failed to publish chain-tip template: {:?}", e);
+                                            tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
+                                            self_clone.global_cancellation_token.cancel();
+                                            break;
+                                        }
+                                    }
 
                                     // process the stale template data after 10s
                                     self_clone.process_stale_template_data(stale_template_ids).await;
-
-                                    // send the future NewTemplate message
-                                    let future_template = match new_template_data.get_new_template_message(true) {
-                                        Ok(future_template) => future_template,
-                                        Err(e) => {
-                                            tracing::error!("Failed to get future template message: {:?}", e);
-                                            tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                                            self_clone.global_cancellation_token.cancel();
-                                            break;
-                                        }
-                                    };
-                                    tracing::debug!("Sending NewTemplate (future=true) after chain tip change");
-
-                                    if let Err(e) = self_clone.outgoing_messages.send(TemplateDistribution::NewTemplate(future_template.clone())).await {
-                                        tracing::error!("Failed to send future NewTemplate message: {:?}", e);
-                                        tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                                        self_clone.global_cancellation_token.cancel();
-                                        break;
-                                    }
-
-                                    // send the SetNewPrevHash message
-                                    let set_new_prev_hash = new_template_data.get_set_new_prev_hash_message();
-                                    tracing::debug!("Sending SetNewPrevHash after chain tip change");
-
-                                    match self_clone.outgoing_messages.send(TemplateDistribution::SetNewPrevHash(set_new_prev_hash.clone())).await {
-                                        Ok(_) => {
-                                            tracing::debug!("Successfully sent SetNewPrevHash");
-                                        },
-                                        Err(e) => {
-                                            tracing::error!("Failed to send SetNewPrevHash message: {:?}", e);
-                                            tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                                            self_clone.global_cancellation_token.cancel();
-                                            break;
-                                        }
-                                    }
                                 } else {
                                     // check if the minimum interval has been reached
                                     if let Some(last_sent_template_instant) = self_clone.last_sent_template_instant {
@@ -213,43 +187,21 @@ impl BitcoinCoreSv2TDP {
                                         }
                                     }
 
-                                    self_clone.last_sent_template_instant = Some(std::time::Instant::now());
-
                                     info!("💹 Mempool fees increased! Sending NewTemplate message.");
                                     tracing::debug!("MEMPOOL FEE CHANGE DETECTED - sending non-future template");
 
-                                    // send the non-future NewTemplate message
-                                    let non_future_template = match new_template_data.get_new_template_message(false) {
-                                        Ok(non_future_template) => non_future_template,
+                                    match self_clone.publish_template(new_template_data, false, false, true).await {
+                                        Ok(()) => {
+                                            self_clone.set_current_template_ipc_client(new_template_ipc_client.clone());
+                                            template_ipc_client = new_template_ipc_client;
+                                        }
                                         Err(e) => {
-                                            tracing::error!("Failed to get non-future template message: {:?}", e);
+                                            tracing::error!("Failed to publish fee-update template: {:?}", e);
                                             tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
                                             self_clone.global_cancellation_token.cancel();
                                             break;
                                         }
-                                    };
-                                    tracing::debug!("Sending NewTemplate (future=false) after fee change");
-
-                                    if let Err(e) = self_clone.outgoing_messages.send(TemplateDistribution::NewTemplate(non_future_template.clone())).await {
-                                        tracing::error!("Failed to send future NewTemplate message: {:?}", e);
-                                        tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                                        self_clone.global_cancellation_token.cancel();
-                                        break;
                                     }
-
-                                    // save the new template data
-                                    tracing::debug!("Saving template data for template_id: {}", new_template_data.get_template_id());
-                                    let mut template_data_guard = match self_clone.template_data.write() {
-                                        Ok(guard) => guard,
-                                        Err(e) => {
-                                            tracing::error!("Failed to acquire write lock on template_data: {:?}", e);
-                                            tracing::warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                                            self_clone.global_cancellation_token.cancel();
-                                            break;
-                                        }
-                                    };
-                                    template_data_guard.insert(new_template_data.get_template_id(), new_template_data.clone());
-
                                 }
                             }
                             Err(e) => {

--- a/integration-tests/tests/jdc_fallback_to_solo.rs
+++ b/integration-tests/tests/jdc_fallback_to_solo.rs
@@ -1,0 +1,164 @@
+use integration_tests_sv2::{interceptor::MessageDirection, template_provider::DifficultyLevel, *};
+use stratum_apps::stratum_core::{common_messages_sv2::*, job_declaration_sv2::*};
+
+// launch a JDC (with Bitcoin Core IPC) connected to a Pool/JDS and then triggers a fallback to solo
+// then it mines a block using solo and verifies the block was propagated
+// meant to avoid regressions like https://github.com/stratum-mining/sv2-apps/issues/466
+#[tokio::test]
+async fn jdc_fallback_to_solo_mines_block_with_bitcoin_core_ipc() {
+    start_tracing();
+    let bitcoin_core = start_bitcoin_core(DifficultyLevel::Low);
+    let current_block_hash = bitcoin_core.get_best_block_hash().unwrap();
+
+    let (pool, pool_addr, jds_addr, _) =
+        start_pool_with_jds(&bitcoin_core, vec![], vec![], false).await;
+    let (jdc_jds_sniffer, jdc_jds_sniffer_addr) = start_sniffer(
+        "jdc-fallback-bitcoin-core-jds",
+        jds_addr,
+        false,
+        vec![],
+        None,
+    );
+    let (jdc, jdc_addr, _) = start_jdc(
+        &[(pool_addr, jdc_jds_sniffer_addr)],
+        ipc_config(
+            bitcoin_core.data_dir().clone(),
+            bitcoin_core.is_signet(),
+            None,
+        ),
+        vec![],
+        vec![],
+        false,
+        None,
+    );
+
+    // assert JDC-JDS connection is established
+    {
+        jdc_jds_sniffer
+            .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+            .await;
+        jdc_jds_sniffer
+            .wait_for_message_type(
+                MessageDirection::ToDownstream,
+                MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+            )
+            .await;
+        jdc_jds_sniffer
+            .wait_for_message_type(
+                MessageDirection::ToUpstream,
+                MESSAGE_TYPE_ALLOCATE_MINING_JOB_TOKEN,
+            )
+            .await;
+        jdc_jds_sniffer
+            .wait_for_message_type(
+                MessageDirection::ToDownstream,
+                MESSAGE_TYPE_ALLOCATE_MINING_JOB_TOKEN_SUCCESS,
+            )
+            .await;
+    }
+
+    // trigger JDC fallback
+    pool.shutdown().await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    let (tproxy, tproxy_addr, _) =
+        start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;
+    let (_minerd_process, _minerd_addr) = start_minerd(tproxy_addr, None, None, false).await;
+
+    let timeout = tokio::time::Duration::from_secs(60);
+    let poll_interval = tokio::time::Duration::from_secs(2);
+    let start_time = tokio::time::Instant::now();
+
+    // assert JDC was able to propagate a block while doing solo
+    loop {
+        tokio::time::sleep(poll_interval).await;
+        let new_block_hash = bitcoin_core.get_best_block_hash().unwrap();
+        if new_block_hash != current_block_hash {
+            shutdown_all!(jdc, tproxy);
+            return;
+        }
+        if start_time.elapsed() > timeout {
+            panic!(
+                "JDC fallback to solo with BitcoinCoreIpc should have propagated a new block \
+                 within {} seconds",
+                timeout.as_secs()
+            );
+        }
+    }
+}
+
+// launch a JDC (with Sv2 TP over TCP) connected to a Pool/JDS and then triggers a fallback to solo
+// then it mines a block using solo and verifies the block was propagated
+// meant to avoid regressions like https://github.com/stratum-mining/sv2-apps/issues/466
+//
+// currently disabled, blocked by https://github.com/stratum-mining/sv2-tp/issues/99
+#[ignore = "https://github.com/stratum-mining/sv2-tp/issues/99"]
+#[tokio::test]
+async fn jdc_fallback_to_solo_mines_block_with_template_provider() {
+    use stratum_apps::stratum_core::template_distribution_sv2::*;
+
+    start_tracing();
+    let (tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
+    let current_block_hash = tp.get_best_block_hash().unwrap();
+
+    let (pool, pool_addr, jds_addr, _) =
+        start_pool_with_jds(tp.bitcoin_core(), vec![], vec![], false).await;
+    let (jdc_jds_sniffer, jdc_jds_sniffer_addr) =
+        start_sniffer("jdc-fallback-sv2-tp-jds", jds_addr, false, vec![], None);
+    let (jdc_tp_sniffer, jdc_tp_sniffer_addr) =
+        start_sniffer("jdc-fallback-sv2-tp-tp", tp_addr, false, vec![], None);
+    let (jdc, jdc_addr, _) = start_jdc(
+        &[(pool_addr, jdc_jds_sniffer_addr)],
+        sv2_tp_config(jdc_tp_sniffer_addr),
+        vec![],
+        vec![],
+        false,
+        None,
+    );
+
+    // assert JDC-JDS connection is established
+    {
+        jdc_jds_sniffer
+            .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+            .await;
+        jdc_jds_sniffer
+            .wait_for_message_type(
+                MessageDirection::ToDownstream,
+                MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+            )
+            .await;
+        jdc_jds_sniffer
+            .wait_for_message_type(
+                MessageDirection::ToUpstream,
+                MESSAGE_TYPE_ALLOCATE_MINING_JOB_TOKEN,
+            )
+            .await;
+        jdc_jds_sniffer
+            .wait_for_message_type(
+                MessageDirection::ToDownstream,
+                MESSAGE_TYPE_ALLOCATE_MINING_JOB_TOKEN_SUCCESS,
+            )
+            .await;
+    }
+
+    // trigger JDC fallback
+    pool.shutdown().await;
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    let (tproxy, tproxy_addr, _) =
+        start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;
+    let (_minerd_process, _minerd_addr) = start_minerd(tproxy_addr, None, None, false).await;
+
+    // assert JDC was able to propagate a block while doing solo
+    {
+        jdc_tp_sniffer
+            .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SUBMIT_SOLUTION)
+            .await;
+
+        let new_block_hash = tp.get_best_block_hash().unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+        assert_ne!(current_block_hash, new_block_hash);
+    }
+
+    shutdown_all!(jdc, tproxy);
+}

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -500,6 +500,7 @@ impl ChannelManager {
         let this = Arc::new(self);
 
         // Wait for initial template and prevhash before accepting connections
+        let fallback_token = fallback_coordinator.token();
         loop {
             let has_required_data = this.channel_manager_data.super_safe_lock(|data| {
                 data.last_future_template.is_some() && data.last_new_prev_hash.is_some()
@@ -516,6 +517,10 @@ impl ChannelManager {
                     info!("Channel Manager: received shutdown while waiting for templates");
                     return Ok(());
                 }
+                _ = fallback_token.cancelled() => {
+                    info!("Channel Manager: received fallback while waiting for templates");
+                    return Ok(());
+                }
                 _ = tokio::time::sleep(std::time::Duration::from_millis(100)) => {}
             }
         }
@@ -530,7 +535,6 @@ impl ChannelManager {
         // Register the listener task in fallback coordination, so fallback waits
         // for this accept loop to stop before attempting to re-bind the same port.
         let fallback_handler = fallback_coordinator.register();
-        let fallback_token = fallback_coordinator.token();
         task_manager.spawn(async move {
             loop {
                 select! {

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -297,6 +297,22 @@ impl ChannelManager {
         cancellation_token: &CancellationToken,
         fallback_token: &CancellationToken,
     ) -> LoopControl {
+        if cancellation_token.is_cancelled() {
+            debug!(
+                error_kind = ?e.kind,
+                "{context} returned an error after shutdown was requested"
+            );
+            return LoopControl::Continue;
+        }
+
+        if fallback_token.is_cancelled() {
+            debug!(
+                error_kind = ?e.kind,
+                "{context} returned an error during fallback"
+            );
+            return LoopControl::Continue;
+        }
+
         match e.action {
             Action::Log => {
                 warn!(

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -696,7 +696,9 @@ impl ChannelManager {
                     res = &mut vardiff_future => {
                         info!("Vardiff loop completed with: {res:?}");
                     }
-                    res = cm_jds.handle_jds_message() => {
+                    res = cm_jds.handle_jds_message(),
+                        if !cm.channel_manager_io.jd_receiver.is_closed() =>
+                    {
                         if let Err(e) = res {
                             error!(error = ?e, "Error handling JDS message");
                             if let LoopControl::Break = cm.handle_error_action(
@@ -709,7 +711,9 @@ impl ChannelManager {
                             }
                         }
                     }
-                    res = cm_pool.handle_pool_message_frame() => {
+                    res = cm_pool.handle_pool_message_frame(),
+                        if !cm.channel_manager_io.upstream_receiver.is_closed() =>
+                    {
                         if let Err(e) = res {
                             error!(error = ?e, "Error handling Pool message");
                             if let LoopControl::Break = cm.handle_error_action(

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -807,10 +807,15 @@ impl ChannelManager {
     ///   message handler.
     /// - If the frame contains any unsupported message type, an error is returned.
     async fn handle_jds_message(&mut self) -> JDCResult<(), error::ChannelManager> {
-        if let Ok(message) = self.channel_manager_io.jd_receiver.recv().await {
-            self.handle_job_declaration_message_from_server(None, message, None)
-                .await?;
-        }
+        let message = self
+            .channel_manager_io
+            .jd_receiver
+            .recv()
+            .await
+            .map_err(JDCError::fallback)?;
+
+        self.handle_job_declaration_message_from_server(None, message, None)
+            .await?;
         Ok(())
     }
 
@@ -821,30 +826,34 @@ impl ChannelManager {
     ///   handler.
     /// - If the frame contains any unsupported message type, an error is returned.
     async fn handle_pool_message_frame(&mut self) -> JDCResult<(), error::ChannelManager> {
-        if let Ok(mut sv2_frame) = self.channel_manager_io.upstream_receiver.recv().await {
-            let header = sv2_frame.get_header().ok_or_else(|| {
-                error!("SV2 frame missing header");
-                JDCError::fallback(framing_sv2::Error::MissingHeader)
-            })?;
-            let message_type = header.msg_type();
-            let extension_type = header.ext_type();
-            let payload = sv2_frame.payload();
-            match protocol_message_type(extension_type, message_type) {
-                MessageType::Mining => {
-                    self.handle_mining_message_frame_from_server(None, header, payload)
-                        .await?;
-                }
-                MessageType::Extensions => {
-                    self.handle_extensions_message_frame_from_server(None, header, payload)
-                        .await?;
-                }
-                _ => {
-                    warn!("Received unsupported message type from upstream: {message_type}");
-                    return Err(JDCError::log(JDCErrorKind::UnexpectedMessage(
-                        extension_type,
-                        message_type,
-                    )));
-                }
+        let mut sv2_frame = self
+            .channel_manager_io
+            .upstream_receiver
+            .recv()
+            .await
+            .map_err(JDCError::fallback)?;
+        let header = sv2_frame.get_header().ok_or_else(|| {
+            error!("SV2 frame missing header");
+            JDCError::fallback(framing_sv2::Error::MissingHeader)
+        })?;
+        let message_type = header.msg_type();
+        let extension_type = header.ext_type();
+        let payload = sv2_frame.payload();
+        match protocol_message_type(extension_type, message_type) {
+            MessageType::Mining => {
+                self.handle_mining_message_frame_from_server(None, header, payload)
+                    .await?;
+            }
+            MessageType::Extensions => {
+                self.handle_extensions_message_frame_from_server(None, header, payload)
+                    .await?;
+            }
+            _ => {
+                warn!("Received unsupported message type from upstream: {message_type}");
+                return Err(JDCError::log(JDCErrorKind::UnexpectedMessage(
+                    extension_type,
+                    message_type,
+                )));
             }
         }
         Ok(())
@@ -857,10 +866,15 @@ impl ChannelManager {
     //   distribution message handler.
     // - If the frame contains any unsupported message type, an error is returned.
     async fn handle_template_provider_message(&mut self) -> JDCResult<(), error::ChannelManager> {
-        if let Ok(message) = self.channel_manager_io.tp_receiver.recv().await {
-            self.handle_template_distribution_message_from_server(None, message, None)
-                .await?;
-        }
+        let message = self
+            .channel_manager_io
+            .tp_receiver
+            .recv()
+            .await
+            .map_err(JDCError::shutdown)?;
+
+        self.handle_template_distribution_message_from_server(None, message, None)
+            .await?;
         Ok(())
     }
 
@@ -898,165 +912,166 @@ impl ChannelManager {
     // - After the upstream channel is established, all new downstream requests bypass the pending
     //   mechanism and are sent directly to the mining handler.
     async fn handle_downstream_message(&mut self) -> JDCResult<(), error::ChannelManager> {
-        if let Ok((downstream_id, message, tlvs)) =
-            self.channel_manager_io.downstream_receiver.recv().await
-        {
-            match message {
-                Mining::OpenExtendedMiningChannel(downstream_channel_request) => {
-                    let downstream_msg = downstream_channel_request.clone().into_static();
+        let (downstream_id, message, tlvs) = self
+            .channel_manager_io
+            .downstream_receiver
+            .recv()
+            .await
+            .map_err(JDCError::shutdown)?;
 
-                    match self.upstream_state.get() {
-                        UpstreamState::NoChannel => {
-                            self.channel_manager_data.super_safe_lock(|data| {
-                                data.pending_downstream_requests
-                                    .push_front((downstream_id, downstream_msg).into());
-                            });
+        match message {
+            Mining::OpenExtendedMiningChannel(downstream_channel_request) => {
+                let downstream_msg = downstream_channel_request.clone().into_static();
 
-                            if self
-                                .upstream_state
-                                .compare_and_set(UpstreamState::NoChannel, UpstreamState::Pending)
-                                .is_ok()
-                            {
-                                let mut upstream_message = downstream_channel_request;
-                                upstream_message.user_identity = self
-                                    .user_identity
-                                    .clone()
-                                    .try_into()
-                                    .map_err(JDCError::shutdown)?;
-                                upstream_message.request_id = 1;
-                                // The upstream extended channel is opened once and its
-                                // `extranonce_size` is fixed. Size its rollable region to fit:
-                                //   - JDC's own `local_index` (JDC_LOCAL_PREFIX_BYTES), plus
-                                //   - the larger of the downstream's request `M` and JDC's
-                                //     retroactive commitment to future downstreams
-                                //     (`reserved_downstream_rollable_extranonce_size`).
-                                // Equivalently:
-                                //   JDC_LOCAL_PREFIX_BYTES +
-                                //     max(reserved_downstream_rollable, M).
-                                let reserved_downstream_rollable =
-                                    self.reserved_downstream_rollable_extranonce_size as usize;
-                                let downstream_min = upstream_message.min_extranonce_size as usize;
-                                let upstream_min =
-                                    (JDC_LOCAL_PREFIX_BYTES as usize).saturating_add(
-                                        std::cmp::max(reserved_downstream_rollable, downstream_min),
-                                    );
-                                upstream_message.min_extranonce_size = upstream_min as u16;
-                                let upstream_message =
-                                    Mining::OpenExtendedMiningChannel(upstream_message)
-                                        .into_static();
-                                let sv2_frame: Sv2Frame = AnyMessage::Mining(upstream_message)
-                                    .try_into()
-                                    .map_err(JDCError::shutdown)?;
-                                self.channel_manager_io
-                                    .upstream_sender
-                                    .send(sv2_frame)
-                                    .await
-                                    .map_err(|_| {
-                                        JDCError::fallback(JDCErrorKind::ChannelErrorSender)
-                                    })?;
-                            }
-                        }
-                        UpstreamState::Pending => {
-                            self.channel_manager_data.super_safe_lock(|data| {
-                                data.pending_downstream_requests
-                                    .push_back((downstream_id, downstream_msg).into());
-                            });
-                        }
-                        UpstreamState::Connected => {
-                            self.send_open_channel_request_to_mining_handler(
-                                downstream_id,
-                                Mining::OpenExtendedMiningChannel(downstream_msg),
-                                tlvs.as_deref(),
-                            )
-                            .await?;
-                        }
-                        UpstreamState::SoloMining => {
-                            self.send_open_channel_request_to_mining_handler(
-                                downstream_id,
-                                Mining::OpenExtendedMiningChannel(downstream_msg),
-                                tlvs.as_deref(),
-                            )
-                            .await?;
+                match self.upstream_state.get() {
+                    UpstreamState::NoChannel => {
+                        self.channel_manager_data.super_safe_lock(|data| {
+                            data.pending_downstream_requests
+                                .push_front((downstream_id, downstream_msg).into());
+                        });
+
+                        if self
+                            .upstream_state
+                            .compare_and_set(UpstreamState::NoChannel, UpstreamState::Pending)
+                            .is_ok()
+                        {
+                            let mut upstream_message = downstream_channel_request;
+                            upstream_message.user_identity = self
+                                .user_identity
+                                .clone()
+                                .try_into()
+                                .map_err(JDCError::shutdown)?;
+                            upstream_message.request_id = 1;
+                            // The upstream extended channel is opened once and its
+                            // `extranonce_size` is fixed. Size its rollable region to fit:
+                            //   - JDC's own `local_index` (JDC_LOCAL_PREFIX_BYTES), plus
+                            //   - the larger of the downstream's request `M` and JDC's retroactive
+                            //     commitment to future downstreams
+                            //     (`reserved_downstream_rollable_extranonce_size`).
+                            // Equivalently:
+                            //   JDC_LOCAL_PREFIX_BYTES +
+                            //     max(reserved_downstream_rollable, M).
+                            let reserved_downstream_rollable =
+                                self.reserved_downstream_rollable_extranonce_size as usize;
+                            let downstream_min = upstream_message.min_extranonce_size as usize;
+                            let upstream_min = (JDC_LOCAL_PREFIX_BYTES as usize).saturating_add(
+                                std::cmp::max(reserved_downstream_rollable, downstream_min),
+                            );
+                            upstream_message.min_extranonce_size = upstream_min as u16;
+                            let upstream_message =
+                                Mining::OpenExtendedMiningChannel(upstream_message).into_static();
+                            let sv2_frame: Sv2Frame = AnyMessage::Mining(upstream_message)
+                                .try_into()
+                                .map_err(JDCError::shutdown)?;
+                            self.channel_manager_io
+                                .upstream_sender
+                                .send(sv2_frame)
+                                .await
+                                .map_err(|_| {
+                                    JDCError::fallback(JDCErrorKind::ChannelErrorSender)
+                                })?;
                         }
                     }
-                }
-                Mining::OpenStandardMiningChannel(downstream_channel_request) => {
-                    let downstream_msg = downstream_channel_request.clone().into_static();
-
-                    match self.upstream_state.get() {
-                        UpstreamState::NoChannel => {
-                            self.channel_manager_data.super_safe_lock(|data| {
-                                data.pending_downstream_requests
-                                    .push_front((downstream_id, downstream_msg).into())
-                            });
-
-                            if self
-                                .upstream_state
-                                .compare_and_set(UpstreamState::NoChannel, UpstreamState::Pending)
-                                .is_ok()
-                            {
-                                // The first downstream is a standard channel, which doesn't
-                                // roll the extranonce itself. Ask the pool for
-                                // JDC_LOCAL_PREFIX_BYTES +
-                                // `reserved_downstream_rollable_extranonce_size` so we
-                                // still honor our retroactive commitment to any later
-                                // extended downstream that attaches to this upstream.
-                                let upstream_min_extranonce_size = (JDC_LOCAL_PREFIX_BYTES as u16)
-                                    + self.reserved_downstream_rollable_extranonce_size as u16;
-                                let upstream_open = OpenExtendedMiningChannel {
-                                    user_identity: self.user_identity.clone().try_into().unwrap(),
-                                    request_id: 1,
-                                    nominal_hash_rate: downstream_channel_request.nominal_hash_rate,
-                                    max_target: downstream_channel_request.max_target,
-                                    min_extranonce_size: upstream_min_extranonce_size,
-                                };
-
-                                let message =
-                                    Mining::OpenExtendedMiningChannel(upstream_open).into_static();
-                                let sv2_frame: Sv2Frame = AnyMessage::Mining(message)
-                                    .try_into()
-                                    .map_err(JDCError::shutdown)?;
-                                self.channel_manager_io
-                                    .upstream_sender
-                                    .send(sv2_frame)
-                                    .await
-                                    .map_err(|_| {
-                                        JDCError::fallback(JDCErrorKind::ChannelErrorSender)
-                                    })?;
-                            }
-                        }
-                        UpstreamState::Pending => {
-                            self.channel_manager_data.super_safe_lock(|data| {
-                                data.pending_downstream_requests
-                                    .push_back((downstream_id, downstream_msg).into())
-                            });
-                        }
-                        UpstreamState::Connected => {
-                            self.send_open_channel_request_to_mining_handler(
-                                downstream_id,
-                                Mining::OpenStandardMiningChannel(downstream_msg),
-                                tlvs.as_deref(),
-                            )
-                            .await?;
-                        }
-                        UpstreamState::SoloMining => {
-                            self.send_open_channel_request_to_mining_handler(
-                                downstream_id,
-                                Mining::OpenStandardMiningChannel(downstream_msg),
-                                tlvs.as_deref(),
-                            )
-                            .await?;
-                        }
+                    UpstreamState::Pending => {
+                        self.channel_manager_data.super_safe_lock(|data| {
+                            data.pending_downstream_requests
+                                .push_back((downstream_id, downstream_msg).into());
+                        });
+                    }
+                    UpstreamState::Connected => {
+                        self.send_open_channel_request_to_mining_handler(
+                            downstream_id,
+                            Mining::OpenExtendedMiningChannel(downstream_msg),
+                            tlvs.as_deref(),
+                        )
+                        .await?;
+                    }
+                    UpstreamState::SoloMining => {
+                        self.send_open_channel_request_to_mining_handler(
+                            downstream_id,
+                            Mining::OpenExtendedMiningChannel(downstream_msg),
+                            tlvs.as_deref(),
+                        )
+                        .await?;
                     }
                 }
-                _ => {
-                    self.handle_mining_message_from_client(
-                        Some(downstream_id),
-                        message,
-                        tlvs.as_deref(),
-                    )
-                    .await?;
+            }
+            Mining::OpenStandardMiningChannel(downstream_channel_request) => {
+                let downstream_msg = downstream_channel_request.clone().into_static();
+
+                match self.upstream_state.get() {
+                    UpstreamState::NoChannel => {
+                        self.channel_manager_data.super_safe_lock(|data| {
+                            data.pending_downstream_requests
+                                .push_front((downstream_id, downstream_msg).into())
+                        });
+
+                        if self
+                            .upstream_state
+                            .compare_and_set(UpstreamState::NoChannel, UpstreamState::Pending)
+                            .is_ok()
+                        {
+                            // The first downstream is a standard channel, which doesn't
+                            // roll the extranonce itself. Ask the pool for
+                            // JDC_LOCAL_PREFIX_BYTES +
+                            // `reserved_downstream_rollable_extranonce_size` so we
+                            // still honor our retroactive commitment to any later
+                            // extended downstream that attaches to this upstream.
+                            let upstream_min_extranonce_size = (JDC_LOCAL_PREFIX_BYTES as u16)
+                                + self.reserved_downstream_rollable_extranonce_size as u16;
+                            let upstream_open = OpenExtendedMiningChannel {
+                                user_identity: self.user_identity.clone().try_into().unwrap(),
+                                request_id: 1,
+                                nominal_hash_rate: downstream_channel_request.nominal_hash_rate,
+                                max_target: downstream_channel_request.max_target,
+                                min_extranonce_size: upstream_min_extranonce_size,
+                            };
+
+                            let message =
+                                Mining::OpenExtendedMiningChannel(upstream_open).into_static();
+                            let sv2_frame: Sv2Frame = AnyMessage::Mining(message)
+                                .try_into()
+                                .map_err(JDCError::shutdown)?;
+                            self.channel_manager_io
+                                .upstream_sender
+                                .send(sv2_frame)
+                                .await
+                                .map_err(|_| {
+                                    JDCError::fallback(JDCErrorKind::ChannelErrorSender)
+                                })?;
+                        }
+                    }
+                    UpstreamState::Pending => {
+                        self.channel_manager_data.super_safe_lock(|data| {
+                            data.pending_downstream_requests
+                                .push_back((downstream_id, downstream_msg).into())
+                        });
+                    }
+                    UpstreamState::Connected => {
+                        self.send_open_channel_request_to_mining_handler(
+                            downstream_id,
+                            Mining::OpenStandardMiningChannel(downstream_msg),
+                            tlvs.as_deref(),
+                        )
+                        .await?;
+                    }
+                    UpstreamState::SoloMining => {
+                        self.send_open_channel_request_to_mining_handler(
+                            downstream_id,
+                            Mining::OpenStandardMiningChannel(downstream_msg),
+                            tlvs.as_deref(),
+                        )
+                        .await?;
+                    }
                 }
+            }
+            _ => {
+                self.handle_mining_message_from_client(
+                    Some(downstream_id),
+                    message,
+                    tlvs.as_deref(),
+                )
+                .await?;
             }
         }
 

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -715,7 +715,8 @@ impl ChannelManager {
                         info!("Vardiff loop completed with: {res:?}");
                     }
                     res = cm_jds.handle_jds_message(),
-                        if !cm.channel_manager_io.jd_receiver.is_closed() =>
+                        if !cm.mode.is_solo_mining()
+                            && !cm.channel_manager_io.jd_receiver.is_closed() =>
                     {
                         if let Err(e) = res {
                             error!(error = ?e, "Error handling JDS message");
@@ -730,7 +731,8 @@ impl ChannelManager {
                         }
                     }
                     res = cm_pool.handle_pool_message_frame(),
-                        if !cm.channel_manager_io.upstream_receiver.is_closed() =>
+                        if !cm.mode.is_solo_mining()
+                            && !cm.channel_manager_io.upstream_receiver.is_closed() =>
                     {
                         if let Err(e) = res {
                             error!(error = ?e, "Error handling Pool message");

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -577,7 +577,12 @@ impl ChannelManager {
 
                                 task_manager_clone.spawn(async move {
                                     let noise_stream = tokio::select! {
-                                    result = accept_noise_connection(stream, authority_public_key, authority_secret_key, cert_validity_sec) => {
+                                        biased;
+                                        _ = cancellation_token_inner.cancelled() => {
+                                            info!("Shutdown received during handshake, dropping connection");
+                                            return;
+                                        }
+                                        result = accept_noise_connection(stream, authority_public_key, authority_secret_key, cert_validity_sec) => {
                                             match result {
                                                 Ok(r) => r,
                                                 Err(e) => {
@@ -585,10 +590,6 @@ impl ChannelManager {
                                                     return;
                                                 }
                                             }
-                                        }
-                                        _ = cancellation_token_inner.cancelled() => {
-                                            info!("Shutdown received during handshake, dropping connection");
-                                            return;
                                         }
                                     };
 
@@ -698,6 +699,7 @@ impl ChannelManager {
                 let mut cm_template = cm.clone();
                 let mut cm_downstreams = cm.clone();
                 tokio::select! {
+                    biased;
                     _ = cancellation_token.cancelled() => {
                         info!("Channel Manager: received shutdown signal");
                         break;

--- a/miner-apps/jd-client/src/lib/downstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/downstream/mod.rs
@@ -267,8 +267,12 @@ impl Downstream {
 
                 }
             }
-
-            remove_downstream(self.downstream_id);
+            if !cancellation_token.is_cancelled() && !fallback_token.is_cancelled() {
+                // Only remove downstream when system is not going through shutdown
+                // or fallback. As in those cases we initialize new set of subsystems
+                // and free old allocated memory.
+                remove_downstream(self.downstream_id);
+            }
             self.downstream_cancellation_token.cancel();
             warn!("Downstream: unified message loop exited.");
             fallback_handler.done();

--- a/miner-apps/jd-client/src/lib/downstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/downstream/mod.rs
@@ -164,7 +164,7 @@ impl Downstream {
             outbound_rx,
             inbound_tx,
             downstream_cancellation_token.clone(),
-            fallback_coordinator.clone(),
+            Some(fallback_coordinator.clone()),
         );
 
         let downstream_io = DownstreamIo {

--- a/miner-apps/jd-client/src/lib/downstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/downstream/mod.rs
@@ -252,6 +252,7 @@ impl Downstream {
                 let downstream_id = self_clone_1.downstream_id;
                 let self_clone_2 = self.clone();
                 tokio::select! {
+                    biased;
                     _ = cancellation_token.cancelled() => {
                         debug!("Downstream {downstream_id}: received shutdown signal");
                         break;

--- a/miner-apps/jd-client/src/lib/downstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/downstream/mod.rs
@@ -95,7 +95,26 @@ impl Downstream {
         context: &str,
         e: &JDCError<error::Downstream>,
         cancellation_token: &CancellationToken,
+        fallback_token: &CancellationToken,
     ) -> LoopControl {
+        if cancellation_token.is_cancelled() {
+            debug!(
+                downstream_id = self.downstream_id,
+                error_kind = ?e.kind,
+                "{context} returned an error after shutdown was requested"
+            );
+            return LoopControl::Continue;
+        }
+
+        if fallback_token.is_cancelled() {
+            debug!(
+                downstream_id = self.downstream_id,
+                error_kind = ?e.kind,
+                "{context} returned an error during fallback"
+            );
+            return LoopControl::Continue;
+        }
+
         match e.action {
             Action::Log => {
                 warn!(
@@ -220,6 +239,7 @@ impl Downstream {
                 "Downstream::setup_connection_with_downstream",
                 &e,
                 &cancellation_token,
+                &fallback_token,
             );
             remove_downstream(self.downstream_id);
             fallback_handler.done();
@@ -247,6 +267,7 @@ impl Downstream {
                                 "Downstream::handle_downstream_message",
                                 &e,
                                 &cancellation_token,
+                                &fallback_token,
                             ) {
                                 break;
                             }
@@ -259,6 +280,7 @@ impl Downstream {
                                 "Downstream::handle_channel_manager_message",
                                 &e,
                                 &cancellation_token,
+                                &fallback_token,
                             ) {
                                 break;
                             }

--- a/miner-apps/jd-client/src/lib/io_task.rs
+++ b/miner-apps/jd-client/src/lib/io_task.rs
@@ -79,6 +79,7 @@ pub fn spawn_io_tasks(
 
                 loop {
                     tokio::select! {
+                        biased;
                         _ = cancellation_token_clone.cancelled() => {
                             trace!("Received shutdown signal");
                             inbound_tx.close();
@@ -144,6 +145,7 @@ pub fn spawn_io_tasks(
 
                 loop {
                     tokio::select! {
+                        biased;
                         _ = cancellation_token.cancelled() => {
                             trace!("Received shutdown signal");
                             inbound_tx_clone.close();

--- a/miner-apps/jd-client/src/lib/io_task.rs
+++ b/miner-apps/jd-client/src/lib/io_task.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_channel::{Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
-    fallback_coordinator::FallbackCoordinator,
+    fallback_coordinator::{FallbackCoordinator, FallbackHandler},
     network_helpers::noise_stream::{NoiseTcpReadHalf, NoiseTcpWriteHalf},
     stratum_core::framing_sv2::framing::Frame,
     task_manager::TaskManager,
@@ -11,7 +11,46 @@ use stratum_apps::{
 };
 use tracing::{error, trace, warn, Instrument as _};
 
+struct FallbackRegistration {
+    handler: Option<FallbackHandler>,
+    token: Option<CancellationToken>,
+}
+
+impl FallbackRegistration {
+    fn new(fallback_coordinator: Option<FallbackCoordinator>) -> Self {
+        match fallback_coordinator {
+            Some(fallback_coordinator) => Self {
+                handler: Some(fallback_coordinator.register()),
+                token: Some(fallback_coordinator.token()),
+            },
+            None => Self {
+                handler: None,
+                token: None,
+            },
+        }
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.token.is_some()
+    }
+
+    async fn cancelled(&self) {
+        if let Some(token) = &self.token {
+            token.cancelled().await;
+        }
+    }
+
+    fn done(self) {
+        if let Some(handler) = self.handler {
+            handler.done();
+        }
+    }
+}
+
 /// Spawns async reader and writer tasks for handling framed I/O with shutdown support.
+///
+/// If a fallback coordinator is provided, both tasks are registered with it and listen for fallback
+/// cancellation.
 #[track_caller]
 #[allow(clippy::too_many_arguments)]
 #[cfg_attr(not(test), hotpath::measure)]
@@ -22,7 +61,7 @@ pub fn spawn_io_tasks(
     outbound_rx: Receiver<Sv2Frame>,
     inbound_tx: Sender<Sv2Frame>,
     cancellation_token: CancellationToken,
-    fallback_coordinator: FallbackCoordinator,
+    fallback_coordinator: Option<FallbackCoordinator>,
 ) {
     let caller = std::panic::Location::caller();
     let inbound_tx_clone = inbound_tx.clone();
@@ -34,14 +73,10 @@ pub fn spawn_io_tasks(
 
         task_manager.spawn(
             async move {
-                // we just spawned a new task that's relevant to fallback coordination
-                // so register it with the fallback coordinator
-                let fallback_handler = fallback_coordinator_clone.register();
-
-                // get the cancellation token that signals fallback
-                let fallback_token = fallback_coordinator_clone.token();
+                let fallback = FallbackRegistration::new(fallback_coordinator_clone);
 
                 trace!("Reader task started");
+
                 loop {
                     tokio::select! {
                         _ = cancellation_token_clone.cancelled() => {
@@ -49,7 +84,7 @@ pub fn spawn_io_tasks(
                             inbound_tx.close();
                             break;
                         }
-                        _ = fallback_token.cancelled() => {
+                        _ = fallback.cancelled(), if fallback.is_enabled() => {
                             trace!("Received fallback signal");
                             inbound_tx.close();
                             break;
@@ -82,13 +117,14 @@ pub fn spawn_io_tasks(
                         }
                     }
                 }
+
                 inbound_tx.close();
                 outbound_rx_clone.close();
                 drop(inbound_tx);
                 drop(outbound_rx_clone);
 
-                // signal fallback coordinator that this task has completed its cleanup
-                fallback_handler.done();
+                fallback.done();
+
                 warn!("Reader task exited.");
             }
             .instrument(tracing::trace_span!(
@@ -102,14 +138,10 @@ pub fn spawn_io_tasks(
         let fallback_coordinator_clone = fallback_coordinator.clone();
         task_manager.spawn(
             async move {
-                // we just spawned a new task that's relevant to fallback coordination
-                // so register it with the fallback coordinator
-                let fallback_handler = fallback_coordinator_clone.register();
-
-                // get the cancellation token that signals fallback
-                let fallback_token = fallback_coordinator_clone.token();
+                let fallback = FallbackRegistration::new(fallback_coordinator_clone);
 
                 trace!("Writer task started");
+
                 loop {
                     tokio::select! {
                         _ = cancellation_token.cancelled() => {
@@ -117,7 +149,7 @@ pub fn spawn_io_tasks(
                             inbound_tx_clone.close();
                             break;
                         }
-                        _ = fallback_token.cancelled() => {
+                        _ = fallback.cancelled(), if fallback.is_enabled() => {
                             trace!("Received fallback signal");
                             inbound_tx_clone.close();
                             break;
@@ -146,8 +178,8 @@ pub fn spawn_io_tasks(
                 drop(outbound_rx);
                 drop(inbound_tx_clone);
 
-                // signal fallback coordinator that this task has completed its cleanup
-                fallback_handler.done();
+                fallback.done();
+
                 warn!("Writer task exited.");
             }
             .instrument(tracing::trace_span!(

--- a/miner-apps/jd-client/src/lib/job_declarator/mod.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/mod.rs
@@ -57,6 +57,22 @@ impl JobDeclarator {
         cancellation_token: &CancellationToken,
         fallback_token: &CancellationToken,
     ) -> LoopControl {
+        if cancellation_token.is_cancelled() {
+            debug!(
+                error_kind = ?e.kind,
+                "{context} returned an error after shutdown was requested"
+            );
+            return LoopControl::Continue;
+        }
+
+        if fallback_token.is_cancelled() {
+            debug!(
+                error_kind = ?e.kind,
+                "{context} returned an error during fallback"
+            );
+            return LoopControl::Continue;
+        }
+
         match e.action {
             Action::Log => {
                 warn!(

--- a/miner-apps/jd-client/src/lib/job_declarator/mod.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/mod.rs
@@ -147,7 +147,7 @@ impl JobDeclarator {
             outbound_rx,
             inbound_tx,
             cancellation_token,
-            fallback_coordinator,
+            Some(fallback_coordinator),
         );
 
         let job_declarator_io = JobDeclaratorIo {

--- a/miner-apps/jd-client/src/lib/job_declarator/mod.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/mod.rs
@@ -144,12 +144,13 @@ impl JobDeclarator {
         info!("Connection established with JD Server at {addr} in mode: {mode:?}");
 
         let (noise_stream_reader, noise_stream_writer) = tokio::select! {
-            result = connect_with_noise(stream, Some(upstream_entry.authority_pubkey)) => {
-                result.map_err(JDCError::fallback)?.into_split()
-            }
+            biased;
             _ = cancellation_token.cancelled() => {
                 info!("Shutdown received during handshake, dropping connection");
                 return Err(JDCError::shutdown(JDCErrorKind::CouldNotInitiateSystem));
+            }
+            result = connect_with_noise(stream, Some(upstream_entry.authority_pubkey)) => {
+                result.map_err(JDCError::fallback)?.into_split()
             }
         };
 
@@ -212,6 +213,7 @@ impl JobDeclarator {
                 let mut self_clone_1 = self.clone();
                 let self_clone_2 = self.clone();
                 tokio::select! {
+                    biased;
                     _ = cancellation_token.cancelled() => {
                         info!("Job Declarator: received shutdown signal");
                         break;

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -101,7 +101,7 @@ impl JobDeclaratorClient {
 
         debug!("Channels initialized.");
 
-        let mut channel_manager = ChannelManager::new(
+        let channel_manager = ChannelManager::new(
             self.config.clone(),
             channel_manager_to_upstream_sender.clone(),
             upstream_to_channel_manager_receiver.clone(),
@@ -166,7 +166,7 @@ impl JobDeclaratorClient {
             });
         }
 
-        let mut channel_manager_clone = channel_manager.clone();
+        let initial_channel_manager = channel_manager.clone();
         let mut bitcoin_core_sv2_join_handle: Option<JoinHandle<()>> = None;
 
         match self.config.template_provider_type().clone() {
@@ -311,10 +311,10 @@ impl JobDeclaratorClient {
                         )
                         .await;
 
-                    channel_manager_clone
+                    initial_channel_manager
                         .upstream_state
                         .set(UpstreamState::NoChannel);
-                    _ = channel_manager_clone.allocate_tokens(2).await;
+                    _ = initial_channel_manager.allocate_tokens(2).await;
                 }
                 Err(e) => {
                     tracing::error!("Failed to initialize upstream: {:?}", e);
@@ -378,7 +378,7 @@ impl JobDeclaratorClient {
                         unbounded();
 
                     // Create a fresh channel_manager with new channels
-                    channel_manager = ChannelManager::new(
+                    let channel_manager = ChannelManager::new(
                         self.config.clone(),
                         channel_manager_to_upstream_sender_new.clone(),
                         upstream_to_channel_manager_receiver_new.clone(),
@@ -394,10 +394,8 @@ impl JobDeclaratorClient {
                     )
                     .await
                     .unwrap();
-                    channel_manager_clone = channel_manager.clone();
 
-                    channel_manager
-                        .clone()
+                    channel_manager.clone()
                         .start(
                             self.cancellation_token.clone(),
                             fallback_coordinator.clone(),
@@ -441,15 +439,15 @@ impl JobDeclaratorClient {
                                 )
                                 .await;
 
-                            channel_manager_clone
+                            channel_manager
                                 .upstream_state
                                 .set(UpstreamState::NoChannel);
 
-                            _ = channel_manager_clone.allocate_tokens(2).await;
+                            _ = channel_manager.allocate_tokens(2).await;
                         }
                         Err(e) => {
                             tracing::error!("Failed to initialize upstream: {:?}", e);
-                            channel_manager_clone
+                            channel_manager
                                 .upstream_state
                                 .set(UpstreamState::SoloMining);
                             mode.set_solo_mining();
@@ -467,8 +465,8 @@ impl JobDeclaratorClient {
 
                         let monitoring_server = stratum_apps::monitoring::MonitoringServer::new(
                             monitoring_addr,
-                            Some(Arc::new(channel_manager_clone.clone())),
-                            Some(Arc::new(channel_manager_clone.clone())),
+                            Some(Arc::new(channel_manager.clone())),
+                            Some(Arc::new(channel_manager.clone())),
                             std::time::Duration::from_secs(self.config.monitoring_cache_refresh_secs().unwrap_or(15)),
                         )
                         .expect("Failed to initialize monitoring server");
@@ -503,21 +501,28 @@ impl JobDeclaratorClient {
                         });
                     }
 
-                    _ = channel_manager_clone
-                        .clone()
-                        .start_downstream_server(
-                            *self.config.authority_public_key(),
-                            *self.config.authority_secret_key(),
-                            self.config.cert_validity_sec(),
-                            *self.config.listening_address(),
-                            task_manager.clone(),
-                            self.cancellation_token.clone(),
-                            fallback_coordinator.clone(),
-                            downstream_to_channel_manager_sender_new.clone(),
-                            self.config.supported_extensions().to_vec(),
-                            self.config.required_extensions().to_vec(),
-                        )
-                        .await;
+                    task_manager.spawn({
+                        let config = self.config.clone();
+                        let cancellation_token = self.cancellation_token.clone();
+                        let task_manager = task_manager.clone();
+                        let fallback_coordinator = fallback_coordinator.clone();
+                        async move {
+                            _ = channel_manager
+                                .start_downstream_server(
+                                    *config.authority_public_key(),
+                                    *config.authority_secret_key(),
+                                    config.cert_validity_sec(),
+                                    *config.listening_address(),
+                                    task_manager,
+                                    cancellation_token,
+                                    fallback_coordinator,
+                                    downstream_to_channel_manager_sender_new,
+                                    config.supported_extensions().to_vec(),
+                                    config.required_extensions().to_vec(),
+                                )
+                                .await;
+                        }
+                    });
                 }
             }
         }

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -78,9 +78,13 @@ impl JobDeclaratorClient {
         let mut encoded_outputs = vec![];
         let mode = JDMode::new(self.config.mode);
 
-        miner_coinbase_outputs
-            .consensus_encode(&mut encoded_outputs)
-            .expect("Invalid coinbase output in config");
+        if let Err(e) = miner_coinbase_outputs.consensus_encode(&mut encoded_outputs) {
+            error!(error = ?e, "Invalid coinbase output in config");
+            self.cancellation_token.cancel();
+            self.shutdown_notify.notify_waiters();
+            self.is_alive.store(false, Ordering::Relaxed);
+            return;
+        }
 
         let mut fallback_coordinator = FallbackCoordinator::new();
         let task_manager = Arc::new(TaskManager::new());
@@ -101,7 +105,7 @@ impl JobDeclaratorClient {
 
         debug!("Channels initialized.");
 
-        let channel_manager = ChannelManager::new(
+        let channel_manager = match ChannelManager::new(
             self.config.clone(),
             channel_manager_to_upstream_sender.clone(),
             upstream_to_channel_manager_receiver.clone(),
@@ -116,7 +120,16 @@ impl JobDeclaratorClient {
             mode.clone(),
         )
         .await
-        .unwrap();
+        {
+            Ok(channel_manager) => channel_manager,
+            Err(e) => {
+                error!(error = ?e, "Failed to initialize channel manager");
+                self.cancellation_token.cancel();
+                self.shutdown_notify.notify_waiters();
+                self.is_alive.store(false, Ordering::Relaxed);
+                return;
+            }
+        };
 
         // Start monitoring server if configured
         #[cfg(feature = "monitoring")]
@@ -126,44 +139,51 @@ impl JobDeclaratorClient {
                 monitoring_addr
             );
 
-            let monitoring_server = stratum_apps::monitoring::MonitoringServer::new(
+            let monitoring_server = match stratum_apps::monitoring::MonitoringServer::new(
                 monitoring_addr,
                 Some(Arc::new(channel_manager.clone())), // SV2 channels opened with servers
                 Some(Arc::new(channel_manager.clone())), // SV2 channels opened with clients
                 std::time::Duration::from_secs(
                     self.config.monitoring_cache_refresh_secs().unwrap_or(15),
                 ),
-            )
-            .expect("Failed to initialize monitoring server");
-
-            // Create shutdown signal using cancellation token
-            let cancellation_token_clone = self.cancellation_token.clone();
-            let fallback_coordinator_token = fallback_coordinator.token();
-            let shutdown_signal = async move {
-                tokio::select! {
-                    _ = cancellation_token_clone.cancelled() => {
-                        info!("Monitoring server: received shutdown signal.");
-                    }
-                    _ = fallback_coordinator_token.cancelled() => {
-                        info!("Monitoring server: fallback triggered.");
-                    }
+            ) {
+                Ok(monitoring_server) => Some(monitoring_server),
+                Err(e) => {
+                    error!(error = ?e, "Failed to initialize monitoring server");
+                    None
                 }
             };
 
-            let fallback_coordinator_clone = fallback_coordinator.clone();
-            task_manager.spawn(async move {
-                // we just spawned a new task that's relevant to fallback coordination
-                // so register it with the fallback coordinator
-                let fallback_handler = fallback_coordinator_clone.register();
+            if let Some(monitoring_server) = monitoring_server {
+                // Create shutdown signal using cancellation token
+                let cancellation_token_clone = self.cancellation_token.clone();
+                let fallback_coordinator_token = fallback_coordinator.token();
+                let shutdown_signal = async move {
+                    tokio::select! {
+                        _ = cancellation_token_clone.cancelled() => {
+                            info!("Monitoring server: received shutdown signal.");
+                        }
+                        _ = fallback_coordinator_token.cancelled() => {
+                            info!("Monitoring server: fallback triggered.");
+                        }
+                    }
+                };
 
-                if let Err(e) = monitoring_server.run(shutdown_signal).await {
-                    error!("Monitoring server error: {:?}", e);
-                }
+                let fallback_coordinator_clone = fallback_coordinator.clone();
+                task_manager.spawn(async move {
+                    // we just spawned a new task that's relevant to fallback coordination
+                    // so register it with the fallback coordinator
+                    let fallback_handler = fallback_coordinator_clone.register();
 
-                // signal fallback coordinator that this task has completed its cleanup
-                fallback_handler.done();
-                info!("Monitoring server task exited and signaled fallback coordinator");
-            });
+                    if let Err(e) = monitoring_server.run(shutdown_signal).await {
+                        error!("Monitoring server error: {:?}", e);
+                    }
+
+                    // signal fallback coordinator that this task has completed its cleanup
+                    fallback_handler.done();
+                    info!("Monitoring server task exited and signaled fallback coordinator");
+                });
+            }
         }
 
         let initial_channel_manager = channel_manager.clone();
@@ -175,7 +195,7 @@ impl JobDeclaratorClient {
                 address,
                 public_key,
             } => {
-                let template_receiver = Sv2Tp::new(
+                let template_receiver = match Sv2Tp::new(
                     address.clone(),
                     public_key,
                     channel_manager_to_tp_receiver,
@@ -184,7 +204,16 @@ impl JobDeclaratorClient {
                     task_manager.clone(),
                 )
                 .await
-                .unwrap();
+                {
+                    Ok(template_receiver) => template_receiver,
+                    Err(e) => {
+                        error!(error = ?e, "Failed to initialize SV2 template receiver");
+                        self.cancellation_token.cancel();
+                        self.shutdown_notify.notify_waiters();
+                        self.is_alive.store(false, Ordering::Relaxed);
+                        return;
+                    }
+                };
 
                 let cancellation_token_tp = self.cancellation_token.clone();
                 let task_manager_cl = task_manager.clone();
@@ -201,12 +230,20 @@ impl JobDeclaratorClient {
                 fee_threshold,
                 min_interval,
             } => {
-                let unix_socket_path = stratum_apps::tp_type::resolve_ipc_socket_path(
+                let unix_socket_path = match stratum_apps::tp_type::resolve_ipc_socket_path(
                     &network, data_dir,
-                )
-                .expect(
-                    "Could not determine Bitcoin data directory. Please set data_dir in config.",
-                );
+                ) {
+                    Some(unix_socket_path) => unix_socket_path,
+                    None => {
+                        error!(
+                                "Could not determine Bitcoin data directory. Please set data_dir in config."
+                            );
+                        self.cancellation_token.cancel();
+                        self.shutdown_notify.notify_waiters();
+                        self.is_alive.store(false, Ordering::Relaxed);
+                        return;
+                    }
+                };
 
                 info!(
                     "Using Bitcoin Core IPC socket at: {}",
@@ -391,7 +428,7 @@ impl JobDeclaratorClient {
                         unbounded();
 
                     // Create a fresh channel_manager with new channels
-                    let channel_manager = ChannelManager::new(
+                    let channel_manager = match ChannelManager::new(
                         self.config.clone(),
                         channel_manager_to_upstream_sender_new.clone(),
                         upstream_to_channel_manager_receiver_new.clone(),
@@ -403,10 +440,17 @@ impl JobDeclaratorClient {
                         encoded_outputs.clone(),
                         self.config.supported_extensions().to_vec(),
                         self.config.required_extensions().to_vec(),
-                                    mode.clone()
+                        mode.clone(),
                     )
                     .await
-                    .unwrap();
+                    {
+                        Ok(channel_manager) => channel_manager,
+                        Err(e) => {
+                            error!(error = ?e, "Failed to initialize channel manager during fallback");
+                            self.cancellation_token.cancel();
+                            break;
+                        }
+                    };
 
                     channel_manager.clone()
                         .start(
@@ -476,42 +520,52 @@ impl JobDeclaratorClient {
                             monitoring_addr
                         );
 
-                        let monitoring_server = stratum_apps::monitoring::MonitoringServer::new(
+                        let monitoring_server = match stratum_apps::monitoring::MonitoringServer::new(
                             monitoring_addr,
                             Some(Arc::new(channel_manager.clone())),
                             Some(Arc::new(channel_manager.clone())),
-                            std::time::Duration::from_secs(self.config.monitoring_cache_refresh_secs().unwrap_or(15)),
+                            std::time::Duration::from_secs(
+                                self.config.monitoring_cache_refresh_secs().map_or(15, |secs| secs),
+                            ),
                         )
-                        .expect("Failed to initialize monitoring server");
-
-                        let cancellation_token_clone = self.cancellation_token.clone();
-                        let fallback_coordinator_token = fallback_coordinator.token();
-                        let shutdown_signal = async move {
-                            tokio::select! {
-                                _ = cancellation_token_clone.cancelled() => {
-                                    info!("Monitoring server: received shutdown signal.");
-                                }
-                                _ = fallback_coordinator_token.cancelled() => {
-                                    info!("Monitoring server: fallback triggered.");
-                                }
+                        {
+                            Ok(monitoring_server) => Some(monitoring_server),
+                            Err(e) => {
+                                error!(error = ?e, "Failed to initialize monitoring server");
+                                None
                             }
                         };
 
-                        let fallback_coordinator_clone = fallback_coordinator.clone();
-                        task_manager.spawn(async move {
-                            // we just spawned a new task that's relevant to fallback coordination
-                            // so register it with the fallback coordinator
-                            let fallback_handler = fallback_coordinator_clone.register();
+                        if let Some(monitoring_server) = monitoring_server {
+                            let cancellation_token_clone = self.cancellation_token.clone();
+                            let fallback_coordinator_token = fallback_coordinator.token();
+                            let shutdown_signal = async move {
+                                tokio::select! {
+                                    _ = cancellation_token_clone.cancelled() => {
+                                        info!("Monitoring server: received shutdown signal.");
+                                    }
+                                    _ = fallback_coordinator_token.cancelled() => {
+                                        info!("Monitoring server: fallback triggered.");
+                                    }
+                                }
+                            };
 
-                            if let Err(e) = monitoring_server.run(shutdown_signal).await {
-                                error!("Monitoring server error: {:?}", e);
-                            }
+                            let fallback_coordinator_clone = fallback_coordinator.clone();
+                            task_manager.spawn(async move {
+                                // we just spawned a new task that's relevant to fallback coordination
+                                // so register it with the fallback coordinator
+                                let fallback_handler = fallback_coordinator_clone.register();
 
-                            // signal that this task has completed its cleanup
-                            // (no-op during normal shutdown, only matters during fallback)
-                            fallback_handler.done();
-                            info!("Monitoring server task exited and signaled fallback coordinator");
-                        });
+                                if let Err(e) = monitoring_server.run(shutdown_signal).await {
+                                    error!("Monitoring server error: {:?}", e);
+                                }
+
+                                // signal that this task has completed its cleanup
+                                // (no-op during normal shutdown, only matters during fallback)
+                                fallback_handler.done();
+                                info!("Monitoring server task exited and signaled fallback coordinator");
+                            });
+                        }
                     }
 
                     task_manager.spawn({

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -331,20 +331,24 @@ impl JobDeclaratorClient {
             let task_manager = task_manager.clone();
             let fallback_coordinator = fallback_coordinator.clone();
             async move {
-                _ = initial_channel_manager
+                if let Err(e) = initial_channel_manager
                     .start_downstream_server(
                         *config.authority_public_key(),
                         *config.authority_secret_key(),
                         config.cert_validity_sec(),
                         *config.listening_address(),
                         task_manager,
-                        cancellation_token,
+                        cancellation_token.clone(),
                         fallback_coordinator,
                         downstream_to_channel_manager_sender,
                         config.supported_extensions().to_vec(),
                         config.required_extensions().to_vec(),
                     )
-                    .await;
+                    .await
+                {
+                    tracing::error!(?e, "Downstream server task exited with error");
+                    cancellation_token.cancel();
+                }
             }
         });
 
@@ -516,20 +520,23 @@ impl JobDeclaratorClient {
                         let task_manager = task_manager.clone();
                         let fallback_coordinator = fallback_coordinator.clone();
                         async move {
-                            _ = channel_manager
+                            if let Err(e) = channel_manager
                                 .start_downstream_server(
                                     *config.authority_public_key(),
                                     *config.authority_secret_key(),
                                     config.cert_validity_sec(),
                                     *config.listening_address(),
                                     task_manager,
-                                    cancellation_token,
+                                    cancellation_token.clone(),
                                     fallback_coordinator,
                                     downstream_to_channel_manager_sender_new,
                                     config.supported_extensions().to_vec(),
                                     config.required_extensions().to_vec(),
                                 )
-                                .await;
+                                .await {
+                                    tracing::error!(?e, "Downstream server task exited with error");
+                                    cancellation_token.cancel();
+                                }
                         }
                     });
                 }

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -168,6 +168,7 @@ impl JobDeclaratorClient {
 
         let initial_channel_manager = channel_manager.clone();
         let mut bitcoin_core_sv2_join_handle: Option<JoinHandle<()>> = None;
+        let mut bitcoin_core_sv2_cancellation_token: Option<CancellationToken> = None;
 
         match self.config.template_provider_type().clone() {
             TemplateProviderType::Sv2Tp {
@@ -217,15 +218,17 @@ impl JobDeclaratorClient {
                 let incoming_tdp_receiver = channel_manager_to_tp_receiver.clone();
                 let outgoing_tdp_sender = tp_to_channel_manager_sender.clone();
 
+                let bitcoin_core_cancellation_token = CancellationToken::new();
                 let bitcoin_core_config = BitcoinCoreSv2TDPConfig {
                     unix_socket_path,
                     fee_threshold,
                     min_interval,
                     incoming_tdp_receiver,
                     outgoing_tdp_sender,
-                    cancellation_token: CancellationToken::new(),
+                    cancellation_token: bitcoin_core_cancellation_token.clone(),
                 };
 
+                bitcoin_core_sv2_cancellation_token = Some(bitcoin_core_cancellation_token);
                 bitcoin_core_sv2_join_handle = Some(
                     connect_to_bitcoin_core(
                         bitcoin_core_config,
@@ -532,6 +535,10 @@ impl JobDeclaratorClient {
                     });
                 }
             }
+        }
+
+        if let Some(bitcoin_core_sv2_cancellation_token) = bitcoin_core_sv2_cancellation_token {
+            bitcoin_core_sv2_cancellation_token.cancel();
         }
 
         if let Some(bitcoin_core_sv2_join_handle) = bitcoin_core_sv2_join_handle {

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -394,11 +394,8 @@ impl JobDeclaratorClient {
 
         loop {
             tokio::select! {
-                _ = tokio::signal::ctrl_c() => {
-                    info!("Ctrl+C received — initiating graceful shutdown...");
-                    self.cancellation_token.cancel();
-                    break;
-                }
+                biased;
+
                 _ = self.cancellation_token.cancelled() => {
                     break;
                 }
@@ -594,6 +591,11 @@ impl JobDeclaratorClient {
                         }
                     });
                 }
+                _ = tokio::signal::ctrl_c() => {
+                    info!("Ctrl+C received — initiating graceful shutdown...");
+                    self.cancellation_token.cancel();
+                    break;
+                }
             }
         }
 
@@ -677,6 +679,7 @@ impl JobDeclaratorClient {
             );
 
             tokio::select! {
+                biased;
                 _ = cancellation_token.cancelled() => {
                     info!("Shutdown requested while waiting to initialize upstream, aborting retries");
                     return Err(JDCErrorKind::CouldNotInitiateSystem);
@@ -723,6 +726,7 @@ impl JobDeclaratorClient {
                         tracing::error!("Upstream and JDS connection terminated");
 
                         tokio::select! {
+                            biased;
                             _ = cancellation_token.cancelled() => {
                                 info!("Shutdown requested after upstream initialization failure, aborting retries");
                                 return Err(JDCErrorKind::CouldNotInitiateSystem);

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -323,21 +323,28 @@ impl JobDeclaratorClient {
             };
         }
 
-        _ = channel_manager_clone
-            .clone()
-            .start_downstream_server(
-                *self.config.authority_public_key(),
-                *self.config.authority_secret_key(),
-                self.config.cert_validity_sec(),
-                *self.config.listening_address(),
-                task_manager.clone(),
-                self.cancellation_token.clone(),
-                fallback_coordinator.clone(),
-                downstream_to_channel_manager_sender.clone(),
-                self.config.supported_extensions().to_vec(),
-                self.config.required_extensions().to_vec(),
-            )
-            .await;
+        task_manager.spawn({
+            let config = self.config.clone();
+            let cancellation_token = self.cancellation_token.clone();
+            let task_manager = task_manager.clone();
+            let fallback_coordinator = fallback_coordinator.clone();
+            async move {
+                _ = initial_channel_manager
+                    .start_downstream_server(
+                        *config.authority_public_key(),
+                        *config.authority_secret_key(),
+                        config.cert_validity_sec(),
+                        *config.listening_address(),
+                        task_manager,
+                        cancellation_token,
+                        fallback_coordinator,
+                        downstream_to_channel_manager_sender,
+                        config.supported_extensions().to_vec(),
+                        config.required_extensions().to_vec(),
+                    )
+                    .await;
+            }
+        });
 
         info!("Spawning status listener task...");
         let mut fallback_token = fallback_coordinator.token();

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -181,7 +181,6 @@ impl JobDeclaratorClient {
                     channel_manager_to_tp_receiver,
                     tp_to_channel_manager_sender,
                     self.cancellation_token.clone(),
-                    fallback_coordinator.clone(),
                     task_manager.clone(),
                 )
                 .await

--- a/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
@@ -15,7 +15,6 @@ use std::sync::Arc;
 use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
-    fallback_coordinator::FallbackCoordinator,
     key_utils::Secp256k1PublicKey,
     network_helpers::{self, connect_with_noise, resolve_host_port},
     stratum_core::{
@@ -120,7 +119,6 @@ impl Sv2Tp {
         channel_manager_receiver: Receiver<TemplateDistribution<'static>>,
         channel_manager_sender: Sender<TemplateDistribution<'static>>,
         cancellation_token: CancellationToken,
-        fallback_coordinator: FallbackCoordinator,
         task_manager: Arc<TaskManager>,
     ) -> JDCResult<Sv2Tp, error::TemplateProvider> {
         const MAX_RETRIES: usize = 3;
@@ -155,7 +153,7 @@ impl Sv2Tp {
                                         outbound_rx,
                                         inbound_tx,
                                         cancellation_token.clone(),
-                                        fallback_coordinator.clone(),
+                                        None,
                                     );
 
                                     let sv2_tp_io = Sv2TpIo {

--- a/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
@@ -142,6 +142,12 @@ impl Sv2Tp {
                     );
 
                     tokio::select! {
+                        biased;
+
+                         _ = cancellation_token.cancelled() => {
+                            info!("Shutdown received during handshake, dropping connection");
+                            return Err(JDCError::shutdown(JDCErrorKind::CouldNotInitiateSystem));
+                        }
                         result = connect_with_noise(stream, public_key) => {
                             match result {
                                 Ok(noise_stream) => {
@@ -185,10 +191,6 @@ impl Sv2Tp {
                                 }
                             }
                         }
-                         _ = cancellation_token.cancelled() => {
-                            info!("Shutdown received during handshake, dropping connection");
-                            return Err(JDCError::shutdown(JDCErrorKind::CouldNotInitiateSystem));
-                        }
                     }
                 }
                 Err(e) => {
@@ -230,6 +232,8 @@ impl Sv2Tp {
                 let mut self_clone_1 = self.clone();
                 let self_clone_2 = self.clone();
                 tokio::select! {
+                    biased;
+
                     _ = cancellation_token.cancelled() => {
                         info!("TemplateReceiver received shutdown signal");
                         break;

--- a/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
@@ -79,6 +79,14 @@ impl Sv2Tp {
         e: &JDCError<error::TemplateProvider>,
         cancellation_token: &CancellationToken,
     ) -> LoopControl {
+        if cancellation_token.is_cancelled() {
+            debug!(
+                error_kind = ?e.kind,
+                "{context} returned an error after shutdown was requested"
+            );
+            return LoopControl::Continue;
+        }
+
         match e.action {
             Action::Log => {
                 warn!(

--- a/miner-apps/jd-client/src/lib/upstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/upstream/mod.rs
@@ -162,7 +162,7 @@ impl Upstream {
             outbound_rx,
             inbound_tx,
             cancellation_token.clone(),
-            fallback_coordinator.clone(),
+            Some(fallback_coordinator.clone()),
         );
 
         debug!("Noise setup done in upstream connection");

--- a/miner-apps/jd-client/src/lib/upstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/upstream/mod.rs
@@ -156,15 +156,16 @@ impl Upstream {
         debug!("Begin with noise setup in upstream connection");
 
         let (noise_stream_reader, noise_stream_writer) = tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => {
+                info!("Shutdown received during handshake, dropping connection");
+                Err(JDCError::shutdown(JDCErrorKind::CouldNotInitiateSystem))
+            }
             result = connect_with_noise(stream, Some(upstream_entry.authority_pubkey)) => {
                 match result {
                     Ok(noise_stream) => Ok(noise_stream.into_split()),
                     Err(e) => Err(JDCError::fallback(e))
                 }
-            }
-            _ = cancellation_token.cancelled() => {
-                info!("Shutdown received during handshake, dropping connection");
-                Err(JDCError::shutdown(JDCErrorKind::CouldNotInitiateSystem))
             }
         }?;
 
@@ -336,6 +337,8 @@ impl Upstream {
             let mut self_clone_2 = self.clone();
             loop {
                 tokio::select! {
+                    biased;
+
                     _ = cancellation_token.cancelled() => {
                         info!("Upstream: received shutdown signal");
                         break;

--- a/miner-apps/jd-client/src/lib/upstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/upstream/mod.rs
@@ -70,6 +70,22 @@ impl Upstream {
         cancellation_token: &CancellationToken,
         fallback_token: &CancellationToken,
     ) -> LoopControl {
+        if cancellation_token.is_cancelled() {
+            debug!(
+                error_kind = ?e.kind,
+                "{context} returned an error after shutdown was requested"
+            );
+            return LoopControl::Continue;
+        }
+
+        if fallback_token.is_cancelled() {
+            debug!(
+                error_kind = ?e.kind,
+                "{context} returned an error during fallback"
+            );
+            return LoopControl::Continue;
+        }
+
         match e.action {
             Action::Log => {
                 warn!(

--- a/pool-apps/pool/src/lib/mod.rs
+++ b/pool-apps/pool/src/lib/mod.rs
@@ -191,6 +191,7 @@ impl PoolSv2 {
 
         let channel_manager_clone = channel_manager.clone();
         let mut bitcoin_core_sv2_join_handle: Option<JoinHandle<()>> = None;
+        let mut bitcoin_core_sv2_cancellation_token: Option<CancellationToken> = None;
 
         match self.config.template_provider_type().clone() {
             TemplateProviderType::Sv2Tp {
@@ -234,15 +235,17 @@ impl PoolSv2 {
                 let incoming_tdp_receiver = channel_manager_to_tp_receiver.clone();
                 let outgoing_tdp_sender = tp_to_channel_manager_sender.clone();
 
+                let bitcoin_core_cancellation_token = CancellationToken::new();
                 let bitcoin_core_config = BitcoinCoreSv2TDPConfig {
                     unix_socket_path,
                     fee_threshold,
                     min_interval,
                     incoming_tdp_receiver,
                     outgoing_tdp_sender,
-                    cancellation_token: CancellationToken::new(),
+                    cancellation_token: bitcoin_core_cancellation_token.clone(),
                 };
 
+                bitcoin_core_sv2_cancellation_token = Some(bitcoin_core_cancellation_token);
                 bitcoin_core_sv2_join_handle = Some(
                     connect_to_bitcoin_core(
                         bitcoin_core_config,
@@ -287,6 +290,10 @@ impl PoolSv2 {
         if let Some(ref jd) = job_declarator_for_shutdown {
             info!("Shutting down embedded JDS...");
             jd.shutdown();
+        }
+
+        if let Some(bitcoin_core_sv2_cancellation_token) = bitcoin_core_sv2_cancellation_token {
+            bitcoin_core_sv2_cancellation_token.cancel();
         }
 
         if let Some(bitcoin_core_sv2_join_handle) = bitcoin_core_sv2_join_handle {


### PR DESCRIPTION
closes: #466 

This PR ensures that bitcoin-core-sv2 sends the template and prevhash as soon as it receives `CoinbaseConstraint`. At the same time, it ensures that the downstream server responds to the fallback handler and spawns in a separate thread so it doesn’t block the main thread from handling termination signals.
