### PR TITLE
feat(nix): add reproducible OCI image build pipeline

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,4 @@
+# direnv: auto-activate the Nix dev shell when entering this directory.
+# Requires direnv (https://direnv.net) and nix-direnv.
+# Run `direnv allow` once after the flake is functional.
+use flake

--- a/.github/workflows/ci-nix.yml
+++ b/.github/workflows/ci-nix.yml
@@ -1,0 +1,153 @@
+# Nix-driven reproducible OCI image build pipeline.
+#
+# Runs alongside .github/workflows/docker-release.yaml — does NOT replace it.
+# Status: experimental / opt-in. Do not gate releases on this until reproducibility
+# is verified end-to-end (see docker/REPRODUCIBILITY.md).
+#
+# Pattern (modeled on Fedimint's ci-nix.yml):
+#   - Native runners per arch: ubuntu-latest (amd64) + ubuntu-24.04-arm (arm64).
+#     Avoids QEMU emulation entirely. ubuntu-24.04-arm has been free for public
+#     repos since 2025-08 GA.
+#   - Each (runner, app) cell builds a single-arch OCI image via `nix build`,
+#     then `docker load`s and pushes a per-arch tag.
+#   - A separate `manifest` job stitches per-arch tags into a multi-arch manifest
+#     using `docker manifest create`. No QEMU, no buildx.
+#
+# TODOs before this workflow is useful in CI:
+#   - Resolve flake.nix first-build TODOs (toolchain hash, git-dep hashes, flake.lock).
+#   - Decide whether to wire a binary cache (Cachix or self-hosted attic) — left as
+#     a commented-out step below. Without one, every CI run rebuilds Rust from scratch.
+
+name: Nix CI / Reproducible OCI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - ".github/workflows/ci-nix.yml"
+      - "rust-toolchain.toml"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "**/src/**"
+  release:
+    types: [published]
+  workflow_dispatch:
+
+# Only one run per ref at a time; cancel superseded ones on PRs.
+concurrency:
+  group: ci-nix-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
+
+jobs:
+  build-image:
+    name: Build ${{ matrix.app }} (${{ matrix.oci_arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { runner: ubuntu-latest,    oci_arch: amd64, nix_system: x86_64-linux }
+          - { runner: ubuntu-24.04-arm, oci_arch: arm64, nix_system: aarch64-linux }
+        app: [pool_sv2, jd_client_sv2, translator_sv2]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            # Larger build log buffer; sv2 builds are chatty.
+            max-jobs = auto
+
+      # Optional: binary cache. Uncomment + configure once you've decided on a host.
+      # - name: Configure Cachix
+      #   uses: cachix/cachix-action@v15
+      #   with:
+      #     name: stratumv2
+      #     authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Sanity-check flake
+        run: nix flake check --no-build
+
+      - name: Build OCI image
+        # `-L` streams build logs to stdout; useful when debugging in CI.
+        run: nix build .#container.${{ matrix.app }} -L
+
+      - name: Load image into local docker
+        run: |
+          docker load < ./result
+          docker images stratumv2/${{ matrix.app }}
+
+      - name: Record image digest
+        id: digest
+        run: |
+          digest=$(sha256sum ./result | cut -d' ' -f1)
+          echo "result_sha256=${digest}" >> "$GITHUB_OUTPUT"
+          echo "OCI tarball sha256: ${digest}"
+
+      - name: Upload image tarball as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: oci-${{ matrix.app }}-${{ matrix.oci_arch }}
+          path: ./result
+          retention-days: 7
+
+      - name: Tag and push per-arch image
+        if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}-${{ matrix.oci_arch }}"
+          docker tag stratumv2/${{ matrix.app }}:latest \
+            stratumv2/${{ matrix.app }}:"${tag}"
+          echo "${DOCKERHUB_TOKEN}" | docker login -u stratumv2 --password-stdin
+          docker push stratumv2/${{ matrix.app }}:"${tag}"
+
+  manifest:
+    name: Multi-arch manifest (${{ matrix.app }})
+    needs: build-image
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        app: [pool_sv2, jd_client_sv2, translator_sv2]
+    steps:
+      - name: Login to Docker Hub
+        env:
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: echo "${DOCKERHUB_TOKEN}" | docker login -u stratumv2 --password-stdin
+
+      - name: Create and push multi-arch manifest
+        run: |
+          set -euo pipefail
+          ref="${GITHUB_REF_NAME}"
+          docker manifest create stratumv2/${{ matrix.app }}:"${ref}" \
+            stratumv2/${{ matrix.app }}:"${ref}-amd64" \
+            stratumv2/${{ matrix.app }}:"${ref}-arm64"
+          docker manifest push stratumv2/${{ matrix.app }}:"${ref}"
+
+  # TODO: reproducibility verification job.
+  # Idea: rebuild the OCI tarball on a separate clean runner and compare sha256.
+  # Skeleton below — finish once the first end-to-end build succeeds, since the
+  # exact output paths and hashing strategy depend on dockerTools' current behavior.
+  #
+  # verify-reproducible:
+  #   needs: build-image
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       app: [pool_sv2, jd_client_sv2, translator_sv2]
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: cachix/install-nix-action@v30
+  #     - name: Rebuild and compare
+  #       run: |
+  #         nix build .#container.${{ matrix.app }} -L --rebuild
+  #         # Compare against the tarball uploaded by build-image (download-artifact).

--- a/docker/REPRODUCIBILITY.md
+++ b/docker/REPRODUCIBILITY.md
@@ -1,0 +1,47 @@
+# Reproducible OCI image builds (experimental)
+
+The Nix flake at the repo root (`flake.nix`) is an alternative, opt-in path
+for building reproducible OCI images of the three release binaries
+(`pool_sv2`, `jd_client_sv2`, `translator_sv2`). It runs **alongside** the
+existing `docker/Dockerfile` + `.github/workflows/docker-release.yaml`
+pipeline; neither is removed.
+
+## Status
+
+Experimental. The flake is wired and ready to build (toolchain pinned via
+`rust-toolchain.toml`; `stratum-core` git dep resolved automatically by
+Crane from the workspace `Cargo.lock`). Bit-identical-output reproducibility
+across independent rebuilders has not yet been verified end-to-end. The
+existing Buildx + QEMU pipeline remains the source of truth for releases.
+
+## How to build locally
+
+```sh
+# Build a single binary as a Nix package
+nix build .#pool_sv2
+
+# Build an OCI image tarball (linux only)
+nix build .#container.pool_sv2
+
+# Load into your local Docker
+docker load < ./result
+```
+
+## How to verify reproducibility
+
+Two builders sharing the same `flake.lock` and source tree should produce
+byte-identical OCI tarballs:
+
+```sh
+nix build .#container.pool_sv2 && sha256sum result
+```
+
+Compare the resulting hash against another builder's. If they match, the
+image is reproducible. CI scaffolding for an automated check lives in
+`.github/workflows/ci-nix.yml` (currently commented out).
+
+## Context
+
+Background, design rationale, and the Fedimint pattern this is modeled on
+are documented in
+`~/wiki/topics/nixos-reproducible-builds-bitcoin/wiki/topics/sv2-apps-oci-reproducibility-feasibility.md`.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,116 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1781527054,
+        "narHash": "sha256-1fX9ev2Fh5QoKQ41G9dYutjo5j/jywu6tZse5Eb1Ck4=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "8c2e51dffefc040a21975da7abf6f252c8c9b783",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780952837,
+        "narHash": "sha256-Fwd1+spDtQ0hDyBwme6ufG3n4mY0UrjjFdYHv+G/Hds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e820eb4a444b46a19b2e03e8dfd2359439ff30fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781453968,
+        "narHash": "sha256-+V3nK4pCngbmgyVGXY6Kkrlevp4ocPkJJLf2aqwkDNA=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "cc272809a173c2c11d0e479d639c811c1eacf049",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,267 @@
+# flake.nix — reproducible OCI image builds for sv2-apps release binaries.
+#
+# WHAT THIS PRODUCES
+#   packages.<system>.{pool_sv2, jd_client_sv2, translator_sv2}            -- release binaries
+#   packages.<system>.container.{pool_sv2, jd_client_sv2, translator_sv2}  -- OCI images (gzipped tarballs)
+#   devShells.<system>.default                                             -- dev env mirroring docker/Dockerfile
+#
+# RELATIONSHIP TO EXISTING DOCKER PIPELINE
+#   This flake lives ALONGSIDE docker/Dockerfile and .github/workflows/docker-release.yaml,
+#   not as a replacement. It is opt-in / experimental. The existing Buildx + QEMU pipeline
+#   continues to be the source of truth until reproducibility of this path is verified.
+#
+# DESIGN
+#   - Crane (https://crane.dev) for Rust builds; Fenix for toolchain pinning from rust-toolchain.toml.
+#   - dockerTools.buildLayeredImage produces OCI tarballs (no Docker daemon needed at build time).
+#   - Multi-arch is achieved at the CI level via native runners per arch (see ci-nix.yml),
+#     not via cross-compilation here. Each Nix system builds a single-arch image; CI stitches
+#     them with `docker manifest create`.
+#   - NO `runAsRoot` is used in image config — sidesteps nixpkgs#416467 on aarch64-linux.
+#   - The repo has TWO cargo workspaces (pool-apps/, miner-apps/) plus the stratum-apps
+#     "shim" crate. Each binary is built from its respective workspace lockfile.
+#
+# CONTEXT
+#   See docker/REPRODUCIBILITY.md and the wiki article at
+#   ~/wiki/topics/nixos-reproducible-builds-bitcoin/wiki/topics/sv2-apps-oci-reproducibility-feasibility.md
+#
+# FIRST-BUILD TODOs
+# NOTE
+#   The toolchain hash below pins channel = "1.85.0" + rustfmt/clippy/rust-analyzer
+#   (matches rust-toolchain.toml). If rust-toolchain.toml changes, replace the sha256
+#   with all-A's, run `nix build`, and copy the "got" value from the resulting error.
+#
+#   The stratum-core git dependency (branch=main, currently rev 083b217...) is
+#   resolved automatically by Crane from each workspace's Cargo.lock — no manual
+#   outputHashes entries are required. If a future Cargo.lock pins a NEW git source
+#   that Crane cannot auto-resolve (rare), Crane will print the expected
+#   `outputHashes` entry; paste it into the corresponding `vendorCargoDeps` block.
+
+{
+  description = "Stratum V2 sv2-apps reproducible OCI image builds";
+
+  inputs = {
+    # Pinned to nixos-25.11 (Crane requires nixpkgs >= 25.11 as of v0.21).
+    # Bump deliberately when you want newer toolchains or dockerTools fixes.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+
+    flake-utils.url = "github:numtide/flake-utils";
+
+    crane = {
+      url = "github:ipetkov/crane";
+      # Crane no longer requires `inputs.nixpkgs.follows` since v0.18; it reads pkgs from the caller.
+    };
+
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, crane, fenix }:
+    flake-utils.lib.eachSystem [
+      "x86_64-linux"
+      "aarch64-linux"
+      # darwin systems are dev-shell only — OCI images target linux.
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ] (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        isLinux = pkgs.stdenv.hostPlatform.isLinux;
+
+        # ---- Rust toolchain pinned via rust-toolchain.toml ----
+        rustToolchain = fenix.packages.${system}.fromToolchainFile {
+          file = ./rust-toolchain.toml;
+          # Hash for rust-toolchain.toml (channel = 1.85.0 + rustfmt/clippy/rust-analyzer).
+          # Regenerate when rust-toolchain.toml changes by replacing with all-A's and
+          # copying the "got" value from the resulting `nix build` error.
+          sha256 = "sha256-AJ6LX/Q/Er9kS15bn9iflkUwcgYqRQxiOIL2ToVAXaU=";
+        };
+
+        craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+        # ---- Source filtering ----
+        # Crane's default cleanCargoSource drops everything that isn't .rs/Cargo.{toml,lock}.
+        # We need the full repo because pool-apps depends on bitcoin-core-sv2 and stratum-apps
+        # via path. Use a permissive filter that keeps Rust + workspace metadata.
+        src = pkgs.lib.cleanSourceWith {
+          src = ./.;
+          filter = path: type:
+            (craneLib.filterCargoSources path type)
+            # Keep config-examples + READMEs referenced by Cargo.toml `readme` keys.
+            || (builtins.match ".*/README\\.md$" path != null)
+            || (builtins.match ".*/config-examples/.*" path != null);
+          name = "sv2-apps-source";
+        };
+
+        # ---- Common build inputs ----
+        nativeBuildInputs = with pkgs; [
+          pkg-config
+          capnproto      # build-time, matches Dockerfile builder stage
+          clang
+        ];
+
+        buildInputs = with pkgs; [
+          # Add openssl/zlib here if a transitive dep complains on first build.
+        ];
+
+        # ---- Per-workspace common args ----
+        # Each binary lives in its own workspace; we build deps once per workspace.
+
+        commonArgsPool = {
+          inherit src nativeBuildInputs buildInputs;
+          pname = "sv2-pool-apps-deps";
+          version = "0.4.0";
+          cargoLock = ./pool-apps/Cargo.lock;
+          cargoToml = ./pool-apps/Cargo.toml;
+          # Build from the workspace root.
+          cargoExtraArgs = "--manifest-path pool-apps/Cargo.toml";
+          # Crane auto-resolves git deps from the lockfile (Cargo.lock pins
+          # stratum-core to a specific rev). No outputHashes entries needed
+          # for the stratum-core branch=main case.
+          cargoVendorDir = craneLib.vendorCargoDeps {
+            src = ./.;
+            cargoLock = ./pool-apps/Cargo.lock;
+          };
+        };
+
+        commonArgsMiner = {
+          inherit src nativeBuildInputs buildInputs;
+          pname = "sv2-miner-apps-deps";
+          version = "0.3.0";
+          cargoLock = ./miner-apps/Cargo.lock;
+          cargoToml = ./miner-apps/Cargo.toml;
+          cargoExtraArgs = "--manifest-path miner-apps/Cargo.toml";
+          cargoVendorDir = craneLib.vendorCargoDeps {
+            src = ./.;
+            cargoLock = ./miner-apps/Cargo.lock;
+          };
+        };
+
+        # ---- Dependency-only builds (cached separately per workspace) ----
+        cargoArtifactsPool = craneLib.buildDepsOnly commonArgsPool;
+        cargoArtifactsMiner = craneLib.buildDepsOnly commonArgsMiner;
+
+        # ---- Per-binary release builds ----
+        pool_sv2 = craneLib.buildPackage (commonArgsPool // {
+          pname = "pool_sv2";
+          version = "0.4.0";
+          cargoArtifacts = cargoArtifactsPool;
+          cargoExtraArgs = "--manifest-path pool-apps/Cargo.toml -p pool_sv2 --bin pool_sv2";
+          # Skip workspace-wide tests at image-build time; CI runs them separately.
+          doCheck = false;
+        });
+
+        jd_client_sv2 = craneLib.buildPackage (commonArgsMiner // {
+          pname = "jd_client_sv2";
+          version = "0.3.0";
+          cargoArtifacts = cargoArtifactsMiner;
+          cargoExtraArgs = "--manifest-path miner-apps/Cargo.toml -p jd_client_sv2 --bin jd_client_sv2";
+          doCheck = false;
+        });
+
+        translator_sv2 = craneLib.buildPackage (commonArgsMiner // {
+          pname = "translator_sv2";
+          version = "0.3.0";
+          cargoArtifacts = cargoArtifactsMiner;
+          cargoExtraArgs = "--manifest-path miner-apps/Cargo.toml -p translator_sv2 --bin translator_sv2";
+          doCheck = false;
+        });
+
+        # ---- OCI image builder ----
+        # Single-arch per system. CI stitches with `docker manifest create`.
+        # NO runAsRoot — sidesteps nixpkgs#416467 on aarch64-linux GitHub runners.
+        mkContainer = { name, pkg, binName }:
+          pkgs.dockerTools.buildLayeredImage {
+            inherit name;
+            tag = "latest";  # CI retags with ${github.ref_name}-${arch}.
+            # Epoch+1 timestamp (the +1 sidesteps a historical dockerTools quirk that
+            # would otherwise treat 0 as "unset" and fall back to build time).
+            created = "1970-01-01T00:00:01Z";
+
+            architecture =
+              if pkgs.stdenv.hostPlatform.system == "x86_64-linux" then "amd64"
+              else if pkgs.stdenv.hostPlatform.system == "aarch64-linux" then "arm64"
+              else throw "OCI images only supported on linux systems; got ${pkgs.stdenv.hostPlatform.system}";
+
+            contents = [
+              pkg
+              # gettext provides envsubst — kept for parity with the existing Dockerfile's
+              # runtime stage, which installs gettext-base for config templating.
+              pkgs.gettext
+              # bash + coreutils so an entrypoint sh -c wrapper works (the Dockerfile uses
+              # ENTRYPOINT ["/bin/sh", "-c", ...]); also handy for `docker exec` debugging.
+              pkgs.bash
+              pkgs.coreutils
+              # CA bundle for any TLS calls the binaries make.
+              pkgs.cacert
+            ];
+
+            config = {
+              # Direct binary invocation. If you need the existing Dockerfile's
+              # `sh -c "/app/${APP}"` envsubst-on-args behavior, swap to:
+              #   Entrypoint = [ "${pkgs.bash}/bin/sh" "-c" "${pkg}/bin/${binName} \"$@\"" "--" ];
+              Cmd = [ "${pkg}/bin/${binName}" ];
+              Env = [
+                "PATH=/bin:/usr/bin"
+                "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+              ];
+              WorkingDir = "/";
+              Labels = {
+                "org.opencontainers.image.source" = "https://github.com/stratum-mining/sv2-apps";
+                "org.opencontainers.image.licenses" = "MIT OR Apache-2.0";
+              };
+            };
+          };
+
+      in {
+        packages = {
+          inherit pool_sv2 jd_client_sv2 translator_sv2;
+
+          # Containers only build on linux; on darwin these attrs are absent.
+          container = pkgs.lib.optionalAttrs isLinux {
+            pool_sv2 = mkContainer {
+              name = "stratumv2/pool_sv2";
+              pkg = pool_sv2;
+              binName = "pool_sv2";
+            };
+            jd_client_sv2 = mkContainer {
+              name = "stratumv2/jd_client_sv2";
+              pkg = jd_client_sv2;
+              binName = "jd_client_sv2";
+            };
+            translator_sv2 = mkContainer {
+              name = "stratumv2/translator_sv2";
+              pkg = translator_sv2;
+              binName = "translator_sv2";
+            };
+          };
+
+          default = pool_sv2;
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = pkgs.lib.optionals isLinux [
+            # Pull in build inputs from one of the binaries on linux for full parity;
+            # on darwin we just want toolchain + tools.
+            pool_sv2
+          ];
+          packages = with pkgs; [
+            rustToolchain
+            capnproto
+            pkg-config
+            clang
+            gettext        # envsubst — runtime parity with Dockerfile
+            cargo-watch
+            cargo-nextest
+          ];
+          # Helpful for rust-analyzer integration.
+          RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+        };
+
+        # `nix flake check` runs this; keep cheap so CI's `nix flake check --no-build` works.
+        checks = pkgs.lib.optionalAttrs isLinux {
+          inherit pool_sv2 jd_client_sv2 translator_sv2;
+        };
+      });
+}


### PR DESCRIPTION
Add a Nix flake and accompanying GitHub Actions workflow that produce reproducible OCI images for the three release binaries (`pool_sv2`, `jd_client_sv2`, `translator_sv2`).