### PR TITLE
enable `semver-checks` CI for `sv2-apps` crates

### DIFF
--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -44,22 +44,18 @@ jobs:
       - name: Install cargo-semver-checks
         run: cargo install cargo-semver-checks --version 0.37.0 --locked
 
-      # TODO: Add semver checks for bitcoin-core-sv2 crate when it is published
-      #- name: Run semver checks for bitcoin-core-sv2
-      #  working-directory: bitcoin-core-sv2
-      #  run: cargo semver-checks
+      - name: Run semver checks for bitcoin-core-sv2
+        working-directory: bitcoin-core-sv2
+        run: cargo semver-checks
 
-      #  TODO: Add semver checks for stratum-apps workspace when it is published
-      #- name: Run semver checks for stratum-apps workspace
-      #  working-directory: stratum-apps
-      #  run: cargo semver-checks --all-features
+      - name: Run semver checks for stratum-apps workspace
+        working-directory: stratum-apps
+        run: cargo semver-checks --all-features
 
-      # TODO: Add semver checks for pool applications workspace when JDS is published
-      #- name: Run semver checks for pool applications workspace
-      #  working-directory: pool-apps
-      #  run: cargo semver-checks
+      - name: Run semver checks for pool applications workspace
+        working-directory: pool-apps
+        run: cargo semver-checks  --workspace --all-features
 
-      # TODO: Add semver checks for miner applications workspace when JDC is published
-      #- name: Run semver checks for miner applications workspace
-      #  working-directory: miner-apps
-      #  run: cargo semver-checks
+      - name: Run semver checks for miner applications workspace
+        working-directory: miner-apps
+        run: cargo semver-checks --workspace --all-features

--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -42,7 +42,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cmake
 
       - name: Install cargo-semver-checks
-        run: cargo install cargo-semver-checks --version 0.37.0 --locked
+        run: cargo install cargo-semver-checks --version 0.44.0 --locked
 
       - name: Run semver checks for bitcoin-core-sv2
         working-directory: bitcoin-core-sv2


### PR DESCRIPTION
we've been publishing these crates to `crates.io` for a while now

`CONTRIBUTING.md` also mentions that we're enforcing basic versioning rules via CI