### PR TITLE
 tproxy + jdc: per-upstream user_identity

### DIFF
--- a/docker/config/jdc-config.toml.template
+++ b/docker/config/jdc-config.toml.template
@@ -10,10 +10,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-
-# User identity/username for pool connection
-user_identity = "${JDC_USER_IDENTITY}"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = ${JDC_SHARES_PER_MINUTE}
 
@@ -61,6 +57,7 @@ pool_address = "${JDC_POOL_ADDRESS}"
 pool_port = "${JDC_POOL_PORT}"
 jds_address = "${JDC_UPSTREAM_JDS_ADDRESS}"
 jds_port = "${JDC_UPSTREAM_JDS_PORT}"
+user_identity = "${JDC_USER_IDENTITY}"
 
 # Bitcoin Core IPC config
 [template_provider_type.BitcoinCoreIpc]

--- a/docker/config/translator-proxy-config.toml.template
+++ b/docker/config/translator-proxy-config.toml.template
@@ -12,11 +12,8 @@ min_supported_version = 2
 # Min value: 2
 downstream_extranonce2_size = 4
 
-# User identity/username for pool connection
-# This will be appended with a counter for each mining client (e.g., username.miner1, username.miner2)
-user_identity = "${TPROXY_USER_IDENTITY}"
-
-# If true, tProxy verifies upstream coinbase outputs against the payout encoded by user_identity.
+# If true, tProxy verifies upstream coinbase outputs against the payout encoded by each upstream
+# `user_identity`.
 # Keep false for standard pool mining, including pools that use a Bitcoin address as the username.
 # Enable for solo/donation identities: sri/solo/<address>/<worker>,
 # sri/donate/<percentage>/<address>/<worker>, or legacy <address>[.worker].
@@ -57,3 +54,4 @@ job_keepalive_interval_secs = 60
 address = "${TPROXY_UPSTREAM_ADDRESS}"
 port = ${TPROXY_UPSTREAM_PORT}
 authority_pubkey = "${TPROXY_UPSTREAM_AUTHORITY_PUBKEY}"
+user_identity = "${TPROXY_USER_IDENTITY}"

--- a/integration-tests/lib/mod.rs
+++ b/integration-tests/lib/mod.rs
@@ -208,10 +208,31 @@ pub fn start_jdc(
     enable_monitoring: bool,
     jdc_mode: Option<ConfigJDCMode>,
 ) -> (JobDeclaratorClient, SocketAddr, Option<SocketAddr>) {
+    let pool_with_ids: Vec<_> = pool
+        .iter()
+        .map(|&(p, j)| (p, j, "IT_TEST".to_string()))
+        .collect();
+    start_jdc_with_user_identities(
+        &pool_with_ids,
+        template_provider_config,
+        supported_extensions,
+        required_extensions,
+        enable_monitoring,
+        jdc_mode,
+    )
+}
+
+pub fn start_jdc_with_user_identities(
+    pool: &[(SocketAddr, SocketAddr, String)], /* (pool_address, jds_address,
+                                                * per_upstream_user_identity) */
+    template_provider_config: TemplateProviderType,
+    supported_extensions: Vec<u16>,
+    required_extensions: Vec<u16>,
+    enable_monitoring: bool,
+    jdc_mode: Option<ConfigJDCMode>,
+) -> (JobDeclaratorClient, SocketAddr, Option<SocketAddr>) {
     use jd_client_sv2::config::{JobDeclaratorClientConfig, PoolConfig, ProtocolConfig, Upstream};
     let jdc_address = get_available_address();
-    let max_supported_version = 2;
-    let min_supported_version = 2;
     let authority_public_key = Secp256k1PublicKey::try_from(
         "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72".to_string(),
     )
@@ -228,26 +249,19 @@ pub fn start_jdc(
     .unwrap();
     let upstreams = pool
         .iter()
-        .map(|(pool_addr, jds_addr)| {
+        .map(|(pool_addr, jds_addr, per_upstream_id)| {
             Upstream::new(
                 authority_pubkey,
                 pool_addr.ip().to_string(),
                 pool_addr.port(),
                 jds_addr.ip().to_string(),
                 jds_addr.port(),
+                per_upstream_id.clone(),
             )
         })
         .collect();
     let pool_config = PoolConfig::new(authority_public_key, authority_secret_key);
-    let protocol_config = ProtocolConfig::new(
-        max_supported_version,
-        min_supported_version,
-        coinbase_reward_script,
-    );
-    let shares_per_minute = 10.0;
-    let shares_batch_size = 1;
-    let user_identity = "IT-test".to_string();
-    let jdc_signature = "JDC".to_string();
+    let protocol_config = ProtocolConfig::new(2, 2, coinbase_reward_script);
     let monitoring_address = if enable_monitoring {
         Some(get_available_address())
     } else {
@@ -257,14 +271,13 @@ pub fn start_jdc(
     let jd_client_proxy = JobDeclaratorClientConfig::new(
         jdc_address,
         protocol_config,
-        user_identity,
-        shares_per_minute,
-        shares_batch_size,
+        10.0,
+        1,
         pool_config,
         3600,
         template_provider_config,
         upstreams,
-        jdc_signature,
+        "JDC".to_string(),
         jdc_mode,
         supported_extensions,
         required_extensions,
@@ -349,17 +362,89 @@ pub async fn start_sv2_translator(
     job_keepalive_interval_secs: Option<u16>,
     enable_monitoring: bool,
 ) -> (TranslatorSv2, SocketAddr, Option<SocketAddr>) {
-    start_sv2_translator_with_user_identity(
-        upstreams,
+    let upstreams: Vec<(SocketAddr, String)> = upstreams
+        .iter()
+        .map(|&addr| (addr, "user_identity".to_string()))
+        .collect();
+    start_sv2_translator_with_user_identities(
+        &upstreams,
         aggregate_channels,
         supported_extensions,
         required_extensions,
         job_keepalive_interval_secs,
-        "user_identity".to_string(),
-        false,
         enable_monitoring,
     )
     .await
+}
+
+pub async fn start_sv2_translator_with_user_identities(
+    upstreams: &[(SocketAddr, String)],
+    aggregate_channels: bool,
+    supported_extensions: Vec<u16>,
+    required_extensions: Vec<u16>,
+    job_keepalive_interval_secs: Option<u16>,
+    enable_monitoring: bool,
+) -> (TranslatorSv2, SocketAddr, Option<SocketAddr>) {
+    let job_keepalive_interval_secs = job_keepalive_interval_secs.unwrap_or(60);
+    let upstream_authority_pubkey = Secp256k1PublicKey::try_from(
+        "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72".to_string(),
+    )
+    .expect("failed to parse test authority pubkey");
+
+    let upstreams = upstreams
+        .iter()
+        .map(|(addr, per_upstream_id)| {
+            translator_sv2::config::Upstream::new(
+                addr.ip().to_string(),
+                addr.port(),
+                upstream_authority_pubkey,
+                per_upstream_id.clone(),
+            )
+        })
+        .collect();
+
+    let listening_address = get_available_address();
+    let listening_port = listening_address.port();
+
+    let minerd_process = MinerdProcess::new(SocketAddr::from((Ipv4Addr::LOCALHOST, 0)), false)
+        .await
+        .unwrap();
+    let min_individual_miner_hashrate = minerd_process.measure_hashrate().await.unwrap() as f32;
+
+    let downstream_difficulty_config = translator_sv2::config::DownstreamDifficultyConfig::new(
+        min_individual_miner_hashrate,
+        SHARES_PER_MINUTE,
+        true,
+        job_keepalive_interval_secs,
+    );
+
+    let monitoring_address = if enable_monitoring {
+        Some(get_available_address())
+    } else {
+        None
+    };
+    let monitoring_cache_refresh_secs = if enable_monitoring { Some(1) } else { None };
+    let config = translator_sv2::config::TranslatorConfig::new(
+        upstreams,
+        listening_address.ip().to_string(),
+        listening_port,
+        downstream_difficulty_config,
+        2,
+        2,
+        4,
+        false,
+        aggregate_channels,
+        supported_extensions,
+        required_extensions,
+        monitoring_address,
+        monitoring_cache_refresh_secs,
+    );
+    let translator_v2 = translator_sv2::TranslatorSv2::new(config);
+    let clone_translator_v2 = translator_v2.clone();
+    tokio::spawn(async move {
+        clone_translator_v2.start().await;
+    });
+    (translator_v2, listening_address, monitoring_address)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -388,6 +473,7 @@ pub async fn start_sv2_translator_with_user_identity(
                 upstream_address,
                 upstream_port,
                 upstream_authority_pubkey,
+                user_identity.clone(),
             )
         })
         .collect();
@@ -423,7 +509,6 @@ pub async fn start_sv2_translator_with_user_identity(
         2,
         2,
         downstream_extranonce2_size,
-        user_identity,
         verify_payout,
         aggregate_channels,
         supported_extensions,

--- a/integration-tests/tests/jd_integration.rs
+++ b/integration-tests/tests/jd_integration.rs
@@ -2,6 +2,7 @@
 use integration_tests_sv2::{
     interceptor::{MessageDirection, ReplaceMessage},
     mock_roles::{MockDownstream, WithSetup},
+    start_jdc_with_user_identities,
     template_provider::DifficultyLevel,
     *,
 };
@@ -10,7 +11,7 @@ use stratum_apps::stratum_core::{
     common_messages_sv2::*,
     job_declaration_sv2::{ProvideMissingTransactionsSuccess, PushSolution, *},
     mining_sv2::*,
-    parsers_sv2::{self, AnyMessage, Mining},
+    parsers_sv2::{self, AnyMessage, JobDeclaration, Mining},
     template_distribution_sv2::*,
 };
 
@@ -1298,4 +1299,81 @@ async fn jdc_require_standard_jobs_set_rejects_open_extended_mining_channel() {
     );
 
     shutdown_all!(jdc, pool);
+}
+
+// Verifies that when the primary pool disconnects, JDC falls back to the next upstream entry
+// and sends *that* upstream's `user_identity` in `AllocateMiningJobToken` — not the primary's.
+#[tokio::test]
+async fn jdc_per_upstream_identity_switches_on_fallback() {
+    start_tracing();
+
+    let (tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
+    let (primary_pool, primary_pool_addr, primary_jds_addr, _) =
+        start_pool_with_jds(tp.bitcoin_core(), vec![], vec![], false).await;
+    let (_fallback_pool, fallback_pool_addr, fallback_jds_addr, _) =
+        start_pool_with_jds(tp.bitcoin_core(), vec![], vec![], false).await;
+
+    const PRIMARY_IDENTITY: &str = "bc1qprimary.worker";
+    const FALLBACK_IDENTITY: &str = "bc1qfallback.worker";
+
+    let (primary_jds_sniffer, primary_jds_sniffer_addr) =
+        start_sniffer("primary-jds", primary_jds_addr, false, vec![], None);
+    let (fallback_jds_sniffer, fallback_jds_sniffer_addr) =
+        start_sniffer("fallback-jds", fallback_jds_addr, false, vec![], None);
+
+    let (jdc, _jdc_addr, _) = start_jdc_with_user_identities(
+        &[
+            (
+                primary_pool_addr,
+                primary_jds_sniffer_addr,
+                PRIMARY_IDENTITY.to_string(),
+            ),
+            (
+                fallback_pool_addr,
+                fallback_jds_sniffer_addr,
+                FALLBACK_IDENTITY.to_string(),
+            ),
+        ],
+        sv2_tp_config(tp_addr),
+        vec![],
+        vec![],
+        false,
+        None,
+    );
+
+    primary_jds_sniffer
+        .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+        .await;
+    primary_jds_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_ALLOCATE_MINING_JOB_TOKEN,
+        )
+        .await;
+
+    primary_pool.shutdown().await;
+
+    fallback_jds_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_ALLOCATE_MINING_JOB_TOKEN,
+        )
+        .await;
+
+    let allocate_msg = loop {
+        match fallback_jds_sniffer.next_message_from_downstream() {
+            Some((_, AnyMessage::JobDeclaration(JobDeclaration::AllocateMiningJobToken(msg)))) => {
+                break msg
+            }
+            _ => continue,
+        }
+    };
+    let allocate_identity = std::str::from_utf8(allocate_msg.user_identifier.as_ref())
+        .expect("user_identifier is not valid UTF-8");
+    assert_eq!(
+        allocate_identity, FALLBACK_IDENTITY,
+        "expected fallback identity in AllocateMiningJobToken '{FALLBACK_IDENTITY}', got '{allocate_identity}'"
+    );
+
+    shutdown_all!(jdc);
 }

--- a/integration-tests/tests/jd_tproxy_integration.rs
+++ b/integration-tests/tests/jd_tproxy_integration.rs
@@ -1,5 +1,16 @@
-use integration_tests_sv2::{interceptor::MessageDirection, template_provider::DifficultyLevel, *};
-use stratum_apps::stratum_core::{common_messages_sv2::*, mining_sv2::*};
+use integration_tests_sv2::{
+    interceptor::MessageDirection,
+    mock_roles::{MockUpstream, WithSetup},
+    start_jdc_with_user_identities,
+    template_provider::DifficultyLevel,
+    utils::get_available_address,
+    *,
+};
+use stratum_apps::stratum_core::{
+    common_messages_sv2::*,
+    mining_sv2::*,
+    parsers_sv2::{AnyMessage, CommonMessages, Mining},
+};
 
 #[tokio::test]
 async fn jd_non_aggregated_tproxy_integration() {
@@ -180,4 +191,79 @@ async fn jd_aggregated_tproxy_integration() {
         )
         .await;
     shutdown_all!(translator, jdc, pool);
+}
+
+// Verifies that when a per-upstream `user_identity` is set on a JDC upstream entry,
+// that identity is sent as-is in `OpenExtendedMiningChannel`.
+#[tokio::test]
+async fn jdc_sends_per_upstream_identity() {
+    start_tracing();
+
+    let (tp, tp_addr) = start_template_provider(None, DifficultyLevel::Low);
+    let (_pool, _pool_addr, jds_addr, _) =
+        start_pool_with_jds(tp.bitcoin_core(), vec![], vec![], false).await;
+
+    let mock_pool_addr = get_available_address();
+    let mock_pool = MockUpstream::new(mock_pool_addr, WithSetup::no());
+    let pool_sender = mock_pool.start().await;
+
+    let (pool_sniffer, pool_sniffer_addr) =
+        start_sniffer("pool", mock_pool_addr, false, vec![], None);
+
+    const PER_UPSTREAM_IDENTITY: &str = "bc1qtest.worker";
+
+    let (jdc, jdc_addr, _) = start_jdc_with_user_identities(
+        &[(
+            pool_sniffer_addr,
+            jds_addr,
+            PER_UPSTREAM_IDENTITY.to_string(),
+        )],
+        sv2_tp_config(tp_addr),
+        vec![],
+        vec![],
+        false,
+        None,
+    );
+
+    pool_sniffer
+        .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+        .await;
+
+    // Respond with success so JDC proceeds to connect to JDS and open channels.
+    pool_sender
+        .send(AnyMessage::Common(CommonMessages::SetupConnectionSuccess(
+            SetupConnectionSuccess {
+                used_version: 2,
+                flags: 0,
+            },
+        )))
+        .await
+        .unwrap();
+
+    let (translator, tproxy_addr, _) =
+        start_sv2_translator(&[jdc_addr], false, vec![], vec![], None, false).await;
+    let (_minerd, _) = start_minerd(tproxy_addr, None, None, false).await;
+
+    pool_sniffer
+        .wait_for_message_type(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
+        )
+        .await;
+
+    let oemc = loop {
+        match pool_sniffer.next_message_from_downstream() {
+            Some((_, AnyMessage::Mining(Mining::OpenExtendedMiningChannel(msg)))) => break msg,
+            _ => continue,
+        }
+    };
+
+    let identity_str =
+        std::str::from_utf8(oemc.user_identity.as_ref()).expect("user_identity is not valid UTF-8");
+    assert_eq!(
+        identity_str, PER_UPSTREAM_IDENTITY,
+        "expected per-upstream identity '{PER_UPSTREAM_IDENTITY}', got '{identity_str}'"
+    );
+
+    shutdown_all!(translator, jdc);
 }

--- a/integration-tests/tests/monitoring_integration.rs
+++ b/integration-tests/tests/monitoring_integration.rs
@@ -102,7 +102,8 @@ async fn pool_monitoring_with_sv2_mining_device() {
     shutdown_all!(pool);
 }
 
-// Pool + tProxy + SV1 miner: Pool sees 1 SV2 client, tProxy sees 1 SV1 client and 1 upstream channel.
+// Pool + tProxy + SV1 miner: Pool sees 1 SV2 client, tProxy sees 1 SV1 client and 1 upstream
+// channel.
 #[tokio::test]
 async fn pool_and_tproxy_monitoring_with_sv1_miner() {
     start_tracing();
@@ -239,7 +240,7 @@ async fn jd_aggregated_topology_monitoring() {
                 &[
                     ("client_id", "1"),
                     ("channel_id", "2"),
-                    ("user_identity", "IT-test"),
+                    ("user_identity", "IT_TEST"),
                 ],
             ),
             1.0,

--- a/integration-tests/tests/translator_integration.rs
+++ b/integration-tests/tests/translator_integration.rs
@@ -2,6 +2,7 @@
 use integration_tests_sv2::{
     interceptor::{IgnoreMessage, MessageDirection, ReplaceMessage},
     mock_roles::{MockUpstream, WithSetup},
+    start_sv2_translator_with_user_identities,
     sv1_sniffer::SV1MessageFilter,
     template_provider::DifficultyLevel,
     utils::get_available_address,
@@ -2382,4 +2383,170 @@ async fn test_translator_fallback_during_abrupt_disconnection() {
         )
         .await;
     shutdown_all!(translator, pool_2);
+}
+
+#[tokio::test]
+async fn tproxy_sends_per_upstream_user_identity() {
+    start_tracing();
+
+    let mock_upstream_addr = get_available_address();
+    let mock_upstream = MockUpstream::new(mock_upstream_addr, WithSetup::no());
+    let send_to_tproxy = mock_upstream.start().await;
+
+    let (sniffer, sniffer_addr) = start_sniffer("", mock_upstream_addr, false, vec![], None);
+
+    const PER_UPSTREAM_IDENTITY: &str = "bc1qtest.worker";
+
+    let (translator, tproxy_addr, _) = start_sv2_translator_with_user_identities(
+        &[(sniffer_addr, PER_UPSTREAM_IDENTITY.to_string())],
+        false,
+        vec![],
+        vec![],
+        None,
+        false,
+    )
+    .await;
+
+    sniffer
+        .wait_for_message_type_and_clean_queue(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_SETUP_CONNECTION,
+        )
+        .await;
+
+    send_to_tproxy
+        .send(AnyMessage::Common(CommonMessages::SetupConnectionSuccess(
+            SetupConnectionSuccess {
+                used_version: 2,
+                flags: 0,
+            },
+        )))
+        .await
+        .unwrap();
+
+    let (_minerd, _) = start_minerd(tproxy_addr, None, None, false).await;
+
+    sniffer
+        .wait_for_message_type(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
+        )
+        .await;
+
+    let oemc = loop {
+        match sniffer.next_message_from_downstream() {
+            Some((_, AnyMessage::Mining(parsers_sv2::Mining::OpenExtendedMiningChannel(msg)))) => {
+                break msg
+            }
+            _ => continue,
+        }
+    };
+
+    let identity_str =
+        std::str::from_utf8(oemc.user_identity.as_ref()).expect("user_identity is not valid UTF-8");
+    let expected = format!("{}.miner1", PER_UPSTREAM_IDENTITY);
+    assert_eq!(
+        identity_str, expected,
+        "expected per-upstream identity '{expected}', got '{identity_str}'"
+    );
+
+    shutdown_all!(translator);
+}
+
+#[tokio::test]
+async fn tproxy_per_upstream_user_identity_switches_on_fallback() {
+    start_tracing();
+
+    // Both upstreams are mocks: assertions happen on the sniffers, no real pool needed.
+    let mock_primary_addr = get_available_address();
+    let send_to_tproxy = MockUpstream::new(mock_primary_addr, WithSetup::no())
+        .start()
+        .await;
+    let mock_fallback_addr = get_available_address();
+    let _mock_fallback = MockUpstream::new(
+        mock_fallback_addr,
+        WithSetup::yes_with_defaults(Protocol::MiningProtocol, 0),
+    )
+    .start()
+    .await;
+
+    const PRIMARY_IDENTITY: &str = "bc1qprimary.worker";
+    const FALLBACK_IDENTITY: &str = "bc1qfallback.worker";
+
+    let (sniffer_1, sniffer_addr_1) =
+        start_sniffer("primary", mock_primary_addr, false, vec![], None);
+    let (sniffer_2, sniffer_addr_2) =
+        start_sniffer("fallback", mock_fallback_addr, false, vec![], None);
+
+    let (translator, tproxy_addr, _) = start_sv2_translator_with_user_identities(
+        &[
+            (sniffer_addr_1, PRIMARY_IDENTITY.to_string()),
+            (sniffer_addr_2, FALLBACK_IDENTITY.to_string()),
+        ],
+        false,
+        vec![],
+        vec![],
+        None,
+        false,
+    )
+    .await;
+
+    let (_minerd, _) = start_minerd(tproxy_addr, None, None, false).await;
+
+    // The primary mock (WithSetup::no) sends back SetupConnectionError by hand once tproxy's
+    // SetupConnection arrives, forcing tproxy to fall over to mock_fallback.
+    sniffer_1
+        .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+        .await;
+    send_to_tproxy
+        .send(AnyMessage::Common(
+            parsers_sv2::CommonMessages::SetupConnectionError(SetupConnectionError {
+                flags: 0,
+                error_code: "test-identity-fallback".to_string().try_into().unwrap(),
+            }),
+        ))
+        .await
+        .unwrap();
+    sniffer_1
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SETUP_CONNECTION_ERROR,
+        )
+        .await;
+
+    // Fallback connects and opens a channel.
+    sniffer_2
+        .wait_for_message_type(MessageDirection::ToUpstream, MESSAGE_TYPE_SETUP_CONNECTION)
+        .await;
+    sniffer_2
+        .wait_for_message_type(
+            MessageDirection::ToDownstream,
+            MESSAGE_TYPE_SETUP_CONNECTION_SUCCESS,
+        )
+        .await;
+    sniffer_2
+        .wait_for_message_type(
+            MessageDirection::ToUpstream,
+            MESSAGE_TYPE_OPEN_EXTENDED_MINING_CHANNEL,
+        )
+        .await;
+
+    let oemc = loop {
+        match sniffer_2.next_message_from_downstream() {
+            Some((_, AnyMessage::Mining(parsers_sv2::Mining::OpenExtendedMiningChannel(msg)))) => {
+                break msg
+            }
+            _ => continue,
+        }
+    };
+
+    let identity_str =
+        std::str::from_utf8(oemc.user_identity.as_ref()).expect("user_identity is not valid UTF-8");
+    let expected = format!("{}.miner1", FALLBACK_IDENTITY);
+    assert_eq!(
+        identity_str, expected,
+        "expected fallback pool identity '{expected}', got '{identity_str}'"
+    );
+
+    shutdown_all!(translator);
 }

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -1528,6 +1528,7 @@ dependencies = [
  "serde",
  "stratum-apps",
  "tokio",
+ "toml",
  "tracing",
 ]
 
@@ -2882,6 +2883,7 @@ dependencies = [
  "stratum-apps",
  "tokio",
  "tokio-util",
+ "toml",
  "tracing",
 ]
 

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -667,7 +667,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.8.23",
  "yaml-rust2",
 ]
 
@@ -1528,7 +1528,7 @@ dependencies = [
  "serde",
  "stratum-apps",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
 ]
 
@@ -2322,6 +2322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,9 +2711,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -2718,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -2733,7 +2757,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -2746,16 +2770,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow 1.0.0",
 ]
@@ -2765,6 +2789,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -2883,7 +2913,7 @@ dependencies = [
  "stratum-apps",
  "tokio",
  "tokio-util",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
 ]
 

--- a/miner-apps/jd-client/Cargo.toml
+++ b/miner-apps/jd-client/Cargo.toml
@@ -27,6 +27,9 @@ bitcoin_core_sv2 = { version = "0.3.0", path = "../../bitcoin-core-sv2" }
 hex = "0.4.3"
 hotpath = "0.14.0"
 
+[dev-dependencies]
+toml = "0.8"
+
 [features]
 default = ["monitoring"]
 monitoring = ["stratum-apps/monitoring"]

--- a/miner-apps/jd-client/Cargo.toml
+++ b/miner-apps/jd-client/Cargo.toml
@@ -28,7 +28,7 @@ hex = "0.4.3"
 hotpath = "0.14.0"
 
 [dev-dependencies]
-toml = "0.8"
+toml = "1.1.2"
 
 [features]
 default = ["monitoring"]

--- a/miner-apps/jd-client/config-examples/mainnet/jdc-config-bitcoin-core-ipc-hosted-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/mainnet/jdc-config-bitcoin-core-ipc-hosted-infra-example.toml
@@ -10,10 +10,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-
-# User identity/username for pool connection
-user_identity = "your_username_here"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = 6.0
 
@@ -65,6 +61,7 @@ pool_address = "75.119.150.111"
 pool_port = 3333
 jds_address = "75.119.150.111"
 jds_port = 3334
+user_identity = "your_primary_username_here"
  
 # [[upstreams]]
 # authority_pubkey = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"
@@ -72,6 +69,7 @@ jds_port = 3334
 # pool_port = "34254"
 # jds_address = "127.0.0.1:34264"
 # jds_port = "34264"
+# user_identity = "your_backup_username_here"
 
 # Bitcoin Core IPC config
 # Supported networks: mainnet, testnet4, signet, regtest

--- a/miner-apps/jd-client/config-examples/mainnet/jdc-config-bitcoin-core-ipc-local-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/mainnet/jdc-config-bitcoin-core-ipc-local-infra-example.toml
@@ -10,10 +10,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-
-# User identity/username for pool connection
-user_identity = "your_username_here"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = 6.0
 
@@ -65,6 +61,7 @@ pool_address = "0.0.0.0"
 pool_port = 3333
 jds_address = "0.0.0.0"
 jds_port = 3334
+user_identity = "your_primary_username_here"
  
 # [[upstreams]]
 # authority_pubkey = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"
@@ -72,6 +69,7 @@ jds_port = 3334
 # pool_port = "34254"
 # jds_address = "127.0.0.1:34264"
 # jds_port = "34264"
+# user_identity = "your_backup_username_here"
 
 # Bitcoin Core IPC config
 # Supported networks: mainnet, testnet4, signet, regtest

--- a/miner-apps/jd-client/config-examples/mainnet/jdc-config-hosted-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/mainnet/jdc-config-hosted-infra-example.toml
@@ -10,10 +10,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-
-# User identity/username for pool connection
-user_identity = "your_username_here"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = 6.0
 
@@ -65,6 +61,7 @@ pool_address = "75.119.150.111"
 pool_port = 3333
 jds_address = "75.119.150.111"
 jds_port = 3334
+user_identity = "your_primary_username_here"
  
 # [[upstreams]]
 # authority_pubkey = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"
@@ -72,6 +69,7 @@ jds_port = 3334
 # pool_port = "34254"
 # jds_address = "127.0.0.1:34264"
 # jds_port = "34264"
+# user_identity = "your_backup_username_here"
 
 # Hosted Sv2 Template Provider config
 [template_provider_type.Sv2Tp]

--- a/miner-apps/jd-client/config-examples/mainnet/jdc-config-local-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/mainnet/jdc-config-local-infra-example.toml
@@ -10,10 +10,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-
-# User identity/username for pool connection
-user_identity = "your_username_here"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = 6.0
 
@@ -65,6 +61,7 @@ pool_address = "127.0.0.1"
 pool_port = 3333
 jds_address = "127.0.0.1"
 jds_port = 3334
+user_identity = "your_primary_username_here"
 
 [[upstreams]]
 authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
@@ -72,6 +69,7 @@ pool_address = "75.119.150.111"
 pool_port = 3333
 jds_address = "75.119.150.111"
 jds_port = 3334
+user_identity = "your_backup_username_here"
 
 # Local Sv2 Template Provider config
 [template_provider_type.Sv2Tp]

--- a/miner-apps/jd-client/config-examples/mainnet/jdc-config-solo-mining-example.toml
+++ b/miner-apps/jd-client/config-examples/mainnet/jdc-config-solo-mining-example.toml
@@ -15,9 +15,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-# User identity/username
-user_identity = "solo_miner"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = 6.0
 

--- a/miner-apps/jd-client/config-examples/signet/jdc-config-bitcoin-core-ipc-local-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/signet/jdc-config-bitcoin-core-ipc-local-infra-example.toml
@@ -10,10 +10,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-
-# User identity/username for pool connection
-user_identity = "your_username_here"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = 6.0
 
@@ -65,6 +61,7 @@ pool_address = "0.0.0.0"
 pool_port = 33333
 jds_address = "0.0.0.0"
 jds_port = 33334
+user_identity = "your_primary_username_here"
  
 # [[upstreams]]
 # authority_pubkey = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"
@@ -72,6 +69,7 @@ jds_port = 33334
 # pool_port = "34254"
 # jds_address = "127.0.0.1:34264"
 # jds_port = "34264"
+# user_identity = "your_backup_username_here"
 
 # Bitcoin Core IPC config
 # Supported networks: mainnet, testnet4, signet, regtest

--- a/miner-apps/jd-client/config-examples/signet/jdc-config-local-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/signet/jdc-config-local-infra-example.toml
@@ -10,10 +10,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-
-# User identity/username for pool connection
-user_identity = "your_username_here"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = 6.0
 
@@ -65,6 +61,7 @@ pool_address = "127.0.0.1"
 pool_port = 33333
 jds_address = "127.0.0.1"
 jds_port = 33334
+user_identity = "your_primary_username_here"
 
 [[upstreams]]
 authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
@@ -72,6 +69,7 @@ pool_address = "75.119.150.111"
 pool_port = 33333
 jds_address = "75.119.150.111"
 jds_port = 33334
+user_identity = "your_backup_username_here"
 
 # Local Sv2 Template Provider config
 [template_provider_type.Sv2Tp]

--- a/miner-apps/jd-client/config-examples/testnet4/jdc-config-bitcoin-core-ipc-hosted-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/testnet4/jdc-config-bitcoin-core-ipc-hosted-infra-example.toml
@@ -10,10 +10,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-
-# User identity/username for pool connection
-user_identity = "your_username_here"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = 6.0
 
@@ -65,6 +61,7 @@ pool_address = "75.119.150.111"
 pool_port = 43333
 jds_address = "75.119.150.111"
 jds_port = 43334
+user_identity = "your_primary_username_here"
  
 # [[upstreams]]
 # authority_pubkey = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"
@@ -72,6 +69,7 @@ jds_port = 43334
 # pool_port = "34254"
 # jds_address = "127.0.0.1:34264"
 # jds_port = "34264"
+# user_identity = "your_backup_username_here"
 
 # Bitcoin Core IPC config
 # Supported networks: mainnet, testnet4, signet, regtest

--- a/miner-apps/jd-client/config-examples/testnet4/jdc-config-bitcoin-core-ipc-local-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/testnet4/jdc-config-bitcoin-core-ipc-local-infra-example.toml
@@ -10,10 +10,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-
-# User identity/username for pool connection
-user_identity = "your_username_here"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = 6.0
 
@@ -65,6 +61,7 @@ pool_address = "0.0.0.0"
 pool_port = 43333
 jds_address = "0.0.0.0"
 jds_port = 43334
+user_identity = "your_primary_username_here"
  
 # [[upstreams]]
 # authority_pubkey = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"
@@ -72,6 +69,7 @@ jds_port = 43334
 # pool_port = "34254"
 # jds_address = "127.0.0.1:34264"
 # jds_port = "34264"
+# user_identity = "your_backup_username_here"
 
 # Bitcoin Core IPC config
 # Supported networks: mainnet, testnet4, signet, regtest

--- a/miner-apps/jd-client/config-examples/testnet4/jdc-config-hosted-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/testnet4/jdc-config-hosted-infra-example.toml
@@ -10,10 +10,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-
-# User identity/username for pool connection
-user_identity = "your_username_here"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = 6.0
 
@@ -65,6 +61,7 @@ pool_address = "75.119.150.111"
 pool_port = 43333
 jds_address = "75.119.150.111"
 jds_port = 43334
+user_identity = "your_primary_username_here"
  
 # [[upstreams]]
 # authority_pubkey = "2di19GHYQnAZJmEpoUeP7C3Eg9TCcksHr23rZCC83dvUiZgiDL"
@@ -72,6 +69,7 @@ jds_port = 43334
 # pool_port = "34254"
 # jds_address = "127.0.0.1:34264"
 # jds_port = "34264"
+# user_identity = "your_backup_username_here"
 
 # Hosted Sv2 Template Provider config
 [template_provider_type.Sv2Tp]

--- a/miner-apps/jd-client/config-examples/testnet4/jdc-config-local-infra-example.toml
+++ b/miner-apps/jd-client/config-examples/testnet4/jdc-config-local-infra-example.toml
@@ -10,10 +10,6 @@ authority_public_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 authority_secret_key = "mkDLTBBRxdBv998612qipDYoTK3YUrqLe8uWw7gu3iXbSrn2n"
 cert_validity_sec = 3600
 
-
-# User identity/username for pool connection
-user_identity = "your_username_here"
-
 # How many shares we expect to receive in a minute (determines difficulty targets)
 shares_per_minute = 6.0
 
@@ -65,6 +61,7 @@ pool_address = "127.0.0.1"
 pool_port = 43333
 jds_address = "127.0.0.1"
 jds_port = 43334
+user_identity = "your_primary_username_here"
 
 # SRI Pool Backup Pool
 [[upstreams]]
@@ -73,6 +70,7 @@ pool_address = "75.119.150.111"
 pool_port = 43333
 jds_address = "75.119.150.111"
 jds_port = 43334
+user_identity = "your_backup_username_here"
 
 # Local Sv2 Template Provider config
 [template_provider_type.Sv2Tp]

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -3,7 +3,7 @@ use std::{
     net::SocketAddr,
     sync::{
         atomic::{AtomicU32, AtomicUsize, Ordering},
-        Arc,
+        Arc, OnceLock,
     },
 };
 
@@ -298,7 +298,7 @@ pub struct ChannelManager {
     miner_tag_string: String,
     share_batch_size: SharesBatchSize,
     shares_per_minute: SharesPerMinute,
-    user_identity: String,
+    user_identity: Arc<OnceLock<String>>,
     reserved_downstream_rollable_extranonce_size: u8,
     /// This represent the current state of Upstream channel
     /// 1. NoChannel: No active upstream connection.
@@ -435,7 +435,7 @@ impl ChannelManager {
             share_batch_size: config.share_batch_size(),
             shares_per_minute: config.shares_per_minute(),
             miner_tag_string: config.jdc_signature().to_string(),
-            user_identity: config.user_identity().to_string(),
+            user_identity: Arc::new(OnceLock::new()),
             reserved_downstream_rollable_extranonce_size: config
                 .reserved_downstream_rollable_extranonce_size(),
             upstream_state: AtomicUpstreamState::new(UpstreamState::SoloMining),
@@ -443,6 +443,16 @@ impl ChannelManager {
         };
 
         Ok(channel_manager)
+    }
+
+    pub fn set_user_identity(&self, identity: String) {
+        self.user_identity
+            .set(identity)
+            .expect("upstream identity already set");
+    }
+
+    fn user_identity(&self) -> &str {
+        self.user_identity.get().expect("identity should be set")
     }
 
     // Bootstraps a group channel with the given parameters.
@@ -963,11 +973,9 @@ impl ChannelManager {
                             .is_ok()
                         {
                             let mut upstream_message = downstream_channel_request;
-                            upstream_message.user_identity = self
-                                .user_identity
-                                .clone()
-                                .try_into()
-                                .map_err(JDCError::shutdown)?;
+                            let identity = self.user_identity().to_string();
+                            upstream_message.user_identity =
+                                identity.try_into().map_err(JDCError::shutdown)?;
                             upstream_message.request_id = 1;
                             // The upstream extended channel is opened once and its
                             // `extranonce_size` is fixed. Size its rollable region to fit:
@@ -1046,8 +1054,9 @@ impl ChannelManager {
                             // extended downstream that attaches to this upstream.
                             let upstream_min_extranonce_size = (JDC_LOCAL_PREFIX_BYTES as u16)
                                 + self.reserved_downstream_rollable_extranonce_size as u16;
+                            let identity = self.user_identity().to_string();
                             let upstream_open = OpenExtendedMiningChannel {
-                                user_identity: self.user_identity.clone().try_into().unwrap(),
+                                user_identity: identity.try_into().unwrap(),
                                 request_id: 1,
                                 nominal_hash_rate: downstream_channel_request.nominal_hash_rate,
                                 max_target: downstream_channel_request.max_target,
@@ -1137,10 +1146,9 @@ impl ChannelManager {
                 token_to_allocate
             );
 
+            let identifier = self.user_identity().to_string();
             let message = JobDeclaration::AllocateMiningJobToken(AllocateMiningJobToken {
-                user_identifier: self
-                    .user_identity
-                    .to_string()
+                user_identifier: identifier
                     .try_into()
                     .expect("Static string should always convert"),
                 request_id,

--- a/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
@@ -165,7 +165,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
                     .expect("prefix length already validated by allocator");
                 let mut extended_channel = ExtendedChannel::new(
                     msg.channel_id,
-                    self.user_identity.clone(),
+                    self.user_identity().to_string(),
                     extranonce_prefix,
                     Target::from_le_bytes(msg.target.inner_as_ref().try_into().unwrap()),
                     hashrate,

--- a/miner-apps/jd-client/src/lib/config.rs
+++ b/miner-apps/jd-client/src/lib/config.rs
@@ -39,8 +39,6 @@ pub struct JobDeclaratorClientConfig {
     /// The path to the log file where JDC will write logs.
     #[serde(default, deserialize_with = "opt_path_from_toml")]
     log_file: Option<PathBuf>,
-    /// User Identity
-    user_identity: String,
     /// Shares per minute
     shares_per_minute: SharesPerMinute,
     /// share batch size
@@ -81,7 +79,6 @@ impl JobDeclaratorClientConfig {
     pub fn new(
         listening_address: SocketAddr,
         protocol_config: ProtocolConfig,
-        user_identity: String,
         shares_per_minute: SharesPerMinute,
         shares_batch_size: SharesBatchSize,
         pool_config: PoolConfig,
@@ -108,7 +105,6 @@ impl JobDeclaratorClientConfig {
             coinbase_reward_script: protocol_config.coinbase_reward_script,
             jdc_signature,
             log_file: None,
-            user_identity,
             shares_per_minute,
             share_batch_size: shares_batch_size,
             mode: jdc_mode.unwrap_or_default(),
@@ -193,9 +189,6 @@ impl JobDeclaratorClientConfig {
         if let Some(log_file) = log_file {
             self.log_file = Some(log_file);
         }
-    }
-    pub fn user_identity(&self) -> &str {
-        &self.user_identity
     }
 
     pub fn shares_per_minute(&self) -> SharesPerMinute {
@@ -307,6 +300,7 @@ pub struct Upstream {
     // The network address of the JDS.
     pub jds_address: String,
     pub jds_port: u16,
+    pub user_identity: String,
 }
 
 impl Upstream {
@@ -317,6 +311,7 @@ impl Upstream {
         pool_port: u16,
         jds_address: String,
         jds_port: u16,
+        user_identity: String,
     ) -> Self {
         Self {
             authority_pubkey,
@@ -324,6 +319,60 @@ impl Upstream {
             pool_port,
             jds_address,
             jds_port,
+            user_identity,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_PUBKEY: &str = "9bDuixKmZqAJnrmP746n8zU1wyAQRrus7th9dxnkPg6RzQvCnan";
+
+    #[test]
+    fn test_upstream_user_identity_toml_present() {
+        let toml = format!(
+            r#"
+            authority_pubkey = "{TEST_PUBKEY}"
+            pool_address = "127.0.0.1"
+            pool_port = 3333
+            jds_address = "127.0.0.1"
+            jds_port = 3334
+            user_identity = "bc1qfallback.worker"
+            "#
+        );
+        let upstream: Upstream = toml::from_str(&toml).unwrap();
+        assert_eq!(upstream.user_identity, "bc1qfallback.worker");
+    }
+
+    #[test]
+    fn test_upstream_user_identity_toml_absent_is_rejected() {
+        let toml = format!(
+            r#"
+            authority_pubkey = "{TEST_PUBKEY}"
+            pool_address = "127.0.0.1"
+            pool_port = 3333
+            jds_address = "127.0.0.1"
+            jds_port = 3334
+            "#
+        );
+        assert!(toml::from_str::<Upstream>(&toml).is_err());
+    }
+
+    #[test]
+    fn test_upstream_user_identity_toml_empty_string() {
+        let toml = format!(
+            r#"
+            authority_pubkey = "{TEST_PUBKEY}"
+            pool_address = "127.0.0.1"
+            pool_port = 3333
+            jds_address = "127.0.0.1"
+            jds_port = 3334
+            user_identity = ""
+            "#
+        );
+        let upstream: Upstream = toml::from_str(&toml).unwrap();
+        assert_eq!(upstream.user_identity, "");
     }
 }

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -69,10 +69,7 @@ impl JobDeclaratorClient {
 
     /// Starts the Job Declarator Client (JDC) main loop.
     pub async fn start(&self) {
-        info!(
-            "Job declarator client starting... setting up subsystems, User Identity: {}",
-            self.config.user_identity()
-        );
+        info!("Job declarator client starting... setting up subsystems");
 
         let miner_coinbase_outputs = vec![self.config.get_txout()];
         let mut encoded_outputs = vec![];
@@ -298,6 +295,7 @@ impl JobDeclaratorClient {
                 jds_port: u.jds_port,
                 authority_pubkey: u.authority_pubkey,
                 tried_or_flagged: false,
+                user_identity: u.user_identity.clone(),
             })
             .collect();
 
@@ -342,7 +340,9 @@ impl JobDeclaratorClient {
                 )
                 .await
             {
-                Ok((upstream, job_declarator)) => {
+                Ok((upstream, job_declarator, user_identity)) => {
+                    initial_channel_manager.set_user_identity(user_identity);
+
                     upstream
                         .start(
                             self.config.min_supported_version(),
@@ -485,7 +485,9 @@ impl JobDeclaratorClient {
                         )
                         .await
                     {
-                        Ok((upstream, job_declarator)) => {
+                        Ok((upstream, job_declarator, user_identity)) => {
+                            channel_manager.set_user_identity(user_identity);
+
                             upstream
                                 .start(
                                     self.config.min_supported_version(),
@@ -679,7 +681,7 @@ impl JobDeclaratorClient {
         fallback_coordinator: FallbackCoordinator,
         mode: JDMode,
         task_manager: Arc<TaskManager>,
-    ) -> Result<(Upstream, JobDeclarator), JDCErrorKind> {
+    ) -> Result<(Upstream, JobDeclarator, String), JDCErrorKind> {
         const MAX_RETRIES: usize = 3;
         let upstream_len = upstreams.len();
         for (i, upstream_entry) in upstreams.iter_mut().enumerate() {
@@ -733,9 +735,9 @@ impl JobDeclaratorClient {
                 )
                 .await
                 {
-                    Ok(pair) => {
+                    Ok((upstream, jd)) => {
                         upstream_entry.tried_or_flagged = true;
-                        return Ok(pair);
+                        return Ok((upstream, jd, upstream_entry.user_identity.clone()));
                     }
                     Err(e) => {
                         tracing::error!("Upstream and JDS connection terminated");

--- a/miner-apps/jd-client/src/lib/utils.rs
+++ b/miner-apps/jd-client/src/lib/utils.rs
@@ -58,6 +58,7 @@ pub struct UpstreamEntry {
     pub jds_port: u16,
     pub authority_pubkey: Secp256k1PublicKey,
     pub tried_or_flagged: bool,
+    pub user_identity: String,
 }
 
 /// Constructs a `SetupConnection` message for the mining protocol.

--- a/miner-apps/translator/Cargo.toml
+++ b/miner-apps/translator/Cargo.toml
@@ -42,4 +42,4 @@ hotpath-alloc = ["hotpath", "hotpath/hotpath-alloc"]
 
 [dev-dependencies]
 sha2 = "0.10.6"
-toml = "0.8"
+toml = "1.1.2"

--- a/miner-apps/translator/Cargo.toml
+++ b/miner-apps/translator/Cargo.toml
@@ -42,3 +42,4 @@ hotpath-alloc = ["hotpath", "hotpath/hotpath-alloc"]
 
 [dev-dependencies]
 sha2 = "0.10.6"
+toml = "0.8"

--- a/miner-apps/translator/config-examples/mainnet/tproxy-config-hosted-pool-example.toml
+++ b/miner-apps/translator/config-examples/mainnet/tproxy-config-hosted-pool-example.toml
@@ -12,11 +12,8 @@ min_supported_version = 2
 # Min value: 2
 downstream_extranonce2_size = 4
 
-# User identity/username for pool connection
-# This will be appended with a counter for each mining client (e.g., username.miner1, username.miner2)
-user_identity = "your_username_here"
-
-# If true, tProxy verifies upstream coinbase outputs against the payout encoded by user_identity.
+# If true, tProxy verifies upstream coinbase outputs against the payout encoded by each upstream
+# `user_identity`.
 # Keep false for standard pool mining, including pools that use a Bitcoin address as the username.
 # Enable for solo/donation identities: sri/solo/<address>/<worker>,
 # sri/donate/<percentage>/<address>/<worker>, or legacy <address>[.worker].
@@ -59,9 +56,11 @@ job_keepalive_interval_secs = 60
 address = "75.119.150.111"
 port = 3333
 authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+user_identity = "your_primary_username_here"
 
 # Braiins Pool Backup Pool
 [[upstreams]]
-address = "107.170.42.64" 
+address = "107.170.42.64"
 port = 3333
 authority_pubkey = "9awtMD5KQgvRUh2yFbjVeT7b6hjipWcAsQHd6wEhgtDT9soosna"
+user_identity = "your_backup_username_here"

--- a/miner-apps/translator/config-examples/mainnet/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/mainnet/tproxy-config-local-jdc-example.toml
@@ -12,11 +12,8 @@ min_supported_version = 2
 # Min value: 2
 downstream_extranonce2_size = 4
 
-# User identity/username for pool connection
-# This will be appended with a counter for each mining client (e.g., username.miner1, username.miner2)
-user_identity = "your_username_here"
-
-# If true, tProxy verifies upstream coinbase outputs against the payout encoded by user_identity.
+# If true, tProxy verifies upstream coinbase outputs against the payout encoded by each upstream
+# `user_identity`.
 # Keep false for standard pool mining, including pools that use a Bitcoin address as the username.
 # Enable for solo/donation identities: sri/solo/<address>/<worker>,
 # sri/donate/<percentage>/<address>/<worker>, or legacy <address>[.worker].
@@ -58,3 +55,4 @@ job_keepalive_interval_secs = 60
 address = "127.0.0.1"
 port = 34265
 authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+user_identity = "your_username_here"

--- a/miner-apps/translator/config-examples/mainnet/tproxy-config-local-pool-example.toml
+++ b/miner-apps/translator/config-examples/mainnet/tproxy-config-local-pool-example.toml
@@ -12,11 +12,8 @@ min_supported_version = 2
 # Min value: 2
 downstream_extranonce2_size = 4
 
-# User identity/username for pool connection
-# This will be appended with a counter for each mining client (e.g., username.miner1, username.miner2)
-user_identity = "your_username_here"
-
-# If true, tProxy verifies upstream coinbase outputs against the payout encoded by user_identity.
+# If true, tProxy verifies upstream coinbase outputs against the payout encoded by each upstream
+# `user_identity`.
 # Keep false for standard pool mining, including pools that use a Bitcoin address as the username.
 # Enable for solo/donation identities: sri/solo/<address>/<worker>,
 # sri/donate/<percentage>/<address>/<worker>, or legacy <address>[.worker].
@@ -58,3 +55,4 @@ job_keepalive_interval_secs = 60
 address = "127.0.0.1"
 port = 3333
 authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+user_identity = "your_username_here"

--- a/miner-apps/translator/config-examples/signet/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/signet/tproxy-config-local-jdc-example.toml
@@ -12,11 +12,8 @@ min_supported_version = 2
 # Min value: 2
 downstream_extranonce2_size = 4
 
-# User identity/username for pool connection
-# This will be appended with a counter for each mining client (e.g., username.miner1, username.miner2)
-user_identity = "your_username_here"
-
-# If true, tProxy verifies upstream coinbase outputs against the payout encoded by user_identity.
+# If true, tProxy verifies upstream coinbase outputs against the payout encoded by each upstream
+# `user_identity`.
 # Keep false for standard pool mining, including pools that use a Bitcoin address as the username.
 # Enable for solo/donation identities: sri/solo/<address>/<worker>,
 # sri/donate/<percentage>/<address>/<worker>, or legacy <address>[.worker].
@@ -58,3 +55,4 @@ job_keepalive_interval_secs = 60
 address = "127.0.0.1"
 port = 34265
 authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+user_identity = "your_username_here"

--- a/miner-apps/translator/config-examples/signet/tproxy-config-local-pool-example.toml
+++ b/miner-apps/translator/config-examples/signet/tproxy-config-local-pool-example.toml
@@ -12,11 +12,8 @@ min_supported_version = 2
 # Min value: 2
 downstream_extranonce2_size = 4
 
-# User identity/username for pool connection
-# This will be appended with a counter for each mining client (e.g., username.miner1, username.miner2)
-user_identity = "your_username_here"
-
-# If true, tProxy verifies upstream coinbase outputs against the payout encoded by user_identity.
+# If true, tProxy verifies upstream coinbase outputs against the payout encoded by each upstream
+# `user_identity`.
 # Keep false for standard pool mining, including pools that use a Bitcoin address as the username.
 # Enable for solo/donation identities: sri/solo/<address>/<worker>,
 # sri/donate/<percentage>/<address>/<worker>, or legacy <address>[.worker].
@@ -58,3 +55,4 @@ job_keepalive_interval_secs = 60
 address = "127.0.0.1"
 port = 33333
 authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+user_identity = "your_username_here"

--- a/miner-apps/translator/config-examples/testnet4/tproxy-config-hosted-pool-example.toml
+++ b/miner-apps/translator/config-examples/testnet4/tproxy-config-hosted-pool-example.toml
@@ -12,11 +12,8 @@ min_supported_version = 2
 # Min value: 2
 downstream_extranonce2_size = 4
 
-# User identity/username for pool connection
-# This will be appended with a counter for each mining client (e.g., username.miner1, username.miner2)
-user_identity = "your_username_here"
-
-# If true, tProxy verifies upstream coinbase outputs against the payout encoded by user_identity.
+# If true, tProxy verifies upstream coinbase outputs against the payout encoded by each upstream
+# `user_identity`.
 # Keep false for standard pool mining, including pools that use a Bitcoin address as the username.
 # Enable for solo/donation identities: sri/solo/<address>/<worker>,
 # sri/donate/<percentage>/<address>/<worker>, or legacy <address>[.worker].
@@ -59,3 +56,4 @@ job_keepalive_interval_secs = 60
 address = "75.119.150.111"
 port = 43333
 authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+user_identity = "your_primary_username_here"

--- a/miner-apps/translator/config-examples/testnet4/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/testnet4/tproxy-config-local-jdc-example.toml
@@ -12,11 +12,8 @@ min_supported_version = 2
 # Min value: 2
 downstream_extranonce2_size = 4
 
-# User identity/username for pool connection
-# This will be appended with a counter for each mining client (e.g., username.miner1, username.miner2)
-user_identity = "your_username_here"
-
-# If true, tProxy verifies upstream coinbase outputs against the payout encoded by user_identity.
+# If true, tProxy verifies upstream coinbase outputs against the payout encoded by each upstream
+# `user_identity`.
 # Keep false for standard pool mining, including pools that use a Bitcoin address as the username.
 # Enable for solo/donation identities: sri/solo/<address>/<worker>,
 # sri/donate/<percentage>/<address>/<worker>, or legacy <address>[.worker].
@@ -58,3 +55,4 @@ job_keepalive_interval_secs = 60
 address = "127.0.0.1"
 port = 34265
 authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+user_identity = "your_username_here"

--- a/miner-apps/translator/config-examples/testnet4/tproxy-config-local-pool-example.toml
+++ b/miner-apps/translator/config-examples/testnet4/tproxy-config-local-pool-example.toml
@@ -12,11 +12,8 @@ min_supported_version = 2
 # Min value: 2
 downstream_extranonce2_size = 4
 
-# User identity/username for pool connection
-# This will be appended with a counter for each mining client (e.g., username.miner1, username.miner2)
-user_identity = "your_username_here"
-
-# If true, tProxy verifies upstream coinbase outputs against the payout encoded by user_identity.
+# If true, tProxy verifies upstream coinbase outputs against the payout encoded by each upstream
+# `user_identity`.
 # Keep false for standard pool mining, including pools that use a Bitcoin address as the username.
 # Enable for solo/donation identities: sri/solo/<address>/<worker>,
 # sri/donate/<percentage>/<address>/<worker>, or legacy <address>[.worker].
@@ -58,3 +55,4 @@ job_keepalive_interval_secs = 60
 address = "127.0.0.1"
 port = 43333
 authority_pubkey = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
+user_identity = "your_username_here"

--- a/miner-apps/translator/src/lib/config.rs
+++ b/miner-apps/translator/src/lib/config.rs
@@ -35,12 +35,8 @@ pub struct TranslatorConfig {
     pub min_supported_version: u16,
     /// The size of the extranonce2 field for downstream mining connections.
     pub downstream_extranonce2_size: u16,
-    /// The user identity/username to use when connecting to the pool.
-    /// This will be appended with a counter for each mining channel (e.g., username.miner1,
-    /// username.miner2).
-    pub user_identity: String,
-    /// Whether to verify upstream coinbase outputs against a payout address encoded in
-    /// `user_identity`.
+    /// Whether to verify upstream coinbase outputs against a payout address encoded in each
+    /// upstream `user_identity`.
     #[serde(default)]
     pub verify_payout: bool,
     /// Configuration settings for managing difficulty on the downstream connection.
@@ -74,15 +70,25 @@ pub struct Upstream {
     pub port: u16,
     /// The Secp256k1 public key used to authenticate the upstream authority.
     pub authority_pubkey: Secp256k1PublicKey,
+    /// The user identity/username to use when connecting to the pool.
+    /// This will be appended with a counter for each mining channel (e.g., username.miner1,
+    /// username.miner2).
+    pub user_identity: String,
 }
 
 impl Upstream {
     /// Creates a new `UpstreamConfig` instance.
-    pub fn new(address: String, port: u16, authority_pubkey: Secp256k1PublicKey) -> Self {
+    pub fn new(
+        address: String,
+        port: u16,
+        authority_pubkey: Secp256k1PublicKey,
+        user_identity: String,
+    ) -> Self {
         Self {
             address,
             port,
             authority_pubkey,
+            user_identity,
         }
     }
 }
@@ -99,7 +105,6 @@ impl TranslatorConfig {
         max_supported_version: u16,
         min_supported_version: u16,
         downstream_extranonce2_size: u16,
-        user_identity: String,
         verify_payout: bool,
         aggregate_channels: bool,
         supported_extensions: Vec<u16>,
@@ -114,7 +119,6 @@ impl TranslatorConfig {
             max_supported_version,
             min_supported_version,
             downstream_extranonce2_size,
-            user_identity,
             verify_payout,
             downstream_difficulty_config,
             aggregate_channels,
@@ -138,21 +142,22 @@ impl TranslatorConfig {
 
     pub(crate) fn expected_payout_distribution(
         &self,
+        user_identity: &str,
     ) -> Result<Option<PayoutMode>, PayoutModeError> {
         if !self.verify_payout {
             return Ok(None);
         }
 
-        match PayoutMode::try_from(self.user_identity.as_str()) {
+        match PayoutMode::try_from(user_identity) {
             Ok(payout_mode @ (PayoutMode::Solo { .. } | PayoutMode::Donate { .. })) => {
                 Ok(Some(payout_mode))
             }
             Ok(PayoutMode::FullDonation) => Err(PayoutModeError::MissingMinerPayout {
-                user_identity: self.user_identity.clone(),
+                user_identity: user_identity.to_string(),
                 mode: MissingMinerPayoutMode::FullDonation,
             }),
             Err(PayoutModeError::NoPayoutMode(_)) => Err(PayoutModeError::MissingMinerPayout {
-                user_identity: self.user_identity.clone(),
+                user_identity: user_identity.to_string(),
                 mode: MissingMinerPayoutMode::NoPayoutMode,
             }),
             Err(e) => Err(e),
@@ -213,7 +218,7 @@ mod tests {
         // Use a valid base58-encoded public key from the key-utils test cases
         let pubkey_str = "9bDuixKmZqAJnrmP746n8zU1wyAQRrus7th9dxnkPg6RzQvCnan";
         let pubkey = Secp256k1PublicKey::from_str(pubkey_str).unwrap();
-        Upstream::new("127.0.0.1".to_string(), 4444, pubkey)
+        Upstream::new("127.0.0.1".to_string(), 4444, pubkey, "IT_TEST".to_string())
     }
 
     fn create_test_difficulty_config() -> DownstreamDifficultyConfig {
@@ -248,7 +253,6 @@ mod tests {
             2,
             1,
             4,
-            "test_user".to_string(),
             false,
             true,
             vec![],
@@ -263,7 +267,6 @@ mod tests {
         assert_eq!(config.max_supported_version, 2);
         assert_eq!(config.min_supported_version, 1);
         assert_eq!(config.downstream_extranonce2_size, 4);
-        assert_eq!(config.user_identity, "test_user");
         assert!(!config.verify_payout);
         assert!(config.aggregate_channels);
         assert!(config.supported_extensions.is_empty());
@@ -285,7 +288,6 @@ mod tests {
             2,
             1,
             4,
-            payout_address.to_string(),
             false,
             true,
             vec![],
@@ -295,7 +297,7 @@ mod tests {
         );
 
         assert!(disabled_config
-            .expected_payout_distribution()
+            .expected_payout_distribution(payout_address)
             .unwrap()
             .is_none());
 
@@ -307,7 +309,6 @@ mod tests {
             2,
             1,
             4,
-            payout_address.to_string(),
             true,
             true,
             vec![],
@@ -317,7 +318,9 @@ mod tests {
         );
 
         assert!(matches!(
-            enabled_config.expected_payout_distribution().unwrap(),
+            enabled_config
+                .expected_payout_distribution(payout_address)
+                .unwrap(),
             Some(PayoutMode::Solo { .. })
         ));
     }
@@ -332,7 +335,6 @@ mod tests {
             2,
             1,
             4,
-            "sri/donate/worker".to_string(),
             true,
             true,
             vec![],
@@ -342,18 +344,19 @@ mod tests {
         );
 
         assert!(matches!(
-            config.expected_payout_distribution().unwrap_err(),
+            config
+                .expected_payout_distribution("sri/donate/worker")
+                .unwrap_err(),
             PayoutModeError::MissingMinerPayout {
                 mode: MissingMinerPayoutMode::FullDonation,
                 ..
             }
         ));
 
-        let mut config = config;
-        config.user_identity = "invalid_address.worker".to_string();
-
         assert!(matches!(
-            config.expected_payout_distribution().unwrap_err(),
+            config
+                .expected_payout_distribution("invalid_address.worker")
+                .unwrap_err(),
             PayoutModeError::MissingMinerPayout {
                 mode: MissingMinerPayoutMode::NoPayoutMode,
                 ..
@@ -371,7 +374,6 @@ mod tests {
             2,
             1,
             4,
-            "bc1q_typo.worker".to_string(),
             true,
             true,
             vec![],
@@ -381,7 +383,9 @@ mod tests {
         );
 
         assert!(matches!(
-            config.expected_payout_distribution().unwrap_err(),
+            config
+                .expected_payout_distribution("bc1q_typo.worker")
+                .unwrap_err(),
             PayoutModeError::MissingMinerPayout {
                 mode: MissingMinerPayoutMode::NoPayoutMode,
                 ..
@@ -402,7 +406,6 @@ mod tests {
             2,
             1,
             4,
-            "test_user".to_string(),
             false,
             false,
             vec![],
@@ -439,7 +442,6 @@ mod tests {
             2,
             1,
             4,
-            "test_user".to_string(),
             false,
             true,
             vec![],
@@ -469,7 +471,6 @@ mod tests {
             2,
             1,
             4,
-            "test_user".to_string(),
             false,
             false,
             vec![],
@@ -480,5 +481,76 @@ mod tests {
 
         assert!(!config.downstream_difficulty_config.enable_vardiff);
         assert!(!config.aggregate_channels);
+    }
+
+    #[test]
+    fn test_upstream_user_identity_toml_present() {
+        let toml = r#"
+            address = "127.0.0.1"
+            port = 4444
+            authority_pubkey = "9bDuixKmZqAJnrmP746n8zU1wyAQRrus7th9dxnkPg6RzQvCnan"
+            user_identity = "sri/solo/bc1qtest"
+        "#;
+        let upstream: Upstream = toml::from_str(toml).unwrap();
+        assert_eq!(upstream.user_identity, "sri/solo/bc1qtest");
+    }
+
+    #[test]
+    fn test_upstream_user_identity_toml_absent_is_rejected() {
+        let toml = r#"
+            address = "127.0.0.1"
+            port = 4444
+            authority_pubkey = "9bDuixKmZqAJnrmP746n8zU1wyAQRrus7th9dxnkPg6RzQvCnan"
+        "#;
+        assert!(toml::from_str::<Upstream>(toml).is_err());
+    }
+
+    #[test]
+    fn test_upstream_user_identity_toml_empty_string() {
+        let toml = r#"
+            address = "127.0.0.1"
+            port = 4444
+            authority_pubkey = "9bDuixKmZqAJnrmP746n8zU1wyAQRrus7th9dxnkPg6RzQvCnan"
+            user_identity = ""
+        "#;
+        let upstream: Upstream = toml::from_str(toml).unwrap();
+        assert_eq!(upstream.user_identity, "");
+    }
+
+    #[test]
+    fn test_multi_upstream_identity_toml() {
+        let pubkey = "9bDuixKmZqAJnrmP746n8zU1wyAQRrus7th9dxnkPg6RzQvCnan";
+        let toml = format!(
+            r#"
+            downstream_address = "0.0.0.0"
+            downstream_port = 34255
+            max_supported_version = 2
+            min_supported_version = 2
+            downstream_extranonce2_size = 8
+            aggregate_channels = false
+
+            [downstream_difficulty_config]
+            min_individual_miner_hashrate = 10000000.0
+            shares_per_minute = 6.0
+            enable_vardiff = false
+            job_keepalive_interval_secs = 60
+
+            [[upstreams]]
+            address = "127.0.0.1"
+            port = 3333
+            authority_pubkey = "{pubkey}"
+            user_identity = "sri/solo/bc1qprimary"
+
+            [[upstreams]]
+            address = "192.168.1.1"
+            port = 3333
+            authority_pubkey = "{pubkey}"
+            user_identity = "bc1qbackup.worker"
+            "#
+        );
+        let config: TranslatorConfig = toml::from_str(&toml).unwrap();
+        assert_eq!(config.upstreams.len(), 2);
+        assert_eq!(config.upstreams[0].user_identity, "sri/solo/bc1qprimary");
+        assert_eq!(config.upstreams[1].user_identity, "bc1qbackup.worker");
     }
 }

--- a/miner-apps/translator/src/lib/error.rs
+++ b/miner-apps/translator/src/lib/error.rs
@@ -170,6 +170,8 @@ pub enum TproxyErrorKind {
     SetDifficultyToMessage(SetDifficulty),
     /// Received an unexpected message type
     UnexpectedMessage(ExtensionType, MessageType),
+    /// Invalid user identity
+    InvalidUserIdentity(String),
     /// Job not found during share validation
     JobNotFound,
     /// Invalid merkle root during share validation
@@ -241,6 +243,9 @@ impl fmt::Display for TproxyErrorKind {
                     f,
                     "Received a message type that was not expected: {extension_type}, {message_type}"
                 )
+            }
+            InvalidUserIdentity(user_identity) => {
+                write!(f, "Invalid user identity: {user_identity}")
             }
             JobNotFound => write!(f, "Job not found during share validation"),
             InvalidMerkleRoot => write!(f, "Invalid merkle root during share validation"),

--- a/miner-apps/translator/src/lib/mod.rs
+++ b/miner-apps/translator/src/lib/mod.rs
@@ -22,6 +22,7 @@ use std::{
 };
 use stratum_apps::{
     fallback_coordinator::FallbackCoordinator,
+    payout::PayoutMode,
     task_manager::TaskManager,
     utils::types::{Sv2Frame, GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS},
 };
@@ -75,6 +76,24 @@ impl TranslatorSv2 {
         }
     }
 
+    fn payout_mode(&self, user_identity: &str) -> Result<Option<PayoutMode>, TproxyErrorKind> {
+        let expected_payout_distribution = self
+            .config
+            .expected_payout_distribution(user_identity)
+            .map_err(|e| {
+                TproxyErrorKind::InvalidUserIdentity(format!(
+                    "invalid payout user_identity `{user_identity}`: {e}"
+                ))
+            })?;
+        if let Some(distribution) = &expected_payout_distribution {
+            info!(
+                "Payout verification enabled for configured user_identity: {}",
+                distribution
+            );
+        }
+        Ok(expected_payout_distribution)
+    }
+
     /// Starts the translator.
     ///
     /// This method starts the main event loop, which handles connections,
@@ -85,21 +104,6 @@ impl TranslatorSv2 {
         let cancellation_token = self.cancellation_token.clone();
         let mut fallback_coordinator = FallbackCoordinator::new();
         let tproxy_mode = TproxyMode::from(self.config.aggregate_channels);
-        let expected_payout_distribution = match self.config.expected_payout_distribution() {
-            Ok(distribution) => distribution,
-            Err(e) => {
-                error!("Invalid payout user_identity configuration: {e}");
-                self.shutdown_notify.notify_waiters();
-                self.is_alive.store(false, Ordering::Relaxed);
-                return;
-            }
-        };
-        if let Some(distribution) = &expected_payout_distribution {
-            info!(
-                "Payout verification enabled for configured user_identity: {}",
-                distribution
-            );
-        }
 
         let task_manager = Arc::new(TaskManager::new());
 
@@ -123,6 +127,7 @@ impl TranslatorSv2 {
                 port: u.port,
                 authority_pubkey: u.authority_pubkey,
                 tried_or_flagged: false,
+                user_identity: u.user_identity.clone(),
             })
             .collect::<Vec<_>>();
 
@@ -141,6 +146,18 @@ impl TranslatorSv2 {
 
         info!("Initializing upstream connection...");
 
+        let mut channel_manager: Arc<ChannelManager> = Arc::new(ChannelManager::new(
+            channel_manager_to_upstream_sender,
+            upstream_to_channel_manager_receiver,
+            channel_manager_to_sv1_server_sender.clone(),
+            sv1_server_to_channel_manager_receiver,
+            self.config.supported_extensions.clone(),
+            self.config.required_extensions.clone(),
+            tproxy_mode,
+            #[cfg(feature = "monitoring")]
+            self.config.downstream_difficulty_config.enable_vardiff,
+        ));
+
         if let Err(e) = self
             .initialize_upstream(
                 &mut upstream_addresses,
@@ -151,6 +168,7 @@ impl TranslatorSv2 {
                 task_manager.clone(),
                 sv1_server.clone(),
                 self.config.required_extensions.clone(),
+                channel_manager.clone(),
             )
             .await
         {
@@ -159,19 +177,6 @@ impl TranslatorSv2 {
             self.is_alive.store(false, Ordering::Relaxed);
             return;
         }
-
-        let mut channel_manager: Arc<ChannelManager> = Arc::new(ChannelManager::new(
-            channel_manager_to_upstream_sender,
-            upstream_to_channel_manager_receiver,
-            channel_manager_to_sv1_server_sender.clone(),
-            sv1_server_to_channel_manager_receiver,
-            self.config.supported_extensions.clone(),
-            self.config.required_extensions.clone(),
-            expected_payout_distribution.clone(),
-            tproxy_mode,
-            #[cfg(feature = "monitoring")]
-            self.config.downstream_difficulty_config.enable_vardiff,
-        ));
 
         info!("Launching ChannelManager tasks...");
         ChannelManager::run_channel_manager_tasks(
@@ -273,6 +278,18 @@ impl TranslatorSv2 {
                                     tproxy_mode
                                 ));
 
+                                channel_manager = Arc::new(ChannelManager::new(
+                                    channel_manager_to_upstream_sender,
+                                    upstream_to_channel_manager_receiver,
+                                    channel_manager_to_sv1_server_sender,
+                                    sv1_server_to_channel_manager_receiver,
+                                    self.config.supported_extensions.clone(),
+                                    self.config.required_extensions.clone(),
+                                    tproxy_mode,
+                                    #[cfg(feature = "monitoring")]
+                                    self.config.downstream_difficulty_config.enable_vardiff,
+                                ));
+
                                 if let Err(e) = self.initialize_upstream(
                                     &mut upstream_addresses,
                                     channel_manager_to_upstream_receiver,
@@ -282,24 +299,14 @@ impl TranslatorSv2 {
                                     task_manager.clone(),
                                     sv1_server.clone(),
                                     self.config.required_extensions.clone(),
-                                ).await {
+                                    channel_manager.clone(),
+                                )
+                                .await
+                                {
                                     error!("Couldn't perform fallback, shutting system down: {e:?}");
                                     cancellation_token.cancel();
                                     break;
                                 }
-
-                                channel_manager = Arc::new(ChannelManager::new(
-                                    channel_manager_to_upstream_sender,
-                                    upstream_to_channel_manager_receiver,
-                                    channel_manager_to_sv1_server_sender,
-                                    sv1_server_to_channel_manager_receiver,
-                                    self.config.supported_extensions.clone(),
-                                    self.config.required_extensions.clone(),
-                                    expected_payout_distribution.clone(),
-                                    tproxy_mode,
-                                    #[cfg(feature = "monitoring")]
-                                    self.config.downstream_difficulty_config.enable_vardiff
-                                ));
 
                                 info!("Launching ChannelManager tasks...");
                                 ChannelManager::run_channel_manager_tasks(
@@ -430,6 +437,7 @@ impl TranslatorSv2 {
         task_manager: Arc<TaskManager>,
         sv1_server_instance: Arc<Sv1Server>,
         required_extensions: Vec<u16>,
+        channel_manager_instance: Arc<ChannelManager>,
     ) -> Result<(), TproxyErrorKind> {
         const MAX_RETRIES: usize = 3;
         let upstream_len = upstreams.len();
@@ -466,6 +474,12 @@ impl TranslatorSv2 {
                 .await
                 {
                     Ok(()) => {
+                        let user_identity = upstream_entry.user_identity.to_string();
+                        let payout_mode = self.payout_mode(&user_identity)?;
+
+                        channel_manager_instance.set_expected_payout_distribution(payout_mode);
+                        sv1_server_instance.set_user_identity(user_identity);
+
                         // starting sv1 server instance
                         if let Err(e) = sv1_server_instance
                             .clone()

--- a/miner-apps/translator/src/lib/monitoring.rs
+++ b/miner-apps/translator/src/lib/monitoring.rs
@@ -125,7 +125,6 @@ mod tests {
             sv1_server_receiver,
             vec![],
             vec![],
-            None,
             TproxyMode::Aggregated,
             true,
         )

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -17,7 +17,7 @@ use std::{
     net::SocketAddr,
     sync::{
         atomic::{AtomicU32, AtomicUsize, Ordering},
-        Arc,
+        Arc, OnceLock,
     },
     time::{Duration, Instant},
 };
@@ -127,6 +127,7 @@ pub struct Sv1Server {
     /// case of channels aggregation (aggregated mode)
     pub(crate) valid_sv1_jobs: Arc<DashMap<ChannelId, Vec<server_to_client::Notify<'static>>>>,
     pub(crate) mode: TproxyMode,
+    user_identity: Arc<OnceLock<String>>,
 }
 
 #[cfg_attr(not(test), hotpath::measure_all)]
@@ -293,7 +294,20 @@ impl Sv1Server {
             pending_target_updates: Arc::new(Mutex::new(Vec::new())),
             valid_sv1_jobs: Arc::new(DashMap::new()),
             mode,
+            user_identity: Arc::new(OnceLock::new()),
         }
+    }
+
+    pub fn set_user_identity(&self, user_identity: String) {
+        self.user_identity
+            .set(user_identity)
+            .expect("user identity already set");
+    }
+
+    fn user_identity(&self) -> &String {
+        self.user_identity
+            .get()
+            .expect("user identity should exist")
     }
 
     /// Starts the SV1 server and begins accepting connections.
@@ -945,13 +959,14 @@ impl Sv1Server {
         };
 
         let miner_id = self.miner_counter.fetch_add(1, Ordering::SeqCst) + 1;
+        let user_identity = self.user_identity();
         // SRI patterns use `/`-delimited segments for payout mode parsing, so appending
         // a suffix would break pool-side validation.
         // See: https://github.com/stratum-mining/sv2-apps/issues/369
-        let user_identity = if self.config.user_identity.starts_with("sri/") {
-            self.config.user_identity.clone()
+        let user_identity = if user_identity.starts_with("sri/") {
+            user_identity.clone()
         } else {
-            format!("{}.miner{}", self.config.user_identity, miner_id)
+            format!("{}.miner{}", user_identity, miner_id)
         };
 
         downstream
@@ -1447,7 +1462,12 @@ mod tests {
         let pubkey_str = "9bDuixKmZqAJnrmP746n8zU1wyAQRrus7th9dxnkPg6RzQvCnan";
         let pubkey = Secp256k1PublicKey::from_str(pubkey_str).unwrap();
 
-        let upstream = Upstream::new("127.0.0.1".to_string(), 4444, pubkey);
+        let upstream = Upstream::new(
+            "127.0.0.1".to_string(),
+            4444,
+            pubkey,
+            "test_user".to_string(),
+        );
         let difficulty_config = DownstreamDifficultyConfig::new(100.0, 5.0, true, 60);
 
         TranslatorConfig::new(
@@ -1458,13 +1478,12 @@ mod tests {
             2,                     // max_supported_version
             1,                     // min_supported_version
             4,                     // downstream_extranonce2_size
-            "test_user".to_string(),
-            false,  // verify_payout
-            true,   // aggregate_channels
-            vec![], // supported_extensions
-            vec![], // required_extensions
-            None,   // monitoring_address
-            None,   // monitoring_cache_refresh_secs
+            false,                 // verify_payout
+            true,                  // aggregate_channels
+            vec![],                // supported_extensions
+            vec![],                // required_extensions
+            None,                  // monitoring_address
+            None,                  // monitoring_cache_refresh_secs
         )
     }
 
@@ -1484,7 +1503,6 @@ mod tests {
         assert_eq!(server.shares_per_minute, 5.0);
         assert_eq!(server.listener_addr.ip().to_string(), "127.0.0.1");
         assert_eq!(server.listener_addr.port(), 3333);
-        assert_eq!(server.config.user_identity, "test_user");
     }
 
     #[test]

--- a/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
@@ -547,7 +547,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
         info!("Received: {}", m);
-        if let Some(expected_payout_distribution) = &self.expected_payout_distribution {
+        if let Some(expected_payout_distribution) = self.expected_payout_distribution() {
             expected_payout_distribution
                 .validate_coinbase_tx_suffix(m.coinbase_tx_suffix.inner_as_ref())
                 .map_err(|e| {

--- a/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use async_channel::{Receiver, Sender};
 use dashmap::DashMap;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use stratum_apps::{
     channel_utils::ReceiverCleanup,
     custom_mutex::Mutex,
@@ -166,7 +166,7 @@ pub struct ChannelManager {
     /// being established, or connected.
     pub aggregated_channel_state: AtomicAggregatedState,
     /// Expected coinbase payout distribution derived from `user_identity`.
-    pub(crate) expected_payout_distribution: Option<PayoutMode>,
+    expected_payout_distribution: Arc<OnceLock<Option<PayoutMode>>>,
     /// Current mode Tproxy is operating in.
     pub(crate) mode: TproxyMode,
     /// Required to show or not show hashrate on monitoring.
@@ -187,6 +187,18 @@ impl ChannelManager {
             .super_safe_lock(|allocator| *allocator = None);
         self.aggregated_channel_state
             .set(AggregatedState::NoChannel);
+    }
+
+    fn expected_payout_distribution(&self) -> &Option<PayoutMode> {
+        self.expected_payout_distribution
+            .get()
+            .expect("payout mode should be set")
+    }
+
+    pub(crate) fn set_expected_payout_distribution(&self, payout_mode: Option<PayoutMode>) {
+        self.expected_payout_distribution
+            .set(payout_mode)
+            .expect("paymode should be set only once");
     }
 
     fn handle_error_action(
@@ -270,7 +282,6 @@ impl ChannelManager {
         sv1_server_receiver: Receiver<(Mining<'static>, Option<Vec<Tlv>>)>,
         supported_extensions: Vec<u16>,
         required_extensions: Vec<u16>,
-        expected_payout_distribution: Option<PayoutMode>,
         tproxy_mode: TproxyMode,
         #[cfg(feature = "monitoring")] report_hashrate: bool,
     ) -> Self {
@@ -292,7 +303,7 @@ impl ChannelManager {
             negotiated_extensions: Arc::new(Mutex::new(Vec::new())),
             aggregated_extranonce_allocator: Arc::new(Mutex::new(None)),
             aggregated_channel_state: AtomicAggregatedState::new(AggregatedState::NoChannel),
-            expected_payout_distribution,
+            expected_payout_distribution: Arc::new(OnceLock::new()),
             mode: tproxy_mode,
             #[cfg(feature = "monitoring")]
             report_hashrate,
@@ -1019,7 +1030,6 @@ mod tests {
             sv1_server_receiver,
             vec![],
             vec![],
-            None,
             TproxyMode::from(true),
             #[cfg(feature = "monitoring")]
             true,

--- a/miner-apps/translator/src/lib/utils.rs
+++ b/miner-apps/translator/src/lib/utils.rs
@@ -174,6 +174,7 @@ pub struct UpstreamEntry {
     pub port: u16,
     pub authority_pubkey: Secp256k1PublicKey,
     pub tried_or_flagged: bool,
+    pub user_identity: String,
 }
 
 /// Defines the operational mode for Translator Proxy.


### PR DESCRIPTION
This PR adds a `user_identity` field to each `[[upstreams]]` entry in the tproxy and jdc configs. When set, it is sent as-is in `OpenExtendedMiningChannel` and `AllocateMiningJobToken` instead of the global identity, allowing each upstream pool to receive the identity format it expects. Includes  ITF tests for both identity sending and fallback switching.

Closes #485