### PR TITLE
Adapt semantics of REQUIRES_STANDARD_JOBS

### DIFF
--- a/integration-tests/tests/jd_integration.rs
+++ b/integration-tests/tests/jd_integration.rs
@@ -1226,3 +1226,76 @@ async fn jdc_require_standard_jobs_set_does_not_group_standard_channels() {
 
     shutdown_all!(jdc, pool);
 }
+
+// This test verifies that JDC rejects OpenExtendedMiningChannel when
+// REQUIRES_STANDARD_JOBS is set during SetupConnection.
+#[tokio::test]
+async fn jdc_require_standard_jobs_set_rejects_open_extended_mining_channel() {
+    start_tracing();
+    let bitcoin_core = start_bitcoin_core(DifficultyLevel::Low);
+    let (pool, pool_addr, jds_addr, _) =
+        start_pool_with_jds(&bitcoin_core, vec![], vec![], true).await;
+
+    let (jdc, jdc_addr, _) = start_jdc(
+        &[(pool_addr, jds_addr)],
+        ipc_config(
+            bitcoin_core.data_dir().clone(),
+            bitcoin_core.is_signet(),
+            None,
+        ),
+        vec![],
+        vec![],
+        false,
+        None,
+    );
+
+    let (sniffer, sniffer_addr) = start_sniffer("sniffer", jdc_addr, false, vec![], None);
+    // SetupConnection flags: 0b0001 == REQUIRES_STANDARD_JOBS.
+    let mock_downstream = MockDownstream::new(
+        sniffer_addr,
+        WithSetup::yes_with_defaults(Protocol::MiningProtocol, 0b0001),
+    );
+    let send_to_jdc = mock_downstream.start().await;
+
+    sniffer
+        .wait_for_message_type_and_clean_queue(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+        )
+        .await;
+
+    let open_extended_mining_channel = AnyMessage::Mining(Mining::OpenExtendedMiningChannel(
+        OpenExtendedMiningChannel {
+            request_id: 100u32.into(),
+            user_identity: b"user_identity".to_vec().try_into().unwrap(),
+            nominal_hash_rate: 1000.0,
+            max_target: vec![0xff; 32].try_into().unwrap(),
+            min_extranonce_size: 8,
+        },
+    ));
+    send_to_jdc
+        .send(open_extended_mining_channel)
+        .await
+        .unwrap();
+
+    sniffer
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_OPEN_MINING_CHANNEL_ERROR,
+        )
+        .await;
+
+    let error = loop {
+        match sniffer.next_message_from_upstream() {
+            Some((_, AnyMessage::Mining(Mining::OpenMiningChannelError(msg)))) => break msg,
+            _ => continue,
+        }
+    };
+
+    assert_eq!(
+        error.error_code.as_utf8_or_hex(),
+        ERROR_CODE_OPEN_MINING_CHANNEL_EXTENDED_CHANNELS_NOT_SUPPORTED_FOR_STANDARD_JOBS
+    );
+
+    shutdown_all!(jdc, pool);
+}

--- a/integration-tests/tests/pool_integration.rs
+++ b/integration-tests/tests/pool_integration.rs
@@ -1029,3 +1029,72 @@ async fn pool_require_standard_jobs_set_does_not_group_standard_channels() {
     }
     pool.shutdown().await;
 }
+
+// This test verifies that Pool rejects OpenExtendedMiningChannel when
+// REQUIRES_STANDARD_JOBS is set during SetupConnection.
+#[tokio::test]
+async fn pool_require_standard_jobs_set_rejects_open_extended_mining_channel() {
+    start_tracing();
+    let bitcoin_core = start_bitcoin_core(DifficultyLevel::Low);
+    let (pool, pool_addr, _) = start_pool(
+        ipc_config(
+            bitcoin_core.data_dir().clone(),
+            bitcoin_core.is_signet(),
+            None,
+        ),
+        vec![],
+        vec![],
+        false,
+    )
+    .await;
+
+    let (sniffer, sniffer_addr) = start_sniffer("sniffer", pool_addr, false, vec![], None);
+    // SetupConnection flags: 0b0001 == REQUIRES_STANDARD_JOBS.
+    let mock_downstream = MockDownstream::new(
+        sniffer_addr,
+        WithSetup::yes_with_defaults(Protocol::MiningProtocol, 0b0001),
+    );
+    let send_to_pool = mock_downstream.start().await;
+
+    sniffer
+        .wait_for_message_type_and_clean_queue(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+        )
+        .await;
+
+    let open_extended_mining_channel = AnyMessage::Mining(Mining::OpenExtendedMiningChannel(
+        OpenExtendedMiningChannel {
+            request_id: 100u32.into(),
+            user_identity: b"user_identity".to_vec().try_into().unwrap(),
+            nominal_hash_rate: 1000.0,
+            max_target: vec![0xff; 32].try_into().unwrap(),
+            min_extranonce_size: 8,
+        },
+    ));
+    send_to_pool
+        .send(open_extended_mining_channel)
+        .await
+        .unwrap();
+
+    sniffer
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_OPEN_MINING_CHANNEL_ERROR,
+        )
+        .await;
+
+    let error = loop {
+        match sniffer.next_message_from_upstream() {
+            Some((_, AnyMessage::Mining(Mining::OpenMiningChannelError(msg)))) => break msg,
+            _ => continue,
+        }
+    };
+
+    assert_eq!(
+        error.error_code.as_utf8_or_hex(),
+        ERROR_CODE_OPEN_MINING_CHANNEL_EXTENDED_CHANNELS_NOT_SUPPORTED_FOR_STANDARD_JOBS
+    );
+
+    pool.shutdown().await;
+}

