### PR TITLE
Make sure to drain channel on drop

### DIFF
--- a/integration-tests/lib/mock_roles.rs
+++ b/integration-tests/lib/mock_roles.rs
@@ -1,6 +1,6 @@
 use crate::utils::{create_downstream, create_upstream, message_from_frame, wait_for_client};
 use async_channel::Sender;
-use std::{convert::TryInto, net::SocketAddr};
+use std::{convert::TryInto, net::SocketAddr, time::Duration};
 use stratum_apps::{
     stratum_core::{
         codec_sv2::StandardEitherFrame,
@@ -126,6 +126,7 @@ impl MockDownstream {
 pub struct MockUpstream {
     listening_address: SocketAddr,
     setup: WithSetup,
+    disconnect_after_setup: Option<Duration>,
 }
 
 impl MockUpstream {
@@ -133,7 +134,13 @@ impl MockUpstream {
         Self {
             listening_address,
             setup,
+            disconnect_after_setup: None,
         }
+    }
+
+    pub fn disconnect_after_setup_connection_success(mut self, delay: Duration) -> Self {
+        self.disconnect_after_setup = Some(delay);
+        self
     }
 
     pub async fn start(self) -> Sender<AnyMessage<'static>> {
@@ -183,6 +190,13 @@ impl MockUpstream {
                                 "MockUpstream: sent SetupConnectionSuccess with flags {}",
                                 flags
                             );
+
+                            if let Some(delay) = self.disconnect_after_setup {
+                                tokio::time::sleep(delay).await;
+                                downstream_sender.close();
+                                downstream_receiver.close();
+                                return;
+                            }
                         } else {
                             let error = AnyMessage::Common(CommonMessages::SetupConnectionError(
                                 SetupConnectionError {

--- a/integration-tests/tests/translator_integration.rs
+++ b/integration-tests/tests/translator_integration.rs
@@ -2021,3 +2021,61 @@ async fn multiple_tproxy_sessions() {
 
     shutdown_all!(pool, tproxy_1, tproxy_2);
 }
+
+// Demonstrates the scenario where the primary upstream abruptly disconnects.
+#[tokio::test]
+async fn test_translator_fallback_during_abrupt_disconnection() {
+    start_tracing();
+    let primary_addr = get_available_address();
+    let _primary_upstream = MockUpstream::new(
+        primary_addr,
+        WithSetup::yes_with_defaults(Protocol::MiningProtocol, 0),
+    )
+    .disconnect_after_setup_connection_success(Duration::from_secs(1))
+    .start()
+    .await;
+
+    let (_tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
+    let (pool_2, pool_addr_2, _) = start_pool(sv2_tp_config(tp_addr), vec![], vec![], false).await;
+
+    let (pool_translator_sniffer_2, pool_translator_sniffer_addr_2) =
+        start_sniffer("B", pool_addr_2, false, vec![], None);
+
+    let (translator, tproxy_addr, _) = start_sv2_translator(
+        &[primary_addr, pool_translator_sniffer_addr_2],
+        false,
+        vec![],
+        vec![],
+        None,
+        false,
+    )
+    .await;
+
+    pool_translator_sniffer_2
+        .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+        .await;
+
+    pool_translator_sniffer_2
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+        )
+        .await;
+
+    let (_minerd_process, _minerd_addr) = start_minerd(tproxy_addr, None, None, false).await;
+
+    pool_translator_sniffer_2
+        .wait_for_message_type(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
+        )
+        .await;
+
+    pool_translator_sniffer_2
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL_SUCCESS,
+        )
+        .await;
+    shutdown_all!(translator, pool_2);
+}

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -10,6 +10,7 @@ use std::{
 use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     coinbase_output_constraints::coinbase_output_constraints_message,
     custom_mutex::Mutex,
     fallback_coordinator::FallbackCoordinator,
@@ -265,6 +266,26 @@ pub struct ChannelManagerIo {
     tp_receiver: Receiver<TemplateDistribution<'static>>,
     downstream_sender: Arc<Mutex<HashMap<DownstreamId, Sender<DownstreamMessage>>>>,
     downstream_receiver: Receiver<(DownstreamId, Mining<'static>, Option<Vec<Tlv>>)>,
+}
+
+impl ChannelManagerIo {
+    fn close(&self, close_template_provider: bool) {
+        self.upstream_sender.close();
+        self.jd_sender.close();
+        self.upstream_receiver.close_and_drain();
+        self.jd_receiver.close_and_drain();
+        if close_template_provider {
+            self.tp_sender.close();
+            self.tp_receiver.close_and_drain();
+        }
+        self.downstream_receiver.close_and_drain();
+        self.downstream_sender.super_safe_lock(|downstreams| {
+            for sender in downstreams.values() {
+                sender.close();
+            }
+            downstreams.clear();
+        });
+    }
 }
 
 /// Contains all the state of mutable and immutable data required
@@ -776,6 +797,9 @@ impl ChannelManager {
                 }
             }
 
+            let close_template_provider =
+                cancellation_token.is_cancelled() || !fallback_token.is_cancelled();
+            self.channel_manager_io.close(close_template_provider);
             // signal fallback coordinator that this task has completed its cleanup
             fallback_handler.done();
         });

--- a/miner-apps/jd-client/src/lib/downstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/downstream/mod.rs
@@ -6,6 +6,7 @@ use std::{
 
 use async_channel::{unbounded, Receiver, Sender};
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     custom_mutex::Mutex,
     fallback_coordinator::FallbackCoordinator,
     network_helpers::noise_stream::NoiseTcpStream,
@@ -74,6 +75,14 @@ pub struct DownstreamIo {
     channel_manager_receiver: Receiver<(Mining<'static>, Option<Vec<Tlv>>)>,
     downstream_sender: Sender<Sv2Frame>,
     downstream_receiver: Receiver<Sv2Frame>,
+}
+
+impl DownstreamIo {
+    fn close(&self) {
+        self.downstream_sender.close();
+        self.channel_manager_receiver.close_and_drain();
+        self.downstream_receiver.close_and_drain();
+    }
 }
 
 /// Represents a downstream client connected to this node.
@@ -242,6 +251,7 @@ impl Downstream {
                 &fallback_token,
             );
             on_disconnect(self.downstream_id);
+            self.downstream_io.close();
             fallback_handler.done();
             return;
         }
@@ -297,6 +307,7 @@ impl Downstream {
                 on_disconnect(self.downstream_id);
             }
             self.downstream_cancellation_token.cancel();
+            self.downstream_io.close();
             warn!("Downstream: unified message loop exited.");
             fallback_handler.done();
         });

--- a/miner-apps/jd-client/src/lib/io_task.rs
+++ b/miner-apps/jd-client/src/lib/io_task.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_channel::{Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     fallback_coordinator::{FallbackCoordinator, FallbackHandler},
     network_helpers::noise_stream::{NoiseTcpReadHalf, NoiseTcpWriteHalf},
     stratum_core::framing_sv2::framing::Frame,
@@ -120,7 +121,7 @@ pub fn spawn_io_tasks(
                 }
 
                 inbound_tx.close();
-                outbound_rx_clone.close();
+                outbound_rx_clone.close_and_drain();
                 drop(inbound_tx);
                 drop(outbound_rx_clone);
 
@@ -162,12 +163,12 @@ pub fn spawn_io_tasks(
                                     trace!("Sending outbound frame");
                                     if let Err(e) = writer.write_frame(frame.into()).await {
                                         error!(error=?e, "Writer error");
-                                        outbound_rx.close();
+                                        outbound_rx.close_and_drain();
                                         break;
                                     }
                                 }
                                 Err(_) => {
-                                    outbound_rx.close();
+                                    outbound_rx.close_and_drain();
                                     warn!("Outbound channel closed");
                                     break;
                                 }
@@ -175,7 +176,7 @@ pub fn spawn_io_tasks(
                         }
                     }
                 }
-                outbound_rx.close();
+                outbound_rx.close_and_drain();
                 inbound_tx_clone.close();
                 drop(outbound_rx);
                 drop(inbound_tx_clone);

--- a/miner-apps/jd-client/src/lib/job_declarator/mod.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/mod.rs
@@ -3,6 +3,7 @@ use std::{net::SocketAddr, sync::Arc};
 use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     fallback_coordinator::FallbackCoordinator,
     network_helpers::{connect_with_noise, resolve_host, TCP_CONNECT_TIMEOUT},
     stratum_core::{
@@ -35,6 +36,15 @@ pub struct JobDeclaratorIo {
     channel_manager_receiver: Receiver<JobDeclaration<'static>>,
     jds_sender: Sender<Sv2Frame>,
     jds_receiver: Receiver<Sv2Frame>,
+}
+
+impl JobDeclaratorIo {
+    fn close(&self) {
+        self.channel_manager_sender.close();
+        self.jds_sender.close();
+        self.channel_manager_receiver.close_and_drain();
+        self.jds_receiver.close_and_drain();
+    }
 }
 
 /// Manages the lifecycle and communication with a Job Declarator (JDS)
@@ -201,6 +211,7 @@ impl JobDeclarator {
                 &cancellation_token,
                 &fallback_token,
             );
+            self.job_declarator_io.close();
             fallback_handler.done();
             return;
         }
@@ -247,6 +258,7 @@ impl JobDeclarator {
                     },
                 }
             }
+            self.job_declarator_io.close();
             warn!("JobDeclarator: unified message loop exited.");
 
             // signal fallback coordinator that this task has completed its cleanup

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -218,9 +218,16 @@ impl JobDeclaratorClient {
                 let cancellation_token_tp = self.cancellation_token.clone();
                 let task_manager_cl = task_manager.clone();
 
-                template_receiver
+                if let Err(e) = template_receiver
                     .start(address, cancellation_token_tp, task_manager_cl)
-                    .await;
+                    .await
+                {
+                    error!(error = ?e, "Failed to start SV2 template receiver");
+                    self.cancellation_token.cancel();
+                    self.shutdown_notify.notify_waiters();
+                    self.is_alive.store(false, Ordering::Relaxed);
+                    return;
+                }
 
                 info!("Sv2 Template Provider setup done");
             }

--- a/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     key_utils::Secp256k1PublicKey,
     network_helpers::{self, connect_with_noise, resolve_host_port},
     stratum_core::{
@@ -53,6 +54,15 @@ pub struct Sv2TpIo {
     channel_manager_receiver: Receiver<TemplateDistribution<'static>>,
     tp_sender: Sender<Sv2Frame>,
     tp_receiver: Receiver<Sv2Frame>,
+}
+
+impl Sv2TpIo {
+    fn close(&self) {
+        self.channel_manager_sender.close();
+        self.tp_sender.close();
+        self.channel_manager_receiver.close_and_drain();
+        self.tp_receiver.close_and_drain();
+    }
 }
 
 /// Manages communication with a Stratum V2 Template Provider.
@@ -222,9 +232,13 @@ impl Sv2Tp {
         socket_address: String,
         cancellation_token: CancellationToken,
         task_manager: Arc<TaskManager>,
-    ) {
+    ) -> JDCResult<(), error::TemplateProvider> {
         info!("Initialized state for starting template receiver");
-        _ = self.setup_connection(socket_address).await;
+        if let Err(e) = self.setup_connection(socket_address).await {
+            error!("TemplateReceiver setup connection failed: {e:?}");
+            self.sv2_tp_io.close();
+            return Err(e);
+        }
 
         info!("Setup Connection done. connection with template receiver is now done");
         task_manager.spawn(async move {
@@ -264,8 +278,10 @@ impl Sv2Tp {
                     },
                 }
             }
+            self.sv2_tp_io.close();
             warn!("TemplateReceiver: unified message loop exited.");
         });
+        Ok(())
     }
 
     /// Handle inbound messages from the template provider.

