### PR TITLE
Fix broken intra-doc links and clean up comments

### DIFF
--- a/bitcoin-core-sv2/src/common/job_declaration_protocol/io.rs
+++ b/bitcoin-core-sv2/src/common/job_declaration_protocol/io.rs
@@ -10,7 +10,7 @@ use tokio::sync::oneshot;
 ///
 /// This lets callers distinguish stale-tip races from other validation failures.
 ///
-/// Please check https://github.com/stratum-mining/sv2-apps/issues/364
+/// Please check <https://github.com/stratum-mining/sv2-apps/issues/364>
 /// for more details on the regression that motivated this field.
 #[derive(Debug, Clone, Copy)]
 pub struct ValidationContext {

--- a/bitcoin-core-sv2/src/unix_capnp/v30x/job_declaration_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/job_declaration_protocol/mod.rs
@@ -35,22 +35,22 @@ mod monitors;
 /// It is instantiated with:
 /// - A `&`[`std::path::Path`] to the Bitcoin Core UNIX socket
 /// - A [`async_channel::Receiver`] for incoming [`JdRequest`] messages (handles
-///   [`DeclareMiningJob`] and [`PushSolution`] requests)
+///   [`JdRequest::DeclareMiningJob`] and [`JdRequest::PushSolution`] requests)
 /// - A [`tokio_util::sync::CancellationToken`] to stop the internally spawned tasks
 ///
 /// The instance bootstraps its internal mempool state by fetching the current block template
 /// from Bitcoin Core before accepting requests. It then spawns a background monitor task that
 /// tracks mempool changes via `waitNext` requests.
 ///
-/// Incoming [`DeclareMiningJob`] requests are validated by:
+/// Incoming [`JdRequest::DeclareMiningJob`] requests are validated by:
 /// - Verifying all transactions exist in the mempool
 /// - Assembling a test block with the declared coinbase and transactions
 /// - Using Bitcoin Core's `checkBlock` to validate block structure
 ///
-/// If transactions are missing, a [`MissingTransactions`] response is sent. If validation
-/// succeeds, a [`Success`] response with current template parameters is sent.
+/// If transactions are missing, a [`crate::common::job_declaration_protocol::io::JdResponse::MissingTransactions`] response is sent. If validation
+/// succeeds, a [`crate::common::job_declaration_protocol::io::JdResponse::Success`] response with current template parameters is sent.
 ///
-/// Incoming [`PushSolution`] requests are used to submit mining solutions to Bitcoin Core.
+/// Incoming [`JdRequest::PushSolution`] requests are used to submit mining solutions to Bitcoin Core.
 #[derive(Clone)]
 pub struct BitcoinCoreSv2JDP {
     thread_ipc_client: ThreadIpcClient,

--- a/bitcoin-core-sv2/src/unix_capnp/v30x/job_declaration_protocol/monitors.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/job_declaration_protocol/monitors.rs
@@ -8,7 +8,7 @@ use tracing::{debug, error, warn};
 
 impl BitcoinCoreSv2JDP {
     /// Spawns a `spawn_local` task that issues `waitNext` requests to Bitcoin Core and
-    /// refreshes the [`MempoolMirror`](super::mempool::MempoolMirror) whenever the template
+    /// refreshes the `MempoolMirror` whenever the template
     /// changes. Returns the [`JoinHandle`] so the caller can await clean shutdown.
     pub fn monitor_and_update_mempool_mirror(&self) -> JoinHandle<()> {
         let self_clone = self.clone();

--- a/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/error.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/error.rs
@@ -8,7 +8,7 @@ use stratum_core::bitcoin::{
 
 use bitcoin_capnp_types_v30::capnp;
 
-/// Error type for [`crate::BitcoinCoreSv2TDP`]
+/// Error type for [`super::BitcoinCoreSv2TDP`]
 #[derive(Debug)]
 pub enum BitcoinCoreSv2TDPError {
     CapnpError(capnp::Error),

--- a/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/mod.rs
@@ -55,7 +55,7 @@ const MIN_BLOCK_RESERVED_WEIGHT: u64 = 2000;
 /// - A `u64` for the fee delta threshold in satoshis
 /// - A `u8` for the minimum interval in seconds between template updates
 /// - A [`async_channel::Receiver`] for incoming [`TemplateDistribution`] messages (handles
-///   [`CoinbaseOutputConstraints`], [`RequestTransactionData`], and [`SubmitSolution`])
+///   [`CoinbaseOutputConstraints`], [`stratum_core::template_distribution_sv2::RequestTransactionData`], and [`stratum_core::template_distribution_sv2::SubmitSolution`])
 /// - A [`async_channel::Sender`] for outgoing [`TemplateDistribution`] messages
 /// - A [`tokio_util::sync::CancellationToken`] to stop the internally spawned tasks
 ///
@@ -71,11 +71,11 @@ const MIN_BLOCK_RESERVED_WEIGHT: u64 = 2000;
 /// When there's a new Chain Tip, the [`BitcoinCoreSv2TDP`] instance will send a `NewTemplate`
 /// followed by a corresponding `SetNewPrevHash` message over the outgoing channel.
 ///
-/// Incoming [`RequestTransactionData`] messages are used to request transactions relative to a
+/// Incoming [`stratum_core::template_distribution_sv2::RequestTransactionData`] messages are used to request transactions relative to a
 /// specific template, for which a corresponding `RequestTransactionDataSuccess` or
 /// `RequestTransactionDataError` message is sent over the outgoing channel.
 ///
-/// Incoming [`SubmitSolution`] messages are used to submit solutions to a specific template.
+/// Incoming [`stratum_core::template_distribution_sv2::SubmitSolution`] messages are used to submit solutions to a specific template.
 #[derive(Clone)]
 pub struct BitcoinCoreSv2TDP {
     fee_threshold: u64,
@@ -188,9 +188,9 @@ impl BitcoinCoreSv2TDP {
     /// Runs the [`BitcoinCoreSv2TDP`] instance, monitoring for:
     /// - Chain Tip changes, for which it will send a `NewTemplate` message, followed by a
     ///   `SetNewPrevHash` message
-    /// - incoming [`RequestTransactionData`] messages, for which it will send a
+    /// - incoming [`stratum_core::template_distribution_sv2::RequestTransactionData`] messages, for which it will send a
     ///   `RequestTransactionDataSuccess` or `RequestTransactionDataError` message as a response
-    /// - incoming [`SubmitSolution`] messages, for which it will submit the solution to the Bitcoin
+    /// - incoming [`stratum_core::template_distribution_sv2::SubmitSolution`] messages, for which it will submit the solution to the Bitcoin
     ///   Core IPC client
     /// - incoming [`CoinbaseOutputConstraints`] messages, for which it will update the coinbase
     ///   output constraints

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/job_declaration_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/job_declaration_protocol/mod.rs
@@ -35,22 +35,22 @@ mod monitors;
 /// It is instantiated with:
 /// - A `&`[`std::path::Path`] to the Bitcoin Core UNIX socket
 /// - A [`async_channel::Receiver`] for incoming [`JdRequest`] messages (handles
-///   [`DeclareMiningJob`] and [`PushSolution`] requests)
+///   [`JdRequest::DeclareMiningJob`] and [`JdRequest::PushSolution`] requests)
 /// - A [`tokio_util::sync::CancellationToken`] to stop the internally spawned tasks
 ///
 /// The instance bootstraps its internal mempool state by fetching the current block template
 /// from Bitcoin Core before accepting requests. It then spawns a background monitor task that
 /// tracks mempool changes via `waitNext` requests.
 ///
-/// Incoming [`DeclareMiningJob`] requests are validated by:
+/// Incoming [`JdRequest::DeclareMiningJob`] requests are validated by:
 /// - Verifying all transactions exist in the mempool
 /// - Assembling a test block with the declared coinbase and transactions
 /// - Using Bitcoin Core's `checkBlock` to validate block structure
 ///
-/// If transactions are missing, a [`MissingTransactions`] response is sent. If validation
-/// succeeds, a [`Success`] response with current template parameters is sent.
+/// If transactions are missing, a [`crate::common::job_declaration_protocol::io::JdResponse::MissingTransactions`] response is sent. If validation
+/// succeeds, a [`crate::common::job_declaration_protocol::io::JdResponse::Success`] response with current template parameters is sent.
 ///
-/// Incoming [`PushSolution`] requests are used to submit mining solutions to Bitcoin Core.
+/// Incoming [`JdRequest::PushSolution`] requests are used to submit mining solutions to Bitcoin Core.
 #[derive(Clone)]
 pub struct BitcoinCoreSv2JDP {
     thread_map: ThreadMapIpcClient,

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/job_declaration_protocol/monitors.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/job_declaration_protocol/monitors.rs
@@ -8,7 +8,7 @@ use tracing::{debug, error, warn};
 
 impl BitcoinCoreSv2JDP {
     /// Spawns a `spawn_local` task that issues `waitNext` requests to Bitcoin Core and
-    /// refreshes the [`MempoolMirror`](super::mempool::MempoolMirror) whenever the template
+    /// refreshes the `MempoolMirror` whenever the template
     /// changes. Returns the [`JoinHandle`] so the caller can await clean shutdown.
     pub fn monitor_and_update_mempool_mirror(&self) -> JoinHandle<()> {
         let self_clone = self.clone();

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/error.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/error.rs
@@ -8,7 +8,7 @@ use stratum_core::bitcoin::{
 
 use bitcoin_capnp_types_v31::capnp;
 
-/// Error type for [`crate::BitcoinCoreSv2TDP`]
+/// Error type for [`super::BitcoinCoreSv2TDP`]
 #[derive(Debug)]
 pub enum BitcoinCoreSv2TDPError {
     CapnpError(capnp::Error),

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/mod.rs
@@ -62,7 +62,7 @@ const MIN_BLOCK_RESERVED_WEIGHT: u64 = 2000;
 /// - A `u64` for the fee delta threshold in satoshis
 /// - A `u8` for the minimum interval in seconds between template updates
 /// - A [`async_channel::Receiver`] for incoming [`TemplateDistribution`] messages (handles
-///   [`CoinbaseOutputConstraints`], [`RequestTransactionData`], and [`SubmitSolution`])
+///   [`CoinbaseOutputConstraints`], [`stratum_core::template_distribution_sv2::RequestTransactionData`], and [`stratum_core::template_distribution_sv2::SubmitSolution`])
 /// - A [`async_channel::Sender`] for outgoing [`TemplateDistribution`] messages
 /// - A [`tokio_util::sync::CancellationToken`] to stop the internally spawned tasks
 ///
@@ -78,11 +78,11 @@ const MIN_BLOCK_RESERVED_WEIGHT: u64 = 2000;
 /// When there's a new Chain Tip, the [`BitcoinCoreSv2TDP`] instance will send a `NewTemplate`
 /// followed by a corresponding `SetNewPrevHash` message over the outgoing channel.
 ///
-/// Incoming [`RequestTransactionData`] messages are used to request transactions relative to a
+/// Incoming [`stratum_core::template_distribution_sv2::RequestTransactionData`] messages are used to request transactions relative to a
 /// specific template, for which a corresponding `RequestTransactionDataSuccess` or
 /// `RequestTransactionDataError` message is sent over the outgoing channel.
 ///
-/// Incoming [`SubmitSolution`] messages are used to submit solutions to a specific template.
+/// Incoming [`stratum_core::template_distribution_sv2::SubmitSolution`] messages are used to submit solutions to a specific template.
 #[derive(Clone)]
 pub struct BitcoinCoreSv2TDP {
     fee_threshold: u64,
@@ -195,9 +195,9 @@ impl BitcoinCoreSv2TDP {
     /// Runs the [`BitcoinCoreSv2TDP`] instance, monitoring for:
     /// - Chain Tip changes, for which it will send a `NewTemplate` message, followed by a
     ///   `SetNewPrevHash` message
-    /// - incoming [`RequestTransactionData`] messages, for which it will send a
+    /// - incoming [`stratum_core::template_distribution_sv2::RequestTransactionData`] messages, for which it will send a
     ///   `RequestTransactionDataSuccess` or `RequestTransactionDataError` message as a response
-    /// - incoming [`SubmitSolution`] messages, for which it will submit the solution to the Bitcoin
+    /// - incoming [`stratum_core::template_distribution_sv2::SubmitSolution`] messages, for which it will submit the solution to the Bitcoin
     ///   Core IPC client
     /// - incoming [`CoinbaseOutputConstraints`] messages, for which it will update the coinbase
     ///   output constraints

--- a/integration-tests/lib/interceptor.rs
+++ b/integration-tests/lib/interceptor.rs
@@ -18,7 +18,7 @@ impl fmt::Display for MessageDirection {
     }
 }
 
-/// Represents an action that [`Sniffer`] can take on intercepted messages.
+/// Represents an action that [`crate::sniffer::Sniffer`] can take on intercepted messages.
 #[derive(Debug, Clone)]
 pub enum InterceptAction {
     /// Prevents a message from being forwarded and stored into the message aggregator.
@@ -82,7 +82,7 @@ impl From<IgnoreMessage> for InterceptAction {
     }
 }
 
-/// Allows [`Sniffer`] to replace some intercepted message before forwarding it.
+/// Allows [`crate::sniffer::Sniffer`] to replace some intercepted message before forwarding it.
 #[derive(Debug, Clone)]
 pub struct ReplaceMessage {
     direction: MessageDirection,

--- a/integration-tests/lib/prometheus_metrics_assertions.rs
+++ b/integration-tests/lib/prometheus_metrics_assertions.rs
@@ -33,7 +33,7 @@ const DEFAULT_RETRIES: usize = 5;
 /// Builder for [`MonitoringApi`]. Created via [`MonitoringApi::builder`].
 ///
 /// Unset knobs fall back to the module-level defaults
-/// ([`DEFAULT_RETRIES`], [`DEFAULT_REQUEST_TIMEOUT`]).
+/// (`DEFAULT_RETRIES`, `DEFAULT_REQUEST_TIMEOUT`).
 #[derive(Debug, Clone, Copy)]
 pub struct MonitoringApiBuilder {
     addr: SocketAddr,
@@ -74,7 +74,7 @@ impl MonitoringApiBuilder {
 
 impl MonitoringApi {
     /// Start a builder for a client at `addr`. Knobs default to
-    /// [`DEFAULT_RETRIES`] retries and [`DEFAULT_REQUEST_TIMEOUT`] per request;
+    /// `DEFAULT_RETRIES` retries and `DEFAULT_REQUEST_TIMEOUT` per request;
     /// see [`MonitoringApiBuilder`] for overrides.
     pub fn builder(addr: SocketAddr) -> MonitoringApiBuilder {
         MonitoringApiBuilder::new(addr)

--- a/miner-apps/jd-client/src/lib/error.rs
+++ b/miner-apps/jd-client/src/lib/error.rs
@@ -1,6 +1,6 @@
 //! ## Error Module
 //!
-//! Defines [`Error`], the central error enum used throughout the Job Declarator Client (JDC).
+//! Defines [`JDCError`], the central error struct used throughout the Job Declarator Client (JDC).
 //!
 //! It unifies errors from:
 //! - I/O operations

--- a/miner-apps/translator/src/lib/config.rs
+++ b/miner-apps/translator/src/lib/config.rs
@@ -6,8 +6,8 @@
 //! managing connections and settings for both upstream and downstream interfaces.
 //!
 //! This module handles:
-//! - Upstream server address, port, and authentication key ([`UpstreamConfig`])
-//! - Downstream interface address and port ([`DownstreamConfig`])
+//! - Upstream server address, port, and authentication key ([`Upstream`])
+//! - Downstream interface address and port ([`TranslatorConfig::downstream_address`], [`TranslatorConfig::downstream_port`])
 //! - Supported protocol versions
 //! - Downstream difficulty adjustment parameters ([`DownstreamDifficultyConfig`])
 use std::path::{Path, PathBuf};

--- a/miner-apps/translator/src/lib/sv1/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/mod.rs
@@ -7,9 +7,11 @@
 //! structures for submitting shares and updating targets, and constants
 //! and functions for managing client interactions.
 //!
-//! The module is organized into the following sub-modules:
-//! - [`diff_management`]: (Declared here, likely contains downstream difficulty logic)
-//! - [`downstream`]: Defines the core [`Downstream`] struct and its functionalities.
+//! The module is organized as follows:
+//! - The [`Downstream`] struct handles the state and communication for a single downstream SV1
+//!   miner.
+//! - The [`Sv1Server`] struct is the main server that listens for and manages all downstream miner
+//!   connections.
 
 mod downstream;
 #[cfg(feature = "monitoring")]

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -1,3 +1,20 @@
+//! ## SV1 Server Module
+//!
+//! This module implements the SV1 server component of the translator,
+//! responsible for managing connections with SV1 mining clients.
+//!
+//! It handles the full lifecycle of SV1 miner interactions, including:
+//! - Accepting new SV1 miner connections.
+//! - Managing difficulty adjustment for connected miners, including variable difficulty (Vardiff)
+//!   logic.
+//! - Coordinating with the SV2 channel manager for upstream communication, translating SV1 messages
+//!   to SV2 and vice-versa.
+//! - Tracking mining jobs, share submissions, and managing keepalive mechanisms.
+//!
+//! The core component is the [`Sv1Server`] struct, which orchestrates these operations,
+//! maintaining state for multiple downstream connections and ensuring seamless translation
+//! between SV1 and SV2 protocols.
+
 mod difficulty_manager;
 pub mod downstream_message_handler;
 

--- a/pool-apps/pool/src/lib/config.rs
+++ b/pool-apps/pool/src/lib/config.rs
@@ -5,7 +5,7 @@
 //!
 //! This module handles:
 //! - Initializing [`PoolConfig`]
-//! - Managing [`TemplateProviderConfig`], [`AuthorityConfig`], [`CoinbaseOutput`], and
+//! - Managing [`TemplateProviderType`], [`AuthorityConfig`], [`CoinbaseRewardScript`], and
 //!   [`ConnectionConfig`]
 //! - Validating and converting coinbase outputs
 use std::{

--- a/pool-apps/pool/src/lib/mod.rs
+++ b/pool-apps/pool/src/lib/mod.rs
@@ -40,7 +40,7 @@ impl PoolSv2 {
         }
     }
 
-    /// Starts the Pool server and blocks asynchronously on the [`PoolRuntime`].
+    /// Starts the Pool server and blocks asynchronously on the `PoolRuntime`.
     ///
     /// The startup and execution sequence follows:
     /// 1. **Initialize:** Sets up the pool runtime state machine.

--- a/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
@@ -85,7 +85,7 @@ impl Sv2Tp {
     /// - Performs Noise handshake
     /// - Spawns IO tasks for inbound/outbound frames
     ///
-    /// Retries up to 3 times before returning [`PoolError::Shutdown`].
+    /// Retries up to 3 times before returning [`PoolError::shutdown`].
     pub async fn new(
         tp_address: String,
         public_key: Option<Secp256k1PublicKey>,

--- a/stratum-apps/src/fallback_coordinator.rs
+++ b/stratum-apps/src/fallback_coordinator.rs
@@ -13,10 +13,10 @@ use tokio_util::sync::CancellationToken;
 ///
 /// in summary, every time we spawn a fallback-relevant task inside the manager, we MUST:
 /// - call [`FallbackCoordinator::register`] at task bootstrap
-/// - call [`FallbackCoordinator::done`] at task completion
+/// - call [`FallbackHandler::done`] at task completion
 ///
 /// when a fallback trigger arrives to the main status loop, we MUST call
-/// [`FallbackCoordinator::trigger_and_wait`] to wait for all registered components to complete
+/// [`FallbackCoordinator::trigger_fallback_and_wait`] to wait for all registered components to complete
 /// their cleanup before re-initializing them under the new upstream server.
 ///
 /// finally, a new [`FallbackCoordinator`] must be instantiated for the next fallback cycle.

--- a/stratum-apps/src/lib.rs
+++ b/stratum-apps/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! - [`network_helpers`] - High-level networking utilities for SV2 connections
 //! - [`config_helpers`] - Configuration management and parsing utilities
-//! - [`payout`] - Payout-mode parsing and coinbase-output construction/verification helpers
+//! - \[`payout`\] - Payout-mode parsing and coinbase-output construction/verification helpers
 
 /// Re-export all the modules from `stratum_core`
 #[cfg(feature = "core")]

--- a/stratum-apps/src/network_helpers/mod.rs
+++ b/stratum-apps/src/network_helpers/mod.rs
@@ -3,9 +3,9 @@
 //! This module provides connection management, encrypted streams, and protocol handling
 //! for Stratum V2 applications. It includes support for:
 //!
-//! - Noise-encrypted connections ([`noise_connection`], [`noise_stream`])
-//! - SV1 protocol connections ([`sv1_connection`]) - when `sv1` feature is enabled
-//! - Hostname resolution ([`resolve_hostname`])
+//! - Noise-encrypted connections ([`crate::network_helpers::noise_connection`], [`crate::network_helpers::noise_stream`])
+//! - SV1 protocol connections (`sv1_connection`) - when `sv1` feature is enabled
+//! - Hostname resolution ([`crate::network_helpers::resolve_hostname`])
 //!
 //! Originally from the `network_helpers_sv2` crate.
 
@@ -111,7 +111,7 @@ pub const TCP_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Connects to an upstream server as a Noise initiator, returning the split read/write halves.
 ///
-/// The handshake timeout is opinionated and fixed at [`NOISE_HANDSHAKE_TIMEOUT`]. If you need a
+/// The handshake timeout is opinionated and fixed at `NOISE_HANDSHAKE_TIMEOUT`. If you need a
 /// custom timeout, use [`noise_stream::NoiseTcpStream::new`] directly.
 ///
 /// Pass `Some(key)` to verify the server's authority public key, or `None` to skip
@@ -138,7 +138,7 @@ where
 
 /// Accepts a downstream connection as a Noise responder, returning the split read/write halves.
 ///
-/// The handshake timeout is opinionated and fixed at [`NOISE_HANDSHAKE_TIMEOUT`]. If you need a
+/// The handshake timeout is opinionated and fixed at `NOISE_HANDSHAKE_TIMEOUT`. If you need a
 /// custom timeout, use [`noise_stream::NoiseTcpStream::new`] directly.
 ///
 /// `cert_validity` controls how long the generated Noise certificate is valid,

--- a/stratum-apps/src/network_helpers/noise_stream.rs
+++ b/stratum-apps/src/network_helpers/noise_stream.rs
@@ -74,8 +74,8 @@ where
     ///
     /// On success, returns a stream with encrypted communication channels.
     ///
-    /// `timeout` applies to each individual handshake read. Prefer [`super::connect`] or
-    /// [`super::accept`]. For typical use. They apply a sensible default timeout automatically.
+    /// `timeout` applies to each individual handshake read. Prefer [`super::connect_with_noise`] or
+    /// [`super::accept_noise_connection`]. For typical use. They apply a sensible default timeout automatically.
     pub async fn new(
         stream: TcpStream,
         role: HandshakeRole,

--- a/stratum-apps/src/payout.rs
+++ b/stratum-apps/src/payout.rs
@@ -2,8 +2,8 @@
 //!
 //! This module is meant for applications that accept SRI-style mining identities and need a
 //! single source of truth for reward distribution. Pool-like applications can use
-//! [`PayoutMode::coinbase_outputs`] to build outputs, while proxy/client applications can use
-//! [`PayoutMode::validate_coinbase_outputs`] or [`PayoutMode::validate_coinbase_tx_suffix`] to
+//! [`crate::payout::PayoutMode::coinbase_outputs`] to build outputs, while proxy/client applications can use
+//! [`crate::payout::PayoutMode::validate_coinbase_outputs`] or [`crate::payout::PayoutMode::validate_coinbase_tx_suffix`] to
 //! verify upstream jobs.
 
 use std::fmt;


### PR DESCRIPTION
This PR fixes issue https://github.com/stratum-mining/sv2-apps/issues/525. It addresses all `cargo doc` warnings related to broken intra-document links and other documentation inconsistencies across the workspace.

Changes are limited to documentation and do not affect code logic.
