### PR TITLE
bump `translator_sv2` to `0.2.5`

### DIFF
--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "async-channel 1.9.0",
  "clap",

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -2867,7 +2867,7 @@ dependencies = [
 
 [[package]]
 name = "translator_sv2"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "async-channel",
  "clap",

--- a/miner-apps/translator/Cargo.toml
+++ b/miner-apps/translator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "translator_sv2"
-version = "0.2.3"
+version = "0.2.5"
 authors = ["The Stratum V2 Developers"]
 edition = "2021"
 description = "SV1 to SV2 translation proxy"


### PR DESCRIPTION
Latest tProxy version published on `crates.io` is `0.2.4`: https://crates.io/crates/translator_sv2

We published it on our latest `v0.3.5` release.

This PR bumps it to `0.2.5` so we can publish the new version in this `v0.4.0` release.