--- a/miner-apps/jd-client/src/lib/upstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/upstream/mod.rs
@@ -14,6 +14,7 @@ use std::{net::SocketAddr, sync::Arc};
 use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     fallback_coordinator::FallbackCoordinator,
     network_helpers::{connect_with_noise, resolve_host, TCP_CONNECT_TIMEOUT},
     stratum_core::{
@@ -49,6 +50,15 @@ pub struct UpstreamIo {
     channel_manager_receiver: Receiver<Sv2Frame>,
     upstream_sender: Sender<Sv2Frame>,
     upstream_receiver: Receiver<Sv2Frame>,
+}
+
+impl UpstreamIo {
+    fn close(&self) {
+        self.channel_manager_sender.close();
+        self.upstream_sender.close();
+        self.channel_manager_receiver.close_and_drain();
+        self.upstream_receiver.close_and_drain();
+    }
 }
 
 /// Represents an upstream connection (e.g., a pool).
@@ -317,8 +327,10 @@ impl Upstream {
                 &cancellation_token,
                 &setup_fallback_token,
             ) {
+                self.upstream_io.close();
                 return;
             }
+            self.upstream_io.close();
             return;
         }
 
@@ -373,6 +385,7 @@ impl Upstream {
 
                 }
             }
+            self.upstream_io.close();
             warn!("Upstream: unified message loop exited.");
 
             // signal fallback coordinator that this task has completed its cleanup

