### PR TITLE
add connection timeout to tProxy

### DIFF
--- a/miner-apps/jd-client/src/lib/job_declarator/mod.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/mod.rs
@@ -4,7 +4,7 @@ use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
     fallback_coordinator::FallbackCoordinator,
-    network_helpers::{connect_with_noise, resolve_host},
+    network_helpers::{connect_with_noise, resolve_host, TCP_CONNECT_TIMEOUT},
     stratum_core::{
         framing_sv2,
         handlers_sv2::HandleCommonMessagesFromServerAsync,
@@ -134,13 +134,10 @@ impl JobDeclarator {
             })?;
 
         info!("Connecting to JD Server at {addr}");
-        let stream = tokio::time::timeout(
-            tokio::time::Duration::from_secs(5),
-            TcpStream::connect(addr),
-        )
-        .await
-        .map_err(JDCError::fallback)?
-        .map_err(JDCError::fallback)?;
+        let stream = tokio::time::timeout(TCP_CONNECT_TIMEOUT, TcpStream::connect(addr))
+            .await
+            .map_err(JDCError::fallback)?
+            .map_err(JDCError::fallback)?;
         info!("Connection established with JD Server at {addr} in mode: {mode:?}");
 
         let (noise_stream_reader, noise_stream_writer) = tokio::select! {

--- a/miner-apps/jd-client/src/lib/upstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/upstream/mod.rs
@@ -15,7 +15,7 @@ use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
     fallback_coordinator::FallbackCoordinator,
-    network_helpers::{connect_with_noise, resolve_host},
+    network_helpers::{connect_with_noise, resolve_host, TCP_CONNECT_TIMEOUT},
     stratum_core::{
         binary_sv2::Seq064K, extensions_sv2::RequestExtensions, framing_sv2,
         handlers_sv2::HandleCommonMessagesFromServerAsync, parsers_sv2::AnyMessage,
@@ -145,13 +145,10 @@ impl Upstream {
                 JDCError::fallback(JDCErrorKind::NetworkHelpersError(e.into()))
             })?;
 
-        let stream = tokio::time::timeout(
-            tokio::time::Duration::from_secs(5),
-            TcpStream::connect(addr),
-        )
-        .await
-        .map_err(JDCError::fallback)?
-        .map_err(JDCError::fallback)?;
+        let stream = tokio::time::timeout(TCP_CONNECT_TIMEOUT, TcpStream::connect(addr))
+            .await
+            .map_err(JDCError::fallback)?
+            .map_err(JDCError::fallback)?;
         info!("Connected to upstream at {}", addr);
         debug!("Begin with noise setup in upstream connection");
 

--- a/miner-apps/translator/src/lib/error.rs
+++ b/miner-apps/translator/src/lib/error.rs
@@ -29,6 +29,7 @@ use stratum_apps::{
         MessageType,
     },
 };
+use tokio::time::error::Elapsed;
 
 pub type TproxyResult<T, Owner> = Result<T, TproxyError<Owner>>;
 