--- a/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
@@ -529,11 +529,19 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 };
 
                 downstream.downstream_data.super_safe_lock(|data| {
-                        let mut messages: Vec<RouteMessageTo> = vec![];
-                        let extended_channel_id =
-                            data.channel_id_factory.fetch_add(1, Ordering::Relaxed);
+                    if data.require_std_job {
+                        return Ok(vec![(
+                            downstream_id,
+                            build_error(ERROR_CODE_OPEN_MINING_CHANNEL_EXTENDED_CHANNELS_NOT_SUPPORTED_FOR_STANDARD_JOBS),
+                        )
+                        .into()])
+                    }
 
-                        let extranonce_prefix = match channel_manager_data
+                    let mut messages: Vec<RouteMessageTo> = vec![];
+                    let extended_channel_id =
+                        data.channel_id_factory.fetch_add(1, Ordering::Relaxed);
+
+                    let extranonce_prefix = match channel_manager_data
                             .extranonce_allocator
                             .allocate_extended(requested_min_rollable_extranonce_size.into())
                         {
@@ -789,7 +797,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                                     _ => "internal-error",
                                 };
                                     if err_code == "internal-error" {
-                                        warn!("Failed to update extended channel {channel_id}");
+                                        warn!("Failed to update standard channel {channel_id}");
                                     } else {
                                         return vec![(downstream_id, build_error(err_code)).into()];
                                     }
@@ -815,7 +823,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                                 let new_target = extended_channel.get_target();
 
                                 if let Err(e) = update_channel {
-                                    error!(channel_id, ?e, "StandardChannel update failed");
+                                    error!(channel_id, ?e, "ExtendedChannel update failed");
                                     let err_code = match e {
                                     ExtendedChannelError::UpdateChannelInvalidNominalHashrate(
                                         code,

--- a/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
@@ -287,6 +287,24 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 else {
                     return Err(PoolError::disconnect(PoolErrorKind::DownstreamIdNotFound, downstream_id));
                 };
+
+                if downstream.requires_standard_jobs.load(Ordering::SeqCst) {
+                    let open_extended_mining_channel_error = OpenMiningChannelError {
+                        request_id,
+                        error_code: ERROR_CODE_OPEN_MINING_CHANNEL_EXTENDED_CHANNELS_NOT_SUPPORTED_FOR_STANDARD_JOBS
+                            .to_string()
+                            .try_into()
+                            .expect("error code must be valid string"),
+                    };
+                    return Ok(vec![(
+                        downstream_id,
+                        Mining::OpenMiningChannelError(
+                            open_extended_mining_channel_error,
+                        ),
+                    )
+                        .into()]);
+                }
+
                 downstream
                     .downstream_data
                     .super_safe_lock(|downstream_data| {

--- a/pool-apps/pool/src/lib/channel_manager/template_distribution_message_handler.rs
+++ b/pool-apps/pool/src/lib/channel_manager/template_distribution_message_handler.rs
@@ -196,9 +196,9 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
 
                     // did SetupConnection have the REQUIRES_STANDARD_JOBS flag set?
                     // if no, and the group channel is not empty, we need to send the SetNewPrevHashMp to the group channel
-                    let requires_custom_work = downstream.requires_custom_work.load(Ordering::SeqCst);
+                    let requires_standard_jobs = downstream.requires_standard_jobs.load(Ordering::SeqCst);
                     let empty_group_channel = data.group_channel.get_channel_ids().is_empty();
-                    if !requires_custom_work && !empty_group_channel {
+                    if !requires_standard_jobs && !empty_group_channel {
                         let group_channel_id = data.group_channel.get_group_channel_id();
                         let activated_group_job_id = data.group_channel.get_active_job().expect("active job must exist").get_job_id();
                         let group_set_new_prev_hash_message = SetNewPrevHashMp {


### PR DESCRIPTION
This PR hardens the gatekeeping logic when `require_std_job` is set. In general, when downstream calls any function that is related to extended job/channel, we should reject.

I also fixed a few log typo along the way

Related issue: https://github.com/stratum-mining/sv2-apps/issues/227