--- a/miner-apps/translator/src/lib/io_task.rs
+++ b/miner-apps/translator/src/lib/io_task.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use async_channel::{Receiver, Sender};
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     fallback_coordinator::FallbackCoordinator,
     network_helpers::noise_stream::{NoiseTcpReadHalf, NoiseTcpWriteHalf},
     stratum_core::framing_sv2::framing::Frame,
@@ -82,7 +83,7 @@ pub fn spawn_io_tasks(
                     }
                 }
                 inbound_tx.close();
-                outbound_rx_clone.close();
+                outbound_rx_clone.close_and_drain();
                 drop(inbound_tx);
                 drop(outbound_rx_clone);
 
@@ -128,12 +129,12 @@ pub fn spawn_io_tasks(
                                     trace!("Sending outbound frame");
                                     if let Err(e) = writer.write_frame(frame.into()).await {
                                         error!(error=?e, "Writer error");
-                                        outbound_rx.close();
+                                        outbound_rx.close_and_drain();
                                         break;
                                     }
                                 }
                                 Err(_) => {
-                                    outbound_rx.close();
+                                    outbound_rx.close_and_drain();
                                     warn!("Outbound channel closed");
                                     break;
                                 }
@@ -141,7 +142,7 @@ pub fn spawn_io_tasks(
                         }
                     }
                 }
-                outbound_rx.close();
+                outbound_rx.close_and_drain();
                 inbound_tx_clone.close();
                 drop(outbound_rx);
                 drop(inbound_tx_clone);

--- a/miner-apps/translator/src/lib/sv1/downstream.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream.rs
@@ -12,6 +12,7 @@ use std::{
     time::Instant,
 };
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     custom_mutex::Mutex,
     fallback_coordinator::FallbackCoordinator,
     stratum_core::{
@@ -52,10 +53,11 @@ impl DownstreamIo {
         }
     }
 
-    fn drop(&self) {
+    fn close(&self) {
         debug!("Dropping downstream channel state");
-        self.downstream_sv1_receiver.close();
         self.downstream_sv1_sender.close();
+        self.downstream_sv1_receiver.close_and_drain();
+        self.sv1_server_receiver.close_and_drain();
     }
 }
 
@@ -335,7 +337,7 @@ impl Downstream {
 
             warn!("Downstream {downstream_id}: unified task shutting down");
             self.downstream_cancellation_token.cancel();
-            self.downstream_io.drop();
+            self.downstream_io.close();
             on_disconnect().await;
             // signal fallback coordinator that this task has completed its cleanup
             fallback_handler.done();

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -22,6 +22,7 @@ use std::{
     time::{Duration, Instant},
 };
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     custom_mutex::Mutex,
     fallback_coordinator::FallbackCoordinator,
     network_helpers::sv1_connection::ConnectionSV1,
@@ -77,11 +78,18 @@ impl Sv1ServerIo {
         }
     }
 
-    fn drop(&self) {
-        self.channel_manager_receiver.close();
+    fn close(&self) {
         self.channel_manager_sender.close();
-        self.downstream_to_sv1_server_receiver.close();
         self.downstream_to_sv1_server_sender.close();
+        self.channel_manager_receiver.close_and_drain();
+        self.downstream_to_sv1_server_receiver.close_and_drain();
+        self.sv1_server_to_downstream_sender
+            .super_safe_lock(|downstream_senders| {
+                for sender in downstream_senders.values() {
+                    sender.close();
+                }
+                downstream_senders.clear();
+            });
     }
 }
 
@@ -245,7 +253,7 @@ impl Sv1Server {
         self.pending_target_updates
             .safe_lock(|updates| updates.clear())
             .ok();
-        self.sv1_server_io.drop();
+        self.sv1_server_io.close();
     }
 
     /// Creates a new SV1 server instance.

--- a/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
@@ -10,6 +10,7 @@ use async_channel::{Receiver, Sender};
 use dashmap::DashMap;
 use std::sync::Arc;
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     custom_mutex::Mutex,
     fallback_coordinator::FallbackCoordinator,
     stratum_core::{
@@ -87,12 +88,12 @@ impl ChannelManagerIo {
         }
     }
 
-    fn drop(&self) {
+    fn close(&self) {
         debug!("Dropping channel manager channels");
-        self.upstream_receiver.close();
         self.upstream_sender.close();
-        self.sv1_server_receiver.close();
         self.sv1_server_sender.close();
+        self.upstream_receiver.close_and_drain();
+        self.sv1_server_receiver.close_and_drain();
     }
 }
 
@@ -172,6 +173,19 @@ pub struct ChannelManager {
 
 #[cfg_attr(not(test), hotpath::measure_all)]
 impl ChannelManager {
+    fn reset_state(&self) {
+        self.pending_downstream_channels.clear();
+        self.extended_channels.clear();
+        self.group_channels.clear();
+        self.share_sequence_counters.clear();
+        self.negotiated_extensions
+            .super_safe_lock(|data| data.clear());
+        self.aggregated_extranonce_allocator
+            .super_safe_lock(|allocator| *allocator = None);
+        self.aggregated_channel_state
+            .set(AggregatedState::NoChannel);
+    }
+
     fn handle_error_action(
         &self,
         context: &str,
@@ -314,19 +328,13 @@ impl ChannelManager {
                 tokio::select! {
                     biased;
                     _ = cancellation_token.cancelled() => {
-                        info!("ChannelManager: received shutdown signal.");
+                        info!("ChannelManager: received shutdown signal, resetting state");
+                        self.reset_state();
                         break;
                     }
                     _ = fallback_token.cancelled() => {
                         info!("ChannelManager: fallback triggered, resetting state");
-                        self.pending_downstream_channels.clear();
-                        self.extended_channels.clear();
-                        self.group_channels.clear();
-                        self.share_sequence_counters.clear();
-                        self.negotiated_extensions.super_safe_lock(|data| data.clear());
-                        self.aggregated_extranonce_allocator
-                            .super_safe_lock(|allocator| *allocator = None);
-                        self.aggregated_channel_state.set(AggregatedState::NoChannel);
+                        self.reset_state();
                         break;
                     }
                     res = self.clone().handle_upstream_frame() => {
@@ -360,7 +368,7 @@ impl ChannelManager {
                 }
             }
 
-            self.channel_manager_io.drop();
+            self.channel_manager_io.close();
             warn!("ChannelManager: unified message loop exited.");
 
             // signal fallback coordinator that this task has completed its cleanup

--- a/miner-apps/translator/src/lib/sv2/upstream/mod.rs
+++ b/miner-apps/translator/src/lib/sv2/upstream/mod.rs
@@ -8,6 +8,7 @@ use crate::{
 use async_channel::{unbounded, Receiver, Sender};
 use std::{net::SocketAddr, sync::Arc};
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     fallback_coordinator::FallbackCoordinator,
     network_helpers::{self, connect_with_noise, resolve_host, TCP_CONNECT_TIMEOUT},
     stratum_core::{
@@ -56,10 +57,12 @@ impl UpstreamIo {
         }
     }
 
-    fn drop(&self) {
+    fn close(&self) {
         debug!("Closing all upstream channels");
-        self.upstream_receiver.close();
         self.upstream_sender.close();
+        self.channel_manager_sender.close();
+        self.upstream_receiver.close_and_drain();
+        self.channel_manager_receiver.close_and_drain();
     }
 }
 
@@ -290,10 +293,12 @@ impl Upstream {
 
             _ = cancellation_token.cancelled() => {
                 info!("Upstream: shutdown signal received during connection setup.");
+                self.upstream_io.close();
                 return Ok(());
             }
             _ = fallback_token.cancelled() => {
                 info!("Upstream: fallback signal received during connection setup.");
+                self.upstream_io.close();
                 return Ok(());
             }
             result = self.setup_connection() => {
@@ -529,7 +534,7 @@ impl Upstream {
                 }
             }
 
-            self.upstream_io.drop();
+            self.upstream_io.close();
             warn!("Upstream: task shutting down cleanly.");
 
             // signal fallback coordinator that this task has completed its cleanup

--- a/pool-apps/pool/src/lib/channel_manager/mod.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mod.rs
@@ -11,6 +11,7 @@ use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use core::sync::atomic::Ordering;
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     coinbase_output_constraints::coinbase_output_constraints_message_with_offset,
     config_helpers::CoinbaseRewardScript,
     custom_mutex::Mutex,
@@ -94,6 +95,20 @@ pub struct ChannelManagerIo {
     tp_receiver: Receiver<TemplateDistribution<'static>>,
     downstream_sender: Arc<Mutex<HashMap<DownstreamId, Sender<DownstreamMessage>>>>,
     downstream_receiver: Receiver<(usize, Mining<'static>, Option<Vec<Tlv>>)>,
+}
+
+impl ChannelManagerIo {
+    fn close(&self) {
+        self.tp_sender.close();
+        self.tp_receiver.close_and_drain();
+        self.downstream_receiver.close_and_drain();
+        self.downstream_sender.super_safe_lock(|downstreams| {
+            for sender in downstreams.values() {
+                sender.close();
+            }
+            downstreams.clear();
+        });
+    }
 }
 
 /// Contains all the state of mutable and immutable data required
@@ -452,6 +467,7 @@ impl ChannelManager {
                     }
                 }
             }
+            self.channel_manager_io.close();
         });
         Ok(())
     }

--- a/pool-apps/pool/src/lib/downstream/mod.rs
+++ b/pool-apps/pool/src/lib/downstream/mod.rs
@@ -9,6 +9,7 @@ use std::{
 use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     custom_mutex::Mutex,
     network_helpers::noise_stream::NoiseTcpStream,
     stratum_core::{
@@ -75,6 +76,14 @@ pub struct DownstreamIo {
     channel_manager_receiver: Receiver<(Mining<'static>, Option<Vec<Tlv>>)>,
     downstream_sender: Sender<Sv2Frame>,
     downstream_receiver: Receiver<Sv2Frame>,
+}
+
+impl DownstreamIo {
+    fn close(&self) {
+        self.downstream_sender.close();
+        self.channel_manager_receiver.close_and_drain();
+        self.downstream_receiver.close_and_drain();
+    }
 }
 
 /// Represents a downstream client connected to this node.
@@ -224,6 +233,7 @@ impl Downstream {
                 &cancellation_token,
             );
             on_disconnect(self.downstream_id);
+            self.downstream_io.close();
             return;
         }
 
@@ -265,6 +275,7 @@ impl Downstream {
                 }
             }
             self.downstream_connection_token.cancel();
+            self.downstream_io.close();
             on_disconnect(self.downstream_id);
             warn!("Downstream: unified message loop exited.");
         });

--- a/pool-apps/pool/src/lib/io_task.rs
+++ b/pool-apps/pool/src/lib/io_task.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use async_channel::{Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     network_helpers::noise_stream::{NoiseTcpReadHalf, NoiseTcpWriteHalf},
     stratum_core::framing_sv2::framing::Frame,
     task_manager::TaskManager,
@@ -67,7 +68,7 @@ pub fn spawn_io_tasks(
                     }
                 }
                 inbound_tx.close();
-                outbound_rx_clone.close();
+                outbound_rx_clone.close_and_drain();
                 drop(inbound_tx);
                 drop(outbound_rx_clone);
                 warn!("Reader task exited.");
@@ -88,7 +89,7 @@ pub fn spawn_io_tasks(
                     tokio::select! {
                         _ = cancellation_token.cancelled() => {
                             trace!("Received shutdown");
-                            outbound_rx.close();
+                            outbound_rx.close_and_drain();
                             break;
                         }
                         res = outbound_rx.recv() => {
@@ -97,12 +98,12 @@ pub fn spawn_io_tasks(
                                     trace!("Sending outbound frame");
                                     if let Err(e) = writer.write_frame(frame.into()).await {
                                         error!(error=?e, "Writer error");
-                                        outbound_rx.close();
+                                        outbound_rx.close_and_drain();
                                         break;
                                     }
                                 }
                                 Err(_) => {
-                                    outbound_rx.close();
+                                    outbound_rx.close_and_drain();
                                     warn!("Outbound channel closed");
                                     break;
                                 }
@@ -110,7 +111,7 @@ pub fn spawn_io_tasks(
                         }
                     }
                 }
-                outbound_rx.close();
+                outbound_rx.close_and_drain();
                 inbound_tx_clone.close();
                 drop(outbound_rx);
                 drop(inbound_tx_clone);

--- a/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
@@ -3,6 +3,7 @@ mod common_message_handler;
 use async_channel::{unbounded, Receiver, Sender};
 use bitcoin_core_sv2::template_distribution_protocol::CancellationToken;
 use stratum_apps::{
+    channel_utils::ReceiverCleanup,
     key_utils::Secp256k1PublicKey,
     network_helpers::{self, connect_with_noise, resolve_host_port},
     stratum_core::{
@@ -31,6 +32,15 @@ pub struct Sv2TpIo {
     channel_manager_receiver: Receiver<TemplateDistribution<'static>>,
     tp_sender: Sender<Sv2Frame>,
     tp_receiver: Receiver<Sv2Frame>,
+}
+
+impl Sv2TpIo {
+    fn close(&self) {
+        self.channel_manager_sender.close();
+        self.tp_sender.close();
+        self.channel_manager_receiver.close_and_drain();
+        self.tp_receiver.close_and_drain();
+    }
 }
 
 #[derive(Clone)]
@@ -176,7 +186,10 @@ impl Sv2Tp {
         task_manager: Arc<TaskManager>,
     ) -> PoolResult<(), error::TemplateProvider> {
         info!("Initialized state for starting template receiver");
-        self.setup_connection(socket_address).await?;
+        if let Err(e) = self.setup_connection(socket_address).await {
+            self.sv2_tp_io.close();
+            return Err(e);
+        }
 
         info!("Setup Connection done. connection with template receiver is now done");
         task_manager.spawn(async move {
@@ -215,6 +228,7 @@ impl Sv2Tp {
                     },
                 }
             }
+            self.sv2_tp_io.close();
             warn!("TemplateReceiver: unified message loop exited.");
         });
         Ok(())

--- a/stratum-apps/src/channel_utils.rs
+++ b/stratum-apps/src/channel_utils.rs
@@ -1,0 +1,18 @@
+use async_channel::Receiver;
+
+pub trait ReceiverCleanup<T> {
+    fn close_and_drain(&self) -> usize;
+}
+
+impl<T> ReceiverCleanup<T> for Receiver<T> {
+    fn close_and_drain(&self) -> usize {
+        self.close();
+
+        let mut drained = 0;
+        while self.try_recv().is_ok() {
+            drained += 1;
+        }
+
+        drained
+    }
+}

--- a/stratum-apps/src/lib.rs
+++ b/stratum-apps/src/lib.rs
@@ -78,3 +78,6 @@ pub mod coinbase_output_constraints;
 
 /// Fallback coordinator
 pub mod fallback_coordinator;
+
+/// Shared async channel cleanup helpers.
+pub mod channel_utils;


### PR DESCRIPTION
This PR ensures that we drain the receiver end of the channel so that any sender awaiting on a send operation can be unblocked. This was one of the major causes of the translator fallback hanging.
