### PR TITLE
Update get_header call sites

### DIFF
--- a/integration-tests/lib/mining_device/mod.rs
+++ b/integration-tests/lib/mining_device/mod.rs
@@ -218,7 +218,7 @@ impl SetupConnectionHandler {
         info!("Setup connection sent to {}", address);
 
         let mut incoming: StdFrame = receiver.recv().await.unwrap().try_into().unwrap();
-        let message_type = incoming.get_header().unwrap().msg_type();
+        let message_type = incoming.get_header().msg_type();
         let payload = incoming.payload();
         Self::handle_message_common(self_, message_type, payload).unwrap();
     }
@@ -388,7 +388,7 @@ impl Device {
 
         loop {
             let mut incoming: StdFrame = receiver.recv().await.unwrap().try_into().unwrap();
-            let message_type = incoming.get_header().unwrap().msg_type();
+            let message_type = incoming.get_header().msg_type();
             let payload = incoming.payload();
             Device::handle_message_mining(self_mutex.clone(), message_type, payload).unwrap();
             let mut notify_changes_to_mining_thread = self_mutex

--- a/integration-tests/lib/utils.rs
+++ b/integration-tests/lib/utils.rs
@@ -291,39 +291,36 @@ pub fn message_from_frame_with_tlvs(
 ) -> (MsgType, AnyMessage<'static>, Option<Vec<Tlv>>) {
     match frame {
         Frame::Sv2(frame) => {
-            if let Some(header) = frame.get_header() {
-                let payload = frame.payload();
+            let header = frame.get_header();
+            let payload = frame.payload();
 
-                // Try to parse with TLV support if extensions are negotiated
-                if !negotiated_extensions.is_empty() {
-                    match parse_message_frame_with_tlvs(header, payload, negotiated_extensions) {
-                        Ok((message, tlv_fields)) => {
-                            let message = into_static(message);
-                            return (header.msg_type(), message, tlv_fields);
-                        }
-                        Err(e) => {
-                            println!("Failed to parse frame with TLVs: {e:?}, falling back to standard parsing");
-                        }
-                    }
-                }
-
-                // Fallback to standard parsing without TLV support
-                let mut payload = frame.payload().to_vec();
-                let message: Result<AnyMessage<'_>, _> =
-                    (header, payload.as_mut_slice()).try_into();
-                match message {
-                    Ok(message) => {
+            // Try to parse with TLV support if extensions are negotiated
+            if !negotiated_extensions.is_empty() {
+                match parse_message_frame_with_tlvs(header, payload, negotiated_extensions) {
+                    Ok((message, tlv_fields)) => {
                         let message = into_static(message);
-                        (header.msg_type(), message, None)
+                        return (header.msg_type(), message, tlv_fields);
                     }
-                    _ => {
-                        println!("Received frame with invalid payload or message type: {frame:?}");
-                        panic!();
+                    Err(e) => {
+                        println!(
+                            "Failed to parse frame with TLVs: {e:?}, falling back to standard parsing"
+                        );
                     }
                 }
-            } else {
-                println!("Received frame with invalid header: {frame:?}");
-                panic!();
+            }
+
+            // Fallback to standard parsing without TLV support
+            let mut payload = frame.payload().to_vec();
+            let message: Result<AnyMessage<'_>, _> = (header, payload.as_mut_slice()).try_into();
+            match message {
+                Ok(message) => {
+                    let message = into_static(message);
+                    (header.msg_type(), message, None)
+                }
+                _ => {
+                    println!("Received frame with invalid payload or message type: {frame:?}");
+                    panic!();
+                }
             }
         }
         Frame::HandShake(f) => {

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -25,7 +25,6 @@ use stratum_apps::{
             server::{group::GroupChannel, jobs::factory::JobFactory, standard::StandardChannel},
             Vardiff, VardiffState,
         },
-        framing_sv2,
         handlers_sv2::{
             HandleExtensionsFromServerAsync, HandleJobDeclarationMessagesFromServerAsync,
             HandleMiningMessagesFromClientAsync, HandleMiningMessagesFromServerAsync,
@@ -866,10 +865,7 @@ impl ChannelManager {
             .recv()
             .await
             .map_err(JDCError::fallback)?;
-        let header = sv2_frame.get_header().ok_or_else(|| {
-            error!("SV2 frame missing header");
-            JDCError::fallback(framing_sv2::Error::MissingHeader)
-        })?;
+        let header = sv2_frame.get_header();
         let message_type = header.msg_type();
         let extension_type = header.ext_type();
         let payload = sv2_frame.payload();

--- a/miner-apps/jd-client/src/lib/downstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/downstream/mod.rs
@@ -324,7 +324,7 @@ impl Downstream {
             .recv()
             .await
             .map_err(|error| JDCError::disconnect(error, self.downstream_id))?;
-        let header = frame.get_header().expect("frame header must be present");
+        let header = frame.get_header();
         if header.msg_type() == MESSAGE_TYPE_SETUP_CONNECTION {
             self.handle_common_message_frame_from_client(None, header, frame.payload())
                 .await?;
@@ -376,9 +376,7 @@ impl Downstream {
             .recv()
             .await
             .map_err(|error| JDCError::disconnect(error, self.downstream_id))?;
-        let header = sv2_frame
-            .get_header()
-            .expect("frame header must be present");
+        let header = sv2_frame.get_header();
         let payload = sv2_frame.payload();
         let negotiated_extensions = self
             .downstream_data

--- a/miner-apps/jd-client/src/lib/job_declarator/mod.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/mod.rs
@@ -7,7 +7,6 @@ use stratum_apps::{
     fallback_coordinator::FallbackCoordinator,
     network_helpers::{connect_with_noise, resolve_host, TCP_CONNECT_TIMEOUT},
     stratum_core::{
-        framing_sv2,
         handlers_sv2::HandleCommonMessagesFromServerAsync,
         parsers_sv2::{AnyMessage, JobDeclaration},
     },
@@ -298,10 +297,7 @@ impl JobDeclarator {
                 JDCError::fallback(JDCErrorKind::ChannelErrorSender)
             })?;
 
-        let header = incoming.get_header().ok_or_else(|| {
-            error!("Handshake frame missing header.");
-            JDCError::fallback(framing_sv2::Error::MissingHeader)
-        })?;
+        let header = incoming.get_header();
 
         debug!(ext_type = ?header.ext_type(),
             msg_type = ?header.msg_type(),
@@ -351,10 +347,7 @@ impl JobDeclarator {
             .map_err(JDCError::fallback)?;
 
         debug!("Received SV2 frame from JDS.");
-        let header = sv2_frame.get_header().ok_or_else(|| {
-            error!("SV2 frame missing header");
-            JDCError::fallback(framing_sv2::Error::MissingHeader)
-        })?;
+        let header = sv2_frame.get_header();
         let message_type = header.msg_type();
         let extension_type = header.ext_type();
 

--- a/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
@@ -19,7 +19,6 @@ use stratum_apps::{
     key_utils::Secp256k1PublicKey,
     network_helpers::{self, connect_with_noise, resolve_host_port, TCP_CONNECT_TIMEOUT},
     stratum_core::{
-        framing_sv2,
         handlers_sv2::HandleCommonMessagesFromServerAsync,
         noise_sv2,
         parsers_sv2::{AnyMessage, TemplateDistribution},
@@ -304,10 +303,7 @@ impl Sv2Tp {
             .map_err(JDCError::shutdown)?;
 
         debug!("Received SV2 frame from Template provider.");
-        let header = sv2_frame.get_header().ok_or_else(|| {
-            error!("SV2 frame missing header");
-            JDCError::shutdown(framing_sv2::Error::MissingHeader)
-        })?;
+        let header = sv2_frame.get_header();
         let message_type = header.msg_type();
         let extension_type = header.ext_type();
 
@@ -391,10 +387,7 @@ impl Sv2Tp {
             JDCError::shutdown(noise_sv2::Error::ExpectedIncomingHandshakeMessage)
         })?;
 
-        let header = incoming.get_header().ok_or_else(|| {
-            error!("Handshake frame missing header");
-            JDCError::shutdown(framing_sv2::Error::MissingHeader)
-        })?;
+        let header = incoming.get_header();
         debug!(ext_type = ?header.ext_type(),
             msg_type = ?header.msg_type(),
             "Received upstream handshake response");

--- a/miner-apps/jd-client/src/lib/upstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/upstream/mod.rs
@@ -18,7 +18,7 @@ use stratum_apps::{
     fallback_coordinator::FallbackCoordinator,
     network_helpers::{connect_with_noise, resolve_host, TCP_CONNECT_TIMEOUT},
     stratum_core::{
-        binary_sv2::Seq064K, extensions_sv2::RequestExtensions, framing_sv2,
+        binary_sv2::Seq064K, extensions_sv2::RequestExtensions,
         handlers_sv2::HandleCommonMessagesFromServerAsync, parsers_sv2::AnyMessage,
     },
     task_manager::TaskManager,
@@ -242,10 +242,7 @@ impl Upstream {
         let mut incoming: Sv2Frame = incoming_frame;
         debug!(?incoming, "Decoded inbound handshake frame");
 
-        let header = incoming.get_header().ok_or_else(|| {
-            error!("Handshake frame missing header");
-            JDCError::fallback(framing_sv2::Error::MissingHeader)
-        })?;
+        let header = incoming.get_header();
 
         info!(ext_type = ?header.ext_type(), msg_type = ?header.msg_type(), "Dispatching inbound handshake message");
         self.handle_common_message_frame_from_server(None, header, incoming.payload())
@@ -407,10 +404,7 @@ impl Upstream {
             .recv()
             .await
             .map_err(JDCError::fallback)?;
-        let header = sv2_frame.get_header().ok_or_else(|| {
-            error!("SV2 frame missing header");
-            JDCError::fallback(framing_sv2::Error::MissingHeader)
-        })?;
+        let header = sv2_frame.get_header();
         let message_type = header.msg_type();
         let extension_type = header.ext_type();
 

--- a/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
@@ -415,10 +415,7 @@ impl ChannelManager {
             .map_err(TproxyError::fallback)?;
 
         let mut channel_manager: ChannelManager = (*self).clone();
-        let header = sv2_frame.get_header().ok_or_else(|| {
-            error!("SV2 frame missing header");
-            TproxyError::fallback(framing_sv2::Error::MissingHeader)
-        })?;
+        let header = sv2_frame.get_header();
         match protocol_message_type(header.ext_type(), header.msg_type()) {
             MessageType::Mining => {
                 channel_manager

--- a/miner-apps/translator/src/lib/sv2/upstream/mod.rs
+++ b/miner-apps/translator/src/lib/sv2/upstream/mod.rs
@@ -357,10 +357,7 @@ impl Upstream {
             }
         };
 
-        let header = incoming.get_header().ok_or_else(|| {
-            error!("Expected handshake frame but no header found.");
-            TproxyError::fallback(TproxyErrorKind::UnexpectedMessage(0, 0))
-        })?;
+        let header = incoming.get_header();
 
         let payload = incoming.payload();
 
@@ -408,11 +405,7 @@ impl Upstream {
             .map_err(TproxyError::fallback)?;
 
         debug!("Upstream: received frame.");
-        let Some(header) = sv2_frame.get_header() else {
-            return Err(TproxyError::fallback(TproxyErrorKind::UnexpectedMessage(
-                0, 0,
-            )));
-        };
+        let header = sv2_frame.get_header();
 
         match protocol_message_type(header.ext_type(), header.msg_type()) {
             MessageType::Common => {

--- a/pool-apps/jd-server/src/lib/job_declarator/downstream/mod.rs
+++ b/pool-apps/jd-server/src/lib/job_declarator/downstream/mod.rs
@@ -25,7 +25,6 @@ use stratum_apps::{
     network_helpers::noise_stream::NoiseTcpStream,
     stratum_core::{
         common_messages_sv2::MESSAGE_TYPE_SETUP_CONNECTION,
-        framing_sv2,
         handlers_sv2::HandleCommonMessagesFromClientAsync,
         job_declaration_sv2::DeclareMiningJob,
         parsers_sv2::{parse_message_frame_with_tlvs, AnyMessage},
@@ -278,10 +277,7 @@ impl Downstream {
             .await
             .map_err(|e| error::JDSError::disconnect(e, self.downstream_id))?;
 
-        let header = frame.get_header().ok_or_else(|| {
-            error!("SV2 frame missing header");
-            error::JDSError::disconnect(framing_sv2::Error::MissingHeader, self.downstream_id)
-        })?;
+        let header = frame.get_header();
 
         if header.msg_type() == MESSAGE_TYPE_SETUP_CONNECTION {
             self.handle_common_message_frame_from_client(
@@ -341,10 +337,7 @@ impl Downstream {
             .recv()
             .await
             .map_err(|e| error::JDSError::disconnect(e, self.downstream_id))?;
-        let header = sv2_frame.get_header().ok_or_else(|| {
-            error!("SV2 frame missing header");
-            error::JDSError::disconnect(framing_sv2::Error::MissingHeader, self.downstream_id)
-        })?;
+        let header = sv2_frame.get_header();
 
         match protocol_message_type(header.ext_type(), header.msg_type()) {
             MessageType::JobDeclaration => {

--- a/pool-apps/pool/src/lib/downstream/mod.rs
+++ b/pool-apps/pool/src/lib/downstream/mod.rs
@@ -13,7 +13,6 @@ use stratum_apps::{
             extended::ExtendedChannel, group::GroupChannel, standard::StandardChannel,
         },
         common_messages_sv2::MESSAGE_TYPE_SETUP_CONNECTION,
-        framing_sv2,
         handlers_sv2::{HandleCommonMessagesFromClientAsync, HandleExtensionsFromClientAsync},
         parsers_sv2::{parse_message_frame_with_tlvs, AnyMessage, Mining, Tlv},
     },
@@ -265,13 +264,7 @@ impl Downstream {
             .recv()
             .await
             .map_err(|error| PoolError::disconnect(error, self.downstream_id))?;
-        let Some(header) = frame.get_header() else {
-            error!("SV2 frame missing header");
-            return Err(PoolError::disconnect(
-                framing_sv2::Error::MissingHeader,
-                self.downstream_id,
-            ));
-        };
+        let header = frame.get_header();
         // The first ever message received on a new downstream connection
         // should always be a setup connection message.
         if header.msg_type() == MESSAGE_TYPE_SETUP_CONNECTION {
@@ -331,13 +324,7 @@ impl Downstream {
             .recv()
             .await
             .map_err(|error| PoolError::disconnect(error, self.downstream_id))?;
-        let Some(header) = sv2_frame.get_header() else {
-            error!("SV2 frame missing header");
-            return Err(PoolError::disconnect(
-                framing_sv2::Error::MissingHeader,
-                self.downstream_id,
-            ));
-        };
+        let header = sv2_frame.get_header();
 
         match protocol_message_type(header.ext_type(), header.msg_type()) {
             MessageType::Mining => {

--- a/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
@@ -7,7 +7,6 @@ use stratum_apps::{
     key_utils::Secp256k1PublicKey,
     network_helpers::{self, connect_with_noise, resolve_host_port, TCP_CONNECT_TIMEOUT},
     stratum_core::{
-        framing_sv2,
         handlers_sv2::HandleCommonMessagesFromServerAsync,
         parsers_sv2::{AnyMessage, TemplateDistribution},
     },
@@ -253,10 +252,7 @@ impl Sv2Tp {
             .await
             .map_err(PoolError::shutdown)?;
         debug!("Received SV2 frame from Template provider.");
-        let header = sv2_frame.get_header().ok_or_else(|| {
-            error!("SV2 frame missing header");
-            PoolError::shutdown(framing_sv2::Error::MissingHeader)
-        })?;
+        let header = sv2_frame.get_header();
 
         match protocol_message_type(header.ext_type(), header.msg_type()) {
             MessageType::Common => {
@@ -346,10 +342,7 @@ impl Sv2Tp {
             PoolError::shutdown(e)
         })?;
 
-        let header = incoming.get_header().ok_or_else(|| {
-            error!("Handshake frame missing header");
-            PoolError::shutdown(framing_sv2::Error::MissingHeader)
-        })?;
+        let header = incoming.get_header();
         debug!(
             ext_type = ?header.ext_type(),
             msg_type = ?header.msg_type(),


### PR DESCRIPTION
## Summary
- Update sv2-apps call sites for `Sv2Frame::get_header()` returning `Header` directly.
- Remove impossible missing-header branches and obsolete unwrap/expect handling.
- Drop imports that only supported the old missing-header path.

Companion for stratum-mining/stratum#2211.

## Verification
- `cargo fmt --all --check` in `integration-tests`, `miner-apps`, `pool-apps`, and `stratum-apps`
- `git diff --check`
- `cargo check --manifest-path integration-tests/Cargo.toml --config 'patch.crates-io.stratum-core.path="/Users/linghao/Github/stratum/stratum-core"' --config 'patch."https://github.com/stratum-mining/stratum".stratum-core.path="/Users/linghao/Github/stratum/stratum-core"'`

Note: local verification uses the Stratum PR checkout as the patched `stratum-core`, matching the integration-test workflow's companion-PR dependency override.