@@ -157,6 +158,8 @@ pub enum TproxyErrorKind {
     ChannelErrorReceiver(async_channel::RecvError),
     /// Channel sender error
     ChannelErrorSender,
+    /// Operation timed out
+    Timeout,
     /// Error converting SetDifficulty to Message
     SetDifficultyToMessage(SetDifficulty),
     /// Received an unexpected message type
@@ -221,6 +224,7 @@ impl fmt::Display for TproxyErrorKind {
             PoisonLock => write!(f, "Poison Lock error"),
             ChannelErrorReceiver(ref e) => write!(f, "Channel receive error: `{e:?}`"),
             ChannelErrorSender => write!(f, "Sender error"),
+            Timeout => write!(f, "Operation timed out"),
             SetDifficultyToMessage(ref e) => {
                 write!(f, "Error converting SetDifficulty to Message: `{e:?}`")
             }
@@ -327,6 +331,12 @@ impl From<ConfigError> for TproxyErrorKind {
 impl From<async_channel::RecvError> for TproxyErrorKind {
     fn from(e: async_channel::RecvError) -> Self {
         TproxyErrorKind::ChannelErrorReceiver(e)
+    }
+}
+
+impl From<Elapsed> for TproxyErrorKind {
+    fn from(_value: Elapsed) -> Self {
+        TproxyErrorKind::Timeout
     }
 }
 

--- a/miner-apps/translator/src/lib/sv2/upstream/mod.rs
+++ b/miner-apps/translator/src/lib/sv2/upstream/mod.rs
@@ -10,7 +10,7 @@ use async_channel::{unbounded, Receiver, Sender};
 use std::{net::SocketAddr, sync::Arc};
 use stratum_apps::{
     fallback_coordinator::FallbackCoordinator,
-    network_helpers::{self, connect_with_noise, resolve_host},
+    network_helpers::{self, connect_with_noise, resolve_host, TCP_CONNECT_TIMEOUT},
     stratum_core::{
         binary_sv2::Seq064K,
         common_messages_sv2::{Protocol, SetupConnection},
@@ -139,7 +139,10 @@ impl Upstream {
                 TproxyError::fallback(TproxyErrorKind::NetworkHelpersError(e.into()))
             })?;
 
-        match TcpStream::connect(resolved_addr).await {
+        match tokio::time::timeout(TCP_CONNECT_TIMEOUT, TcpStream::connect(resolved_addr))
+            .await
+            .map_err(TproxyError::fallback)?
+        {
             Ok(socket) => {
                 info!("Connected to upstream at {}", resolved_addr);
 
@@ -173,38 +176,37 @@ impl Upstream {
                                     resolved_addr
                                 );
 
-                                return Ok(Self {
+                                Ok(Self {
                                     upstream_io,
                                     required_extensions: required_extensions.clone(),
                                     address: resolved_addr,
-                                });
+                                })
                             }
                             Err(network_helpers::Error::InvalidKey) => {
-                                return Err(TproxyError::fallback(TproxyErrorKind::InvalidKey));
+                                Err(TproxyError::fallback(TproxyErrorKind::InvalidKey))
                             }
                             Err(e) => {
                                 error!(
-                                    "Failed Noise handshake with {}: {e}. Retrying...",
+                                    "Failed Noise handshake with {}: {e}.",
                                     resolved_addr
                                 );
+                                Err(TproxyError::fallback(
+                                    TproxyErrorKind::NetworkHelpersError(e),
+                                ))
                             }
                         }
                     }
                     _ = cancellation_token.cancelled() => {
                         info!("Shutdown received during handshake, dropping connection");
-                        return Err(TproxyError::shutdown(TproxyErrorKind::CouldNotInitiateSystem));
+                        Err(TproxyError::shutdown(TproxyErrorKind::CouldNotInitiateSystem))
                     }
                 }
             }
             Err(e) => {
                 error!("Failed to connect to {}: {e}.", resolved_addr);
+                Err(TproxyError::fallback(e))
             }
         }
-
-        error!("Failed to connect to any configured upstream.");
-        Err(TproxyError::shutdown(
-            TproxyErrorKind::CouldNotInitiateSystem,
-        ))
     }
 
     /// Starts the upstream connection and begins message processing.

--- a/stratum-apps/src/network_helpers/mod.rs
+++ b/stratum-apps/src/network_helpers/mod.rs
@@ -105,6 +105,10 @@ impl From<ResolveError> for Error {
 /// Use [`noise_stream::NoiseTcpStream::new`] directly to override.
 const NOISE_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Default timeout for establishing outbound TCP connections to SV2 peers.
+/// This keeps fallback attempts bounded when a remote endpoint is unreachable or filtered.
+pub const TCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Connects to an upstream server as a Noise initiator, returning the split read/write halves.
 ///
 /// The handshake timeout is opinionated and fixed at [`NOISE_HANDSHAKE_TIMEOUT`]. If you need a


### PR DESCRIPTION
This PR adds a timeout to the connection attempts of tProxy, which unblocks it in case the upstream is not listening at all.

PS: we are already doing this in JDC