### PR TITLE
`bitcoin_core_sv2`: clean up outdated `TemplateData` on `CoinbaseOutputConstraints`

### DIFF
--- a/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/handlers.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/handlers.rs
@@ -42,6 +42,11 @@ impl BitcoinCoreSv2TDP {
             }
         }
 
+        // Capture the current template IDs after the old monitor has exited and
+        // before bootstrapping the new IPC client. This guarantees the snapshot
+        // only contains templates from the previous constraints epoch.
+        let stale_template_ids = self.current_template_ids()?;
+
         self.template_ipc_client_cancellation_token = CancellationToken::new();
         debug!("Created new template_ipc_client_cancellation_token");
 
@@ -54,6 +59,13 @@ impl BitcoinCoreSv2TDP {
             error!("Failed to bootstrap new template IPC client: {:?}", e);
             e
         })?;
+
+        // Retire templates created under previous constraints after the new client
+        // is live. Without this, old template IDs remain usable indefinitely and
+        // accumulate one live template capability per constraints update.
+        if !stale_template_ids.is_empty() {
+            self.process_stale_template_data(stale_template_ids).await;
+        }
 
         debug!("Spawning new monitor_ipc_templates() task");
         self.monitor_ipc_templates();

--- a/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/handlers.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/handlers.rs
@@ -42,10 +42,7 @@ impl BitcoinCoreSv2TDP {
             }
         }
 
-        // Capture the current template IDs after the old monitor has exited and
-        // before bootstrapping the new IPC client. This guarantees the snapshot
-        // only contains templates from the previous constraints epoch.
-        let stale_template_ids = self.current_template_ids()?;
+        self.process_stale_template_data().await?;
 
         self.template_ipc_client_cancellation_token = CancellationToken::new();
         debug!("Created new template_ipc_client_cancellation_token");
@@ -59,13 +56,6 @@ impl BitcoinCoreSv2TDP {
             error!("Failed to bootstrap new template IPC client: {:?}", e);
             e
         })?;
-
-        // Retire templates created under previous constraints after the new client
-        // is live. Without this, old template IDs remain usable indefinitely and
-        // accumulate one live template capability per constraints update.
-        if !stale_template_ids.is_empty() {
-            self.process_stale_template_data(stale_template_ids).await;
-        }
 
         debug!("Spawning new monitor_ipc_templates() task");
         self.monitor_ipc_templates();

--- a/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/mod.rs
@@ -622,6 +622,10 @@ impl BitcoinCoreSv2TDP {
 
     // Spawns a task that processes stale template data after a 10-second grace period.
     //
+    // Takes a snapshot of [`current_template_ids`] at call time, then schedules their
+    // retirement. This ensures the snapshot is always taken at the epoch boundary rather
+    // than relying on the caller to pre-compute the stale set.
+    //
     // The grace period allows in-flight RequestTransactionData and SubmitSolution requests
     // to complete before the template data is retired. After the 10-second window:
     // - Stale template IDs are written to stale_template_ids, causing
@@ -629,7 +633,11 @@ impl BitcoinCoreSv2TDP {
     // - Stale entries are removed from template_data, causing both handle_request_transaction_data
     //   and handle_submit_solution to return errors.
     // - The underlying IPC client capabilities are released via destroy_ipc_client.
-    async fn process_stale_template_data(&self, stale_template_ids: HashSet<u64>) {
+    async fn process_stale_template_data(&self) -> Result<(), BitcoinCoreSv2TDPError> {
+        let stale_template_ids = self.current_template_ids()?;
+        if stale_template_ids.is_empty() {
+            return Ok(());
+        }
         let self_clone = self.clone();
         tokio::task::spawn_local(async move {
             tokio::time::sleep(std::time::Duration::from_secs(10)).await;
@@ -706,5 +714,7 @@ impl BitcoinCoreSv2TDP {
                 }
             }
         });
+
+        Ok(())
     }
 }

--- a/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/mod.rs
@@ -620,9 +620,15 @@ impl BitcoinCoreSv2TDP {
         Ok(wait_next_request)
     }
 
-    // spawns a task that processes the stale template data after 10s
-    // we wait 10s in case there's any incoming RequestTransactionData referring to stale templates
-    // immediately after the chain tip change
+    // Spawns a task that processes stale template data after a 10-second grace period.
+    //
+    // The grace period allows in-flight RequestTransactionData and SubmitSolution requests
+    // to complete before the template data is retired. After the 10-second window:
+    // - Stale template IDs are written to stale_template_ids, causing
+    //   handle_request_transaction_data to return an error.
+    // - Stale entries are removed from template_data, causing both handle_request_transaction_data
+    //   and handle_submit_solution to return errors.
+    // - The underlying IPC client capabilities are released via destroy_ipc_client.
     async fn process_stale_template_data(&self, stale_template_ids: HashSet<u64>) {
         let self_clone = self.clone();
         tokio::task::spawn_local(async move {

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/handlers.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/handlers.rs
@@ -43,6 +43,11 @@ impl BitcoinCoreSv2TDP {
             }
         }
 
+        // Capture the current template IDs after the old monitor has exited and
+        // before bootstrapping the new IPC client. This guarantees the snapshot
+        // only contains templates from the previous constraints epoch.
+        let stale_template_ids = self.current_template_ids()?;
+
         self.template_ipc_client_cancellation_token = CancellationToken::new();
         debug!("Created new template_ipc_client_cancellation_token");
 
@@ -55,6 +60,13 @@ impl BitcoinCoreSv2TDP {
             error!("Failed to bootstrap new template IPC client: {:?}", e);
             e
         })?;
+
+        // Retire templates created under previous constraints after the new client
+        // is live. Without this, old template IDs remain usable indefinitely and
+        // accumulate one live template capability per constraints update.
+        if !stale_template_ids.is_empty() {
+            self.process_stale_template_data(stale_template_ids).await;
+        }
 
         debug!("Spawning new monitor_ipc_templates() task");
         self.monitor_ipc_templates();

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/handlers.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/handlers.rs
@@ -43,10 +43,7 @@ impl BitcoinCoreSv2TDP {
             }
         }
 
-        // Capture the current template IDs after the old monitor has exited and
-        // before bootstrapping the new IPC client. This guarantees the snapshot
-        // only contains templates from the previous constraints epoch.
-        let stale_template_ids = self.current_template_ids()?;
+        self.process_stale_template_data().await?;
 
         self.template_ipc_client_cancellation_token = CancellationToken::new();
         debug!("Created new template_ipc_client_cancellation_token");
@@ -60,13 +57,6 @@ impl BitcoinCoreSv2TDP {
             error!("Failed to bootstrap new template IPC client: {:?}", e);
             e
         })?;
-
-        // Retire templates created under previous constraints after the new client
-        // is live. Without this, old template IDs remain usable indefinitely and
-        // accumulate one live template capability per constraints update.
-        if !stale_template_ids.is_empty() {
-            self.process_stale_template_data(stale_template_ids).await;
-        }
 
         debug!("Spawning new monitor_ipc_templates() task");
         self.monitor_ipc_templates();

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/mod.rs
@@ -653,9 +653,15 @@ impl BitcoinCoreSv2TDP {
         Ok(wait_next_request)
     }
 
-    // spawns a task that processes the stale template data after 10s
-    // we wait 10s in case there's any incoming RequestTransactionData referring to stale templates
-    // immediately after the chain tip change
+    // Spawns a task that processes stale template data after a 10-second grace period.
+    //
+    // The grace period allows in-flight RequestTransactionData and SubmitSolution requests
+    // to complete before the template data is retired. After the 10-second window:
+    // - Stale template IDs are written to stale_template_ids, causing
+    //   handle_request_transaction_data to return an error.
+    // - Stale entries are removed from template_data, causing both handle_request_transaction_data
+    //   and handle_submit_solution to return errors.
+    // - The underlying IPC client capabilities are released via destroy_ipc_client.
     async fn process_stale_template_data(&self, stale_template_ids: HashSet<u64>) {
         let self_clone = self.clone();
         tokio::task::spawn_local(async move {

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/mod.rs
@@ -655,6 +655,10 @@ impl BitcoinCoreSv2TDP {
 
     // Spawns a task that processes stale template data after a 10-second grace period.
     //
+    // Takes a snapshot of [`current_template_ids`] at call time, then schedules their
+    // retirement. This ensures the snapshot is always taken at the epoch boundary rather
+    // than relying on the caller to pre-compute the stale set.
+    //
     // The grace period allows in-flight RequestTransactionData and SubmitSolution requests
     // to complete before the template data is retired. After the 10-second window:
     // - Stale template IDs are written to stale_template_ids, causing
@@ -662,7 +666,11 @@ impl BitcoinCoreSv2TDP {
     // - Stale entries are removed from template_data, causing both handle_request_transaction_data
     //   and handle_submit_solution to return errors.
     // - The underlying IPC client capabilities are released via destroy_ipc_client.
-    async fn process_stale_template_data(&self, stale_template_ids: HashSet<u64>) {
+    async fn process_stale_template_data(&self) -> Result<(), BitcoinCoreSv2TDPError> {
+        let stale_template_ids = self.current_template_ids()?;
+        if stale_template_ids.is_empty() {
+            return Ok(());
+        }
         let self_clone = self.clone();
         tokio::task::spawn_local(async move {
             tokio::time::sleep(std::time::Duration::from_secs(10)).await;
@@ -739,6 +747,8 @@ impl BitcoinCoreSv2TDP {
                 }
             }
         });
+
+        Ok(())
     }
 }
 

--- a/bitcoin-core-sv2/src/unix_capnp/v31x_v30x/template_distribution_protocol/monitors.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x_v30x/template_distribution_protocol/monitors.rs
@@ -147,15 +147,12 @@ impl BitcoinCoreSv2TDP {
                                     info!("⛓️ Chain Tip changed! New prev_hash: {}", new_prev_hash);
                                     debug!("CHAIN TIP CHANGE DETECTED - old: {}, new: {}", current_prev_hash, new_prev_hash);
 
-                                    let stale_template_ids = match self_clone.current_template_ids() {
-                                        Ok(stale_template_ids) => stale_template_ids,
-                                        Err(e) => {
-                                            error!("Failed to collect stale template ids: {:?}", e);
-                                            warn!("Terminating Sv2 Bitcoin Core IPC Connection");
-                                            self_clone.global_cancellation_token.cancel();
-                                            break;
-                                        }
-                                    };
+                                    if let Err(e) = self_clone.process_stale_template_data().await {
+                                        error!("Failed to collect stale template ids: {:?}", e);
+                                        warn!("Terminating Sv2 Bitcoin Core IPC Connection");
+                                        self_clone.global_cancellation_token.cancel();
+                                        break;
+                                    }
 
                                     match self_clone.publish_template(new_template_data, true, true, false).await {
                                         Ok(()) => {
@@ -169,9 +166,6 @@ impl BitcoinCoreSv2TDP {
                                             break;
                                         }
                                     }
-
-                                    // process the stale template data after 10s
-                                    self_clone.process_stale_template_data(stale_template_ids).await;
                                 } else {
                                     // check if the minimum interval has been reached
                                     if let Some(last_sent_template_instant) = self_clone.last_sent_template_instant {


### PR DESCRIPTION
close #611