### PR TITLE
bump `asic-rs` to `v0.6.2`

### DIFF
--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -164,9 +164,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asic-rs"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47307d5a9281af37b5d9832e2d98b886f7cf0318fec65c5d40472a032a513385"
+checksum = "dc00482ee6d0a0c0865e509e1b01d560d203683e3c273878462c7ac6433dc900"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -176,6 +176,7 @@ dependencies = [
  "asic-rs-firmwares-bitaxe",
  "asic-rs-firmwares-braiins",
  "asic-rs-firmwares-epic",
+ "asic-rs-firmwares-futurebit",
  "asic-rs-firmwares-luxminer",
  "asic-rs-firmwares-marathon",
  "asic-rs-firmwares-nerdaxe",
@@ -189,6 +190,7 @@ dependencies = [
  "asic-rs-makes-bitaxe",
  "asic-rs-makes-braiins",
  "asic-rs-makes-epic",
+ "asic-rs-makes-futurebit",
  "asic-rs-makes-marathon",
  "asic-rs-makes-nerdaxe",
  "asic-rs-makes-proto",
@@ -210,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-core"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2757635bc82efe672d71b6c40e0292063cffea3d25a00f94b5b397e6a8126d85"
+checksum = "d2c8bab71c78559b2a274f346b93c432a86a765fdb1b89d67d840293a07d1da6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -232,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-antminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b60783de5ab46e66ca9523c0df9a576457cb16becd805cf7ede5e1a1b6b2880"
+checksum = "b0c3da4344fd4c0d5a46a74b59a3b1434b67b97721d69c4455e8b577417af428"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -254,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-auradine"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131d8d63b6bba7e377b49ab9f2381c4dc704cae5f229599ebf48ad65f7156ad3"
+checksum = "714e4c1089c8c045f522f2a3dc158cb9d00af82e69fdec7c5e13f88a38671799"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -273,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-avalonminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a406e1156e7e42ec1d18c79c1fc3ee7a742bdfc3cb910a01ad5b5e81dd910ce"
+checksum = "615ddfde0b49afcd65eaf9ff2d786cd28e8ac99629c9077a1e17801f40f3e2d9"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -291,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-bitaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f90975fc58de41d343cabae10820662a7f9775466a7f7ab22bba9d6307f24c7"
+checksum = "c11a41114e4b1dabbacf6e9cdba40e3f1090ab0bfe57acc27ffdebe4362c9322"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -310,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-braiins"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6a9a022d46d14198f61341fe5c4b5aa90e83cc7761b04b17059b73af4c7aab"
+checksum = "f66adaab2657790181a9ca5bab133499d7876ffe862605cb002371313206f1c9"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -331,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-epic"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d141ce95bbe57e8165221fcf99fe6e488e43d0b709a88ea7a4bf67cbec0fda"
+checksum = "1658b2f7b358af09f48f8e8711cfea77f0295d5bb20b09a49f5e40fc8d2c7bf2"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -353,10 +355,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "asic-rs-firmwares-luxminer"
-version = "0.6.0"
+name = "asic-rs-firmwares-futurebit"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4477d238962ef469ab2dde5be72977c58952af3916b5f99782e90098f9eeb1bb"
+checksum = "9b8cf8eadf6dcf1a198a60682c586fecd279a5d8e98e62917d9bcb6d96dd4107"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-futurebit",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-luxminer"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fde4154b7467ca0224594aa53ad6ff41f1e7d2526604684c492c58d6ecb4157"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -371,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-marathon"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbce132d943c097aedab3bb8a4b27f113e3d067f1ff9820cf76bd0187ea91458"
+checksum = "49611f22ce457dc6ad98a3b5307fd4167113520df1c4fde8e935ea2293a61c68"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -391,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-nerdaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0196286f312e260e1f924ed4113e0cf54ec5c9e178cb0923cd31341f13a2208c"
+checksum = "e2a33d2d51beee25bb829a018f78c2d95b1aed5fd669ba83b33e2ca7fcb51096"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -410,9 +431,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-proto"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9c08d805b1a6db967c7d1dc9cca9db0bc2d416450d63a5c24433c00d6fef9f"
+checksum = "87d4718b79c5456bd718a83febc5d3e47147db7afa9183a5d6969ab288e7de43"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -430,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-sealminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d244fc3c90b2b8228a3a522c4cae165de89cb9e335149bb5e9160f77edaf05a2"
+checksum = "eb7767f55bbe8c1488eba389c32e49a1cf55c5c7759e01f1ffa77818017fbf2f"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -449,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-vnish"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba89e5454f96dc6ffc732b401d60f688a91e7a3ae82292dca108cac4eaedd78"
+checksum = "56ee24365b23a918effa41215dfbb5d48e9594ec248035d50ef7eaa1309ff2fa"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -468,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-whatsminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78af4dcf62d9486eb44daa47988dd2fa38136496723267c14608dfca48c95dd0"
+checksum = "4ec8e7f78b593ddbbc700ad431877ba381598b1151c1ff6270dfc83db87184c6"
 dependencies = [
  "aes",
  "anyhow",
@@ -494,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-antminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffd48eb7ba44ac3c37ef2839c6d6f652ab3407ccb1557caca6e6b4292321bc7"
+checksum = "1a29c91f048286e3e65c4b435d1598e0b30499df14bebf2238ce369474e2059e"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -506,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-auradine"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aec9b0a99782abb6000a97521f6db03456ce35eb6994f9e0d8b333478c321b5"
+checksum = "86553407758b5c4081745ee465c13febfbcebd45233d809209d5ed492e5a890a"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -518,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-avalon"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c67ab4786ce2972ee128109f54363e5ffc64143a7784f4a043cf9e12823ca4a"
+checksum = "ed457d4963c425039abe21987ff1d70e8d5f0e1fad8f0ae02a9ba77306c96f8e"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -530,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-bitaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4dac2791b0c9204c3292d3a2afadac0aee49308ce4e4c1bbb53fcb78d2c45d"
+checksum = "9648961614946d9e5af27d7b54bdfcc5b18b85f26ff660af3ebef0e53f315496"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -542,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-braiins"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b26c8b14af679abbd4686ecbce256138459064d611ecd80ad6904ba79419540"
+checksum = "9f71017e0e12f2b8fddb023f0f2da25d09dcf46d49a4caf8117a6bd4c1a5ea4c"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -554,9 +575,21 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-epic"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18432260adc21f1f0a2de8060d181553bd361d637ff4f530bf5653722165aac"
+checksum = "3b0f9735452900e274a7eaaa9eb320daccf5c1680625295907171c9a8bf88986"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-futurebit"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccedd3ba1806b43ef7841d66aa892aa6229be5752bf085cc7fa5f17647dd2e55"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -566,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-marathon"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca04e0414fddc848e9209a8a2303226a00e3cd1dfa478d0ce679763b0dcf2f4c"
+checksum = "b00248ef815bc1f81d81fc0e1b2da9a57fd3413c543f2ed792e5b5783d99ddd7"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -578,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-nerdaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b627e6fb3d8af11a6d6e32bc63b37062569c5be3e5578d2ab624eb78c653370"
+checksum = "a53e275492085cbf0f6c7f6418caf598ff7c3e38cf204f2af77570e57974687b"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -590,9 +623,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-proto"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3799837b4273e4275e9d140457ddf998f858f3dbd3ee11a17f1fda0688388001"
+checksum = "8da6222dc810bf58744623e2420874bde2c3ce1d03c42389ed12f9cb3cc718ef"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -602,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-sealminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83af9faef90171cba57eaf77e18eff7420d993eb9ce15a53d497e8176f82a9d2"
+checksum = "19ec972bdcafd3a52c86ffa39b60ae096488fc61aabb12af984b8b1964028112"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -614,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-whatsminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e1b9c88238fc306d7d6e0ecead740e91d78fb6cd765534af7ad35f5755c41f"
+checksum = "1f1c46481710544877ba044e0b5fa9ead3114051208918b1ef6a444d6590fca1"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -1809,7 +1842,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1881,7 +1914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2677,7 +2710,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3106,7 +3139,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3543,7 +3576,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3876,7 +3909,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3945,7 +3978,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4489,7 +4522,7 @@ dependencies = [
  "fastrand 2.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5248,7 +5281,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -173,9 +173,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "asic-rs"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47307d5a9281af37b5d9832e2d98b886f7cf0318fec65c5d40472a032a513385"
+checksum = "dc00482ee6d0a0c0865e509e1b01d560d203683e3c273878462c7ac6433dc900"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -185,6 +185,7 @@ dependencies = [
  "asic-rs-firmwares-bitaxe",
  "asic-rs-firmwares-braiins",
  "asic-rs-firmwares-epic",
+ "asic-rs-firmwares-futurebit",
  "asic-rs-firmwares-luxminer",
  "asic-rs-firmwares-marathon",
  "asic-rs-firmwares-nerdaxe",
@@ -198,6 +199,7 @@ dependencies = [
  "asic-rs-makes-bitaxe",
  "asic-rs-makes-braiins",
  "asic-rs-makes-epic",
+ "asic-rs-makes-futurebit",
  "asic-rs-makes-marathon",
  "asic-rs-makes-nerdaxe",
  "asic-rs-makes-proto",
@@ -219,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-core"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2757635bc82efe672d71b6c40e0292063cffea3d25a00f94b5b397e6a8126d85"
+checksum = "d2c8bab71c78559b2a274f346b93c432a86a765fdb1b89d67d840293a07d1da6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -241,9 +243,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-antminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b60783de5ab46e66ca9523c0df9a576457cb16becd805cf7ede5e1a1b6b2880"
+checksum = "b0c3da4344fd4c0d5a46a74b59a3b1434b67b97721d69c4455e8b577417af428"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -263,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-auradine"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131d8d63b6bba7e377b49ab9f2381c4dc704cae5f229599ebf48ad65f7156ad3"
+checksum = "714e4c1089c8c045f522f2a3dc158cb9d00af82e69fdec7c5e13f88a38671799"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -282,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-avalonminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a406e1156e7e42ec1d18c79c1fc3ee7a742bdfc3cb910a01ad5b5e81dd910ce"
+checksum = "615ddfde0b49afcd65eaf9ff2d786cd28e8ac99629c9077a1e17801f40f3e2d9"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -300,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-bitaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f90975fc58de41d343cabae10820662a7f9775466a7f7ab22bba9d6307f24c7"
+checksum = "c11a41114e4b1dabbacf6e9cdba40e3f1090ab0bfe57acc27ffdebe4362c9322"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -319,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-braiins"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6a9a022d46d14198f61341fe5c4b5aa90e83cc7761b04b17059b73af4c7aab"
+checksum = "f66adaab2657790181a9ca5bab133499d7876ffe862605cb002371313206f1c9"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -340,9 +342,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-epic"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d141ce95bbe57e8165221fcf99fe6e488e43d0b709a88ea7a4bf67cbec0fda"
+checksum = "1658b2f7b358af09f48f8e8711cfea77f0295d5bb20b09a49f5e40fc8d2c7bf2"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -362,10 +364,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "asic-rs-firmwares-luxminer"
-version = "0.6.0"
+name = "asic-rs-firmwares-futurebit"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4477d238962ef469ab2dde5be72977c58952af3916b5f99782e90098f9eeb1bb"
+checksum = "9b8cf8eadf6dcf1a198a60682c586fecd279a5d8e98e62917d9bcb6d96dd4107"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-futurebit",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-luxminer"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fde4154b7467ca0224594aa53ad6ff41f1e7d2526604684c492c58d6ecb4157"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -380,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-marathon"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbce132d943c097aedab3bb8a4b27f113e3d067f1ff9820cf76bd0187ea91458"
+checksum = "49611f22ce457dc6ad98a3b5307fd4167113520df1c4fde8e935ea2293a61c68"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -400,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-nerdaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0196286f312e260e1f924ed4113e0cf54ec5c9e178cb0923cd31341f13a2208c"
+checksum = "e2a33d2d51beee25bb829a018f78c2d95b1aed5fd669ba83b33e2ca7fcb51096"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -419,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-proto"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9c08d805b1a6db967c7d1dc9cca9db0bc2d416450d63a5c24433c00d6fef9f"
+checksum = "87d4718b79c5456bd718a83febc5d3e47147db7afa9183a5d6969ab288e7de43"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -439,9 +460,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-sealminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d244fc3c90b2b8228a3a522c4cae165de89cb9e335149bb5e9160f77edaf05a2"
+checksum = "eb7767f55bbe8c1488eba389c32e49a1cf55c5c7759e01f1ffa77818017fbf2f"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -458,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-vnish"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba89e5454f96dc6ffc732b401d60f688a91e7a3ae82292dca108cac4eaedd78"
+checksum = "56ee24365b23a918effa41215dfbb5d48e9594ec248035d50ef7eaa1309ff2fa"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -477,9 +498,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-whatsminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78af4dcf62d9486eb44daa47988dd2fa38136496723267c14608dfca48c95dd0"
+checksum = "4ec8e7f78b593ddbbc700ad431877ba381598b1151c1ff6270dfc83db87184c6"
 dependencies = [
  "aes",
  "anyhow",
@@ -503,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-antminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffd48eb7ba44ac3c37ef2839c6d6f652ab3407ccb1557caca6e6b4292321bc7"
+checksum = "1a29c91f048286e3e65c4b435d1598e0b30499df14bebf2238ce369474e2059e"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -515,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-auradine"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aec9b0a99782abb6000a97521f6db03456ce35eb6994f9e0d8b333478c321b5"
+checksum = "86553407758b5c4081745ee465c13febfbcebd45233d809209d5ed492e5a890a"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -527,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-avalon"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c67ab4786ce2972ee128109f54363e5ffc64143a7784f4a043cf9e12823ca4a"
+checksum = "ed457d4963c425039abe21987ff1d70e8d5f0e1fad8f0ae02a9ba77306c96f8e"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -539,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-bitaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4dac2791b0c9204c3292d3a2afadac0aee49308ce4e4c1bbb53fcb78d2c45d"
+checksum = "9648961614946d9e5af27d7b54bdfcc5b18b85f26ff660af3ebef0e53f315496"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -551,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-braiins"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b26c8b14af679abbd4686ecbce256138459064d611ecd80ad6904ba79419540"
+checksum = "9f71017e0e12f2b8fddb023f0f2da25d09dcf46d49a4caf8117a6bd4c1a5ea4c"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -563,9 +584,21 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-epic"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18432260adc21f1f0a2de8060d181553bd361d637ff4f530bf5653722165aac"
+checksum = "3b0f9735452900e274a7eaaa9eb320daccf5c1680625295907171c9a8bf88986"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-futurebit"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccedd3ba1806b43ef7841d66aa892aa6229be5752bf085cc7fa5f17647dd2e55"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -575,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-marathon"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca04e0414fddc848e9209a8a2303226a00e3cd1dfa478d0ce679763b0dcf2f4c"
+checksum = "b00248ef815bc1f81d81fc0e1b2da9a57fd3413c543f2ed792e5b5783d99ddd7"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -587,9 +620,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-nerdaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b627e6fb3d8af11a6d6e32bc63b37062569c5be3e5578d2ab624eb78c653370"
+checksum = "a53e275492085cbf0f6c7f6418caf598ff7c3e38cf204f2af77570e57974687b"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -599,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-proto"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3799837b4273e4275e9d140457ddf998f858f3dbd3ee11a17f1fda0688388001"
+checksum = "8da6222dc810bf58744623e2420874bde2c3ce1d03c42389ed12f9cb3cc718ef"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -611,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-sealminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83af9faef90171cba57eaf77e18eff7420d993eb9ce15a53d497e8176f82a9d2"
+checksum = "19ec972bdcafd3a52c86ffa39b60ae096488fc61aabb12af984b8b1964028112"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -623,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-whatsminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e1b9c88238fc306d7d6e0ecead740e91d78fb6cd765534af7ad35f5755c41f"
+checksum = "1f1c46481710544877ba044e0b5fa9ead3114051208918b1ef6a444d6590fca1"
 dependencies = [
  "asic-rs-core",
  "serde",

--- a/stratum-apps/Cargo.lock
+++ b/stratum-apps/Cargo.lock
@@ -108,9 +108,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asic-rs"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47307d5a9281af37b5d9832e2d98b886f7cf0318fec65c5d40472a032a513385"
+checksum = "dc00482ee6d0a0c0865e509e1b01d560d203683e3c273878462c7ac6433dc900"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -120,6 +120,7 @@ dependencies = [
  "asic-rs-firmwares-bitaxe",
  "asic-rs-firmwares-braiins",
  "asic-rs-firmwares-epic",
+ "asic-rs-firmwares-futurebit",
  "asic-rs-firmwares-luxminer",
  "asic-rs-firmwares-marathon",
  "asic-rs-firmwares-nerdaxe",
@@ -133,6 +134,7 @@ dependencies = [
  "asic-rs-makes-bitaxe",
  "asic-rs-makes-braiins",
  "asic-rs-makes-epic",
+ "asic-rs-makes-futurebit",
  "asic-rs-makes-marathon",
  "asic-rs-makes-nerdaxe",
  "asic-rs-makes-proto",
@@ -154,9 +156,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-core"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2757635bc82efe672d71b6c40e0292063cffea3d25a00f94b5b397e6a8126d85"
+checksum = "d2c8bab71c78559b2a274f346b93c432a86a765fdb1b89d67d840293a07d1da6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -176,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-antminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b60783de5ab46e66ca9523c0df9a576457cb16becd805cf7ede5e1a1b6b2880"
+checksum = "b0c3da4344fd4c0d5a46a74b59a3b1434b67b97721d69c4455e8b577417af428"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -198,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-auradine"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131d8d63b6bba7e377b49ab9f2381c4dc704cae5f229599ebf48ad65f7156ad3"
+checksum = "714e4c1089c8c045f522f2a3dc158cb9d00af82e69fdec7c5e13f88a38671799"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -217,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-avalonminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a406e1156e7e42ec1d18c79c1fc3ee7a742bdfc3cb910a01ad5b5e81dd910ce"
+checksum = "615ddfde0b49afcd65eaf9ff2d786cd28e8ac99629c9077a1e17801f40f3e2d9"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -235,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-bitaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f90975fc58de41d343cabae10820662a7f9775466a7f7ab22bba9d6307f24c7"
+checksum = "c11a41114e4b1dabbacf6e9cdba40e3f1090ab0bfe57acc27ffdebe4362c9322"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -254,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-braiins"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6a9a022d46d14198f61341fe5c4b5aa90e83cc7761b04b17059b73af4c7aab"
+checksum = "f66adaab2657790181a9ca5bab133499d7876ffe862605cb002371313206f1c9"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -275,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-epic"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1d141ce95bbe57e8165221fcf99fe6e488e43d0b709a88ea7a4bf67cbec0fda"
+checksum = "1658b2f7b358af09f48f8e8711cfea77f0295d5bb20b09a49f5e40fc8d2c7bf2"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -297,10 +299,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "asic-rs-firmwares-luxminer"
-version = "0.6.0"
+name = "asic-rs-firmwares-futurebit"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4477d238962ef469ab2dde5be72977c58952af3916b5f99782e90098f9eeb1bb"
+checksum = "9b8cf8eadf6dcf1a198a60682c586fecd279a5d8e98e62917d9bcb6d96dd4107"
+dependencies = [
+ "anyhow",
+ "asic-rs-core",
+ "asic-rs-makes-futurebit",
+ "async-trait",
+ "macaddr",
+ "measurements",
+ "once_cell",
+ "reqwest",
+ "semver",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "asic-rs-firmwares-luxminer"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fde4154b7467ca0224594aa53ad6ff41f1e7d2526604684c492c58d6ecb4157"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -315,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-marathon"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbce132d943c097aedab3bb8a4b27f113e3d067f1ff9820cf76bd0187ea91458"
+checksum = "49611f22ce457dc6ad98a3b5307fd4167113520df1c4fde8e935ea2293a61c68"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -335,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-nerdaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0196286f312e260e1f924ed4113e0cf54ec5c9e178cb0923cd31341f13a2208c"
+checksum = "e2a33d2d51beee25bb829a018f78c2d95b1aed5fd669ba83b33e2ca7fcb51096"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -354,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-proto"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9c08d805b1a6db967c7d1dc9cca9db0bc2d416450d63a5c24433c00d6fef9f"
+checksum = "87d4718b79c5456bd718a83febc5d3e47147db7afa9183a5d6969ab288e7de43"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -374,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-sealminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d244fc3c90b2b8228a3a522c4cae165de89cb9e335149bb5e9160f77edaf05a2"
+checksum = "eb7767f55bbe8c1488eba389c32e49a1cf55c5c7759e01f1ffa77818017fbf2f"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -393,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-vnish"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba89e5454f96dc6ffc732b401d60f688a91e7a3ae82292dca108cac4eaedd78"
+checksum = "56ee24365b23a918effa41215dfbb5d48e9594ec248035d50ef7eaa1309ff2fa"
 dependencies = [
  "anyhow",
  "asic-rs-core",
@@ -412,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-firmwares-whatsminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78af4dcf62d9486eb44daa47988dd2fa38136496723267c14608dfca48c95dd0"
+checksum = "4ec8e7f78b593ddbbc700ad431877ba381598b1151c1ff6270dfc83db87184c6"
 dependencies = [
  "aes",
  "anyhow",
@@ -438,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-antminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffd48eb7ba44ac3c37ef2839c6d6f652ab3407ccb1557caca6e6b4292321bc7"
+checksum = "1a29c91f048286e3e65c4b435d1598e0b30499df14bebf2238ce369474e2059e"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -450,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-auradine"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aec9b0a99782abb6000a97521f6db03456ce35eb6994f9e0d8b333478c321b5"
+checksum = "86553407758b5c4081745ee465c13febfbcebd45233d809209d5ed492e5a890a"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -462,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-avalon"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c67ab4786ce2972ee128109f54363e5ffc64143a7784f4a043cf9e12823ca4a"
+checksum = "ed457d4963c425039abe21987ff1d70e8d5f0e1fad8f0ae02a9ba77306c96f8e"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -474,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-bitaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4dac2791b0c9204c3292d3a2afadac0aee49308ce4e4c1bbb53fcb78d2c45d"
+checksum = "9648961614946d9e5af27d7b54bdfcc5b18b85f26ff660af3ebef0e53f315496"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -486,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-braiins"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b26c8b14af679abbd4686ecbce256138459064d611ecd80ad6904ba79419540"
+checksum = "9f71017e0e12f2b8fddb023f0f2da25d09dcf46d49a4caf8117a6bd4c1a5ea4c"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -498,9 +519,21 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-epic"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18432260adc21f1f0a2de8060d181553bd361d637ff4f530bf5653722165aac"
+checksum = "3b0f9735452900e274a7eaaa9eb320daccf5c1680625295907171c9a8bf88986"
+dependencies = [
+ "asic-rs-core",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
+name = "asic-rs-makes-futurebit"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccedd3ba1806b43ef7841d66aa892aa6229be5752bf085cc7fa5f17647dd2e55"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -510,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-marathon"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca04e0414fddc848e9209a8a2303226a00e3cd1dfa478d0ce679763b0dcf2f4c"
+checksum = "b00248ef815bc1f81d81fc0e1b2da9a57fd3413c543f2ed792e5b5783d99ddd7"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -522,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-nerdaxe"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b627e6fb3d8af11a6d6e32bc63b37062569c5be3e5578d2ab624eb78c653370"
+checksum = "a53e275492085cbf0f6c7f6418caf598ff7c3e38cf204f2af77570e57974687b"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -534,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-proto"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3799837b4273e4275e9d140457ddf998f858f3dbd3ee11a17f1fda0688388001"
+checksum = "8da6222dc810bf58744623e2420874bde2c3ce1d03c42389ed12f9cb3cc718ef"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -546,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-sealminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83af9faef90171cba57eaf77e18eff7420d993eb9ce15a53d497e8176f82a9d2"
+checksum = "19ec972bdcafd3a52c86ffa39b60ae096488fc61aabb12af984b8b1964028112"
 dependencies = [
  "asic-rs-core",
  "serde",
@@ -558,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "asic-rs-makes-whatsminer"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e1b9c88238fc306d7d6e0ecead740e91d78fb6cd765534af7ad35f5755c41f"
+checksum = "1f1c46481710544877ba044e0b5fa9ead3114051208918b1ef6a444d6590fca1"
 dependencies = [
  "asic-rs-core",
  "serde",

--- a/stratum-apps/Cargo.toml
+++ b/stratum-apps/Cargo.toml
@@ -43,7 +43,7 @@ rustversion = "1.0"
 serde_json = { version = "1.0", default-features = false, features = ["alloc", "raw_value"], optional = true }
 
 # Monitoring optional dependencies
-asic-rs = { version = "0.6.0", optional = true }
+asic-rs = { version = "0.6.2", optional = true }
 axum = { version = "0.8.7", optional = true }
 prometheus = { version = "0.13", optional = true }
 utoipa = { version = "5.4.0", features = ["axum_extras"], optional = true }


### PR DESCRIPTION
follow-up to #553

`v0.6.2` incorporates fixes to the issues I reported:
- https://github.com/256foundation/asic-rs/issues/276
- https://github.com/256foundation/asic-rs/issues/275