### PR TITLE
fix `release-apps.yaml` due to new dependency relationship between `stratum-apps` and `bitcoin_core_sv2`

### DIFF
--- a/.github/workflows/release-apps.yaml
+++ b/.github/workflows/release-apps.yaml
@@ -31,11 +31,11 @@ jobs:
       - name: Login
         run: cargo login ${{ secrets.CRATES_IO_DEPLOY_KEY }}
 
-      - name: Publish stratum-apps crate
-        run: ./scripts/release-apps.sh stratum-apps
-
       - name: Publish bitcoin-core-sv2 crate
         run: ./scripts/release-apps.sh bitcoin-core-sv2
+
+      - name: Publish stratum-apps crate
+        run: ./scripts/release-apps.sh stratum-apps
 
       - name: Publish jd-client-sv2 crate
         run: ./scripts/release-apps.sh miner-apps/jd-client


### PR DESCRIPTION
on #548 we made `bitcoin_core_sv2` become a dependency of `stratum-apps`

after triggering release v0.6.0, we got this error: https://github.com/stratum-mining/sv2-apps/actions/runs/28964134069/job/85944087667

for v0.6.0, `stratum-apps` and `bitcoin_core_sv2` were both published manually and a re-try of the same CI workflow was successful: https://github.com/stratum-mining/sv2-apps/actions/runs/28964134069

this PR prevents the same problem from happening on future releases