### PR TITLE
add `v0.1.2`+`v0.3.0` compatibility line on `bitcoin_core_sv2` `README.md`

### DIFF
--- a/bitcoin-core-sv2/README.md
+++ b/bitcoin-core-sv2/README.md
@@ -42,7 +42,9 @@ The `min_interval` parameter (in seconds) determines the minimum amount of time 
 |--------------------|--------------|
 | v0.1.0             | v30.2        |
 | v0.1.1             | v30.2        |
+| v0.1.2             | v30.2        |
 | v0.2.0             | v31.0        |
+| v0.3.0             | v31.0        |
 
 ## License
 


### PR DESCRIPTION
`bitcoin_core_sv2` is about to be released on `v0.3.0`

we also missed `v0.1.2`, which was published during global `sv2-apps` `v0.3.4`

https://github.com/stratum-mining/sv2-apps/issues/487#issuecomment-4434542921