### PR TITLE
accelerate CI via `cargo binstall`

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -35,8 +35,18 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: brew install capnp
 
+      # Install cargo-binstall so tool installs below use prebuilt binaries.
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.20.0
+        with:
+          version: "1.20.0"
+
+      # Install cargo-nextest via cargo-binstall (no source build).
+      # Keep quick-install disabled to only use upstream release artifacts.
       - name: Install cargo-nextest
-        run: cargo install cargo-nextest --version 0.9.100 --locked
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: cargo binstall --no-confirm --disable-telemetry --disable-strategies quick-install --locked cargo-nextest@0.9.100
 
       - name: Integration Tests
         run: |

--- a/.github/workflows/semver-check.yaml
+++ b/.github/workflows/semver-check.yaml
@@ -41,8 +41,18 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y cmake
 
+      # Install cargo-binstall so tool installs below use prebuilt binaries.
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@v1.20.0
+        with:
+          version: "1.20.0"
+
+      # Install cargo-semver-checks via cargo-binstall (no source build).
+      # Keep quick-install disabled to only use upstream release artifacts.
       - name: Install cargo-semver-checks
-        run: cargo install cargo-semver-checks --version 0.44.0 --locked
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: cargo binstall --no-confirm --disable-telemetry --disable-strategies quick-install --locked cargo-semver-checks@0.44.0
 
       - name: Run semver checks for bitcoin-core-sv2
         working-directory: bitcoin-core-sv2


### PR DESCRIPTION
accelerate CI via [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall)

instead of compiling `cargo-nextest` and `cargo-semver-checks` on every run, we install pre-built binaries via `cargo-binstall`.

additional hardening:
- disable `quick-install` to only use upstream release artifacts (instead of third-party quick-install artifacts)
- pass `GITHUB_TOKEN` to `cargo-binstall` to avoid unauthenticated GitHub API rate-limit fallback
- use `--locked` for deterministic fallback behavior if source install is ever needed

estimated impact (latest successful PR run vs median of 5 recent comparable successful PR runs on the same workflows/jobs):

- `ci (ubuntu-latest)`:
  - tool install: `~2m34s -> ~3s` (**~98% reduction**)
  - total job: `~32m18s -> ~28m41s` (**~3m37s faster**, ~11%)
- `ci (macos-latest)`:
  - tool install: `~2m38s -> ~5s` (**~97% reduction**)
  - total job: `~31m57s -> ~30m04s` (**~1m53s faster**, ~6%)
- `semver-check`:
  - tool install: `~5m09s -> ~4s` (**~99% reduction**)
  - total job: `~15m04s -> ~9m44s` (**~5m20s faster**, ~35%)

critical-path wall clock also improves (`~32m18s -> ~30m04s`, ~2m14s), while matrix jobs still run in parallel.