### PR TITLE
Validate downstream shares against the advertised pow2 difficulty

### DIFF
--- a/integration-tests/Cargo.lock
+++ b/integration-tests/Cargo.lock
@@ -1025,7 +1025,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -1210,7 +1210,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "aes-gcm",
 ]
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -1460,7 +1460,7 @@ dependencies = [
 [[package]]
 name = "codec_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "8.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -1790,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 
 [[package]]
 name = "digest"
@@ -1969,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "extensions_sv2"
 version = "0.2.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -2042,7 +2042,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -2263,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2826,7 +2826,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "9.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -3071,7 +3071,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "11.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -3124,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -3286,7 +3286,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -4400,7 +4400,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -4422,8 +4422,8 @@ dependencies = [
 
 [[package]]
 name = "stratum_translation"
-version = "0.4.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+version = "0.4.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -4470,7 +4470,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sv1_api"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -4538,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "template_distribution_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]

--- a/miner-apps/Cargo.lock
+++ b/miner-apps/Cargo.lock
@@ -839,7 +839,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "aes-gcm",
 ]
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -1228,7 +1228,7 @@ dependencies = [
 [[package]]
 name = "codec_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1266,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "8.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -1476,7 +1476,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 
 [[package]]
 name = "digest"
@@ -1644,7 +1644,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.2.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -1712,7 +1712,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1883,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2405,7 +2405,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "9.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -2597,7 +2597,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "11.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -2637,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2767,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -3793,8 +3793,8 @@ dependencies = [
 
 [[package]]
 name = "stratum_translation"
-version = "0.4.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+version = "0.4.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -3841,7 +3841,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sv1_api"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -3897,7 +3897,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 [[package]]
 name = "template_distribution_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]

--- a/miner-apps/translator/src/lib/sv1/downstream.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream.rs
@@ -68,6 +68,8 @@ pub struct DownstreamData {
     pub channel_id: Option<ChannelId>,
     pub extranonce1: Extranonce<'static>,
     pub extranonce2_len: usize,
+    // Current SV1 share-validation target. This follows the advertised
+    // difficulty sent to the miner, including any SV1 pow2 rounding.
     pub target: Target,
     pub hashrate: Option<Hashrate>,
     #[cfg(feature = "monitoring")]
@@ -79,6 +81,8 @@ pub struct DownstreamData {
     pub user_identity: String,
     pub cached_set_difficulty: Option<json_rpc::Message>,
     pub cached_notify: Option<json_rpc::Message>,
+    // Next advertised SV1 target, applied when the corresponding
+    // mining.set_difficulty is sent with a new mining.notify.
     pub pending_target: Option<Target>,
     pub pending_hashrate: Option<Hashrate>,
     pub stable_hashrate: bool,
@@ -86,7 +90,8 @@ pub struct DownstreamData {
     pub queued_sv1_handshake_messages: Vec<json_rpc::Message>,
     // Stores pending shares to be sent to the sv1_server
     pub pending_share: Option<SubmitShareWithChannelId>,
-    // Tracks the upstream target for this downstream, used for vardiff target comparison
+    // Exact target currently accepted upstream, used to decide whether a
+    // stricter downstream difficulty must wait for a SetTarget response.
     pub upstream_target: Option<Target>,
     // Timestamp of when the last job was received by this downstream, used for keepalive check
     pub last_job_received_time: Option<Instant>,

--- a/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use crate::sv1::sv1_server::{
     PendingTargetUpdate, SV1_MIN_DIFFICULTY_FOR_INTEGER_POWER_OF_TWO_ROUNDING,
 };
-use crate::utils::advertised_target_from_upstream;
 
 use stratum_apps::{
     stratum_core::{
@@ -11,7 +10,10 @@ use stratum_apps::{
         channels_sv2::{target::hash_rate_to_target, Vardiff},
         mining_sv2::{SetTarget, UpdateChannel},
         parsers_sv2::Mining,
-        stratum_translation::sv2_to_sv1::build_sv1_set_difficulty_from_sv2_target_with_integer_power_of_two_rounding,
+        stratum_translation::sv2_to_sv1::{
+            build_sv1_set_difficulty_from_sv2_target_with_integer_power_of_two_rounding,
+            sv1_advertised_target_from_sv2_target,
+        },
     },
     utils::types::{ChannelId, DownstreamId, Hashrate},
 };
@@ -106,10 +108,11 @@ impl Sv1Server {
                         // Store the advertised (pow2 rounded) target so share
                         // validation matches the difficulty the miner was sent.
                         data.set_pending_target(
-                            advertised_target_from_upstream(
+                            sv1_advertised_target_from_sv2_target(
                                 new_target,
                                 SV1_MIN_DIFFICULTY_FOR_INTEGER_POWER_OF_TWO_ROUNDING,
-                            ),
+                            )
+                            .unwrap_or(new_target),
                             d.downstream_id,
                         );
                         data.set_pending_hashrate(Some(new_hashrate), d.downstream_id);

--- a/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::sv1::sv1_server::{
     PendingTargetUpdate, SV1_MIN_DIFFICULTY_FOR_INTEGER_POWER_OF_TWO_ROUNDING,
 };
+use crate::utils::advertised_target_from_upstream;
 
 use stratum_apps::{
     stratum_core::{
@@ -102,7 +103,15 @@ impl Sv1Server {
                 // Always update the downstream's pending target and hashrate
                 if let Some(d) = self.downstreams.get(downstream_id) {
                     _ = d.downstream_data.safe_lock(|data| {
-                        data.set_pending_target(new_target, d.downstream_id);
+                        // Store the advertised (pow2 rounded) target so share
+                        // validation matches the difficulty the miner was sent.
+                        data.set_pending_target(
+                            advertised_target_from_upstream(
+                                new_target,
+                                SV1_MIN_DIFFICULTY_FOR_INTEGER_POWER_OF_TWO_ROUNDING,
+                            ),
+                            d.downstream_id,
+                        );
                         data.set_pending_hashrate(Some(new_hashrate), d.downstream_id);
                         data.stable_hashrate = false;
                     });

--- a/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
@@ -239,25 +239,41 @@ impl Sv1Server {
 
         let mut min_target: Option<Target> = None;
         let mut total_hashrate: Hashrate = 0.0;
+        let shares_per_minute = self.shares_per_minute as f64;
 
         for downstream in self.downstreams.iter() {
+            let downstream_id = *downstream.key();
             let downstream = downstream.value();
-            downstream.downstream_data.super_safe_lock(|d| {
-                let target = *d.pending_target.as_ref().unwrap_or(&d.target);
-                let hashrate = d
-                    .pending_hashrate
-                    .unwrap_or_else(|| d.hashrate.expect("vardiff implies hashrate"));
-
-                min_target = Some(match min_target {
-                    Some(current) => current.min(target),
-                    None => target,
-                });
-
-                total_hashrate += hashrate;
+            let hashrate = downstream.downstream_data.super_safe_lock(|d| {
+                d.pending_hashrate
+                    .unwrap_or_else(|| d.hashrate.expect("vardiff implies hashrate"))
             });
+
+            // UpdateChannel is upstream-facing, so rebuild the exact target from
+            // hashrate instead of reusing the rounded SV1 advertised target.
+            let target = match hash_rate_to_target(hashrate as f64, shares_per_minute) {
+                Ok(target) => target,
+                Err(e) => {
+                    error!(
+                        "Failed to calculate exact target for downstream {} hashrate {}: {:?}",
+                        downstream_id, hashrate, e
+                    );
+                    continue;
+                }
+            };
+
+            min_target = Some(match min_target {
+                Some(current) => current.min(target),
+                None => target,
+            });
+
+            total_hashrate += hashrate;
         }
 
-        let min_target = min_target.expect("at least one downstream must exist");
+        let Some(min_target) = min_target else {
+            warn!("Skipping aggregated UpdateChannel: no exact downstream target is available");
+            return;
+        };
         let downstream_count = self.downstreams.len();
 
         let update_channel = UpdateChannel {
@@ -496,28 +512,48 @@ impl Sv1Server {
         } else {
             let mut total_hashrate: Hashrate = 0.0;
             let mut min_target: Option<Target> = None;
+            let shares_per_minute = self.shares_per_minute as f64;
 
             for downstream in self.downstreams.iter() {
+                let downstream_id = *downstream.key();
                 let downstream = downstream.value();
-                downstream.downstream_data.super_safe_lock(|d| {
-                    let hashrate = d.pending_hashrate.unwrap_or_else(|| {
+                let hashrate = downstream.downstream_data.super_safe_lock(|d| {
+                    d.pending_hashrate.unwrap_or_else(|| {
                         d.hashrate
                             .expect("vardiff implies downstream must have a hashrate")
-                    });
+                    })
+                });
 
-                    let target = *d.pending_target.as_ref().unwrap_or(&d.target);
+                // UpdateChannel is upstream-facing, so rebuild the exact target from
+                // hashrate instead of reusing the rounded SV1 advertised target.
+                let target = match hash_rate_to_target(hashrate as f64, shares_per_minute) {
+                    Ok(target) => target,
+                    Err(e) => {
+                        error!(
+                            "Failed to calculate exact target for downstream {} hashrate {}: {:?}",
+                            downstream_id, hashrate, e
+                        );
+                        continue;
+                    }
+                };
 
-                    total_hashrate += hashrate;
-                    min_target = Some(match min_target {
-                        Some(current) => current.min(target),
-                        None => target,
-                    });
+                total_hashrate += hashrate;
+                min_target = Some(match min_target {
+                    Some(current) => current.min(target),
+                    None => target,
                 });
             }
 
+            let Some(min_target) = min_target else {
+                warn!(
+                    "Skipping aggregated UpdateChannel after downstream state change: no exact downstream target is available"
+                );
+                return;
+            };
+
             AggregatedSnapshot::Active {
                 total_hashrate,
-                min_target: min_target.expect("downstreams is non-empty"),
+                min_target,
             }
         };
 

--- a/miner-apps/translator/src/lib/sv1/sv1_server/downstream_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/downstream_message_handler.rs
@@ -154,13 +154,38 @@ impl IsServer<'static> for Sv1Server {
                 data.target,
                 data.extranonce1.clone().into(),
                 data.version_rolling_mask.clone(),
-                job,
+                job.clone(),
             )
             .unwrap_or(false);
 
             if !is_valid {
                 error!("Invalid share for channel id: {}", channel_id);
                 return Ok(false);
+            }
+
+            // data.target is the advertised (pow2 rounded) difficulty. With
+            // rounding down, shares in the band between the advertised and the
+            // upstream target are expected: acknowledge them to the miner but
+            // do not queue them for upstream submission, as the upstream would
+            // reject them as below its target.
+            if let Some(upstream_target) = data.upstream_target {
+                let meets_upstream = validate_sv1_share(
+                    request,
+                    upstream_target,
+                    data.extranonce1.clone().into(),
+                    data.version_rolling_mask.clone(),
+                    job,
+                )
+                .unwrap_or(false);
+                if !meets_upstream {
+                    debug!(
+                        "Share from downstream {} channel {} meets advertised pow2 difficulty \
+                         but not upstream target; acknowledged downstream, filtered from \
+                         upstream submission",
+                        downstream_id, channel_id
+                    );
+                    return Ok(true);
+                }
             }
 
             data.pending_share = Some(SubmitShareWithChannelId {

--- a/miner-apps/translator/src/lib/sv1/sv1_server/downstream_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/downstream_message_handler.rs
@@ -163,31 +163,6 @@ impl IsServer<'static> for Sv1Server {
                 return Ok(false);
             }
 
-            // data.target is the advertised (pow2 rounded) difficulty. With
-            // rounding down, shares in the band between the advertised and the
-            // upstream target are expected: acknowledge them to the miner but
-            // do not queue them for upstream submission, as the upstream would
-            // reject them as below its target.
-            if let Some(upstream_target) = data.upstream_target {
-                let meets_upstream = validate_sv1_share(
-                    request,
-                    upstream_target,
-                    data.extranonce1.clone().into(),
-                    data.version_rolling_mask.clone(),
-                    job,
-                )
-                .unwrap_or(false);
-                if !meets_upstream {
-                    debug!(
-                        "Share from downstream {} channel {} meets advertised pow2 difficulty \
-                         but not upstream target; acknowledged downstream, filtered from \
-                         upstream submission",
-                        downstream_id, channel_id
-                    );
-                    return Ok(true);
-                }
-            }
-
             data.pending_share = Some(SubmitShareWithChannelId {
                 channel_id,
                 downstream_id,

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -1208,7 +1208,7 @@ impl Sv1Server {
                     d.set_upstream_target(target, downstream_id);
                     // Downstream validation must use the advertised (pow2
                     // rounded) difficulty; upstream_target keeps the exact
-                    // pool target for filtering forwarded shares.
+                    // pool target for vardiff comparisons.
                     d.set_pending_target(
                         sv1_advertised_target_from_sv2_target(
                             target,
@@ -1308,8 +1308,8 @@ impl Sv1Server {
         };
         downstream.downstream_data.super_safe_lock(|d| {
             d.set_upstream_target(target, downstream_id);
-            // See send_set_difficulty_to_all_downstreams: validate downstream
-            // against the advertised pow2 difficulty, filter with the exact one.
+            // See send_set_difficulty_to_all_downstreams: downstream validation
+            // uses the advertised pow2 difficulty.
             d.set_pending_target(
                 sv1_advertised_target_from_sv2_target(
                     target,

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -23,8 +23,8 @@ use crate::{
     error::{self, Action, LoopControl, TproxyError, TproxyErrorKind, TproxyResult},
     sv1::downstream::Downstream,
     utils::{
-        is_mining_authorize, SubmitShareWithChannelId, TproxyMode, AGGREGATED_CHANNEL_ID,
-        KEEPALIVE_JOB_ID_DELIMITER,
+        advertised_target_from_upstream, is_mining_authorize, SubmitShareWithChannelId,
+        TproxyMode, AGGREGATED_CHANNEL_ID, KEEPALIVE_JOB_ID_DELIMITER,
     },
 };
 use async_channel::{unbounded, Receiver, Sender};
@@ -1205,7 +1205,16 @@ impl Sv1Server {
                 let has_channel = entry.value().downstream_data.super_safe_lock(|d| {
                     let channel_id = d.channel_id?;
                     d.set_upstream_target(target, downstream_id);
-                    d.set_pending_target(target, downstream_id);
+                    // Downstream validation must use the advertised (pow2
+                    // rounded) difficulty; upstream_target keeps the exact
+                    // pool target for filtering forwarded shares.
+                    d.set_pending_target(
+                        advertised_target_from_upstream(
+                            target,
+                            SV1_MIN_DIFFICULTY_FOR_INTEGER_POWER_OF_TWO_ROUNDING,
+                        ),
+                        downstream_id,
+                    );
                     if let Some(hr) = derived_hashrate {
                         d.set_pending_hashrate(Some(hr as f32), downstream_id);
                     }
@@ -1297,7 +1306,15 @@ impl Sv1Server {
         };
         downstream.downstream_data.super_safe_lock(|d| {
             d.set_upstream_target(target, downstream_id);
-            d.set_pending_target(target, downstream_id);
+            // See send_set_difficulty_to_all_downstreams: validate downstream
+            // against the advertised pow2 difficulty, filter with the exact one.
+            d.set_pending_target(
+                advertised_target_from_upstream(
+                    target,
+                    SV1_MIN_DIFFICULTY_FOR_INTEGER_POWER_OF_TWO_ROUNDING,
+                ),
+                downstream_id,
+            );
             // Update pending hashrate derived from the upstream target
             if let Some(hr) = derived_hashrate {
                 d.set_pending_hashrate(Some(hr as f32), downstream_id);

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -23,8 +23,8 @@ use crate::{
     error::{self, Action, LoopControl, TproxyError, TproxyErrorKind, TproxyResult},
     sv1::downstream::Downstream,
     utils::{
-        advertised_target_from_upstream, is_mining_authorize, SubmitShareWithChannelId,
-        TproxyMode, AGGREGATED_CHANNEL_ID, KEEPALIVE_JOB_ID_DELIMITER,
+        is_mining_authorize, SubmitShareWithChannelId, TproxyMode, AGGREGATED_CHANNEL_ID,
+        KEEPALIVE_JOB_ID_DELIMITER,
     },
 };
 use async_channel::{unbounded, Receiver, Sender};
@@ -65,6 +65,7 @@ use stratum_apps::{
             sv2_to_sv1::{
                 build_sv1_notify_from_sv2,
                 build_sv1_set_difficulty_from_sv2_target_with_integer_power_of_two_rounding,
+                sv1_advertised_target_from_sv2_target,
             },
         },
         sv1_api::{json_rpc, server_to_client, utils::HexU32Be, IsServer},
@@ -1209,10 +1210,11 @@ impl Sv1Server {
                     // rounded) difficulty; upstream_target keeps the exact
                     // pool target for filtering forwarded shares.
                     d.set_pending_target(
-                        advertised_target_from_upstream(
+                        sv1_advertised_target_from_sv2_target(
                             target,
                             SV1_MIN_DIFFICULTY_FOR_INTEGER_POWER_OF_TWO_ROUNDING,
-                        ),
+                        )
+                        .unwrap_or(target),
                         downstream_id,
                     );
                     if let Some(hr) = derived_hashrate {
@@ -1309,10 +1311,11 @@ impl Sv1Server {
             // See send_set_difficulty_to_all_downstreams: validate downstream
             // against the advertised pow2 difficulty, filter with the exact one.
             d.set_pending_target(
-                advertised_target_from_upstream(
+                sv1_advertised_target_from_sv2_target(
                     target,
                     SV1_MIN_DIFFICULTY_FOR_INTEGER_POWER_OF_TWO_ROUNDING,
-                ),
+                )
+                .unwrap_or(target),
                 downstream_id,
             );
             // Update pending hashrate derived from the upstream target

--- a/miner-apps/translator/src/lib/utils.rs
+++ b/miner-apps/translator/src/lib/utils.rs
@@ -16,7 +16,6 @@ use stratum_apps::{
             merkle_root::merkle_root_from_path,
             target::{bytes_to_hex, u256_to_block_hash},
         },
-        stratum_translation::sv2_to_sv1::sv1_advertised_difficulty_from_sv2_target,
         sv1_api::{
             client_to_server::{self, Submit},
             json_rpc,
@@ -289,46 +288,4 @@ pub(crate) fn tlv_compatible_username(s: &str) -> &str {
         s, MAX_USER_IDENTITY_BYTES, len, truncated
     );
     truncated
-}
-
-/// Target corresponding to the difficulty actually advertised downstream for
-/// `upstream_target` under integer power-of-two `mining.set_difficulty`
-/// rounding. For a power-of-two difficulty `d` this is diff1 >> log2(d), which
-/// matches the target any firmware derives from the integer difficulty. Below
-/// the rounding threshold the difficulty passes through unchanged, so the
-/// upstream target itself is returned.
-///
-/// Downstream shares must be validated against this target (what the miner was
-/// told), while `upstream_target` decides which of those shares are forwarded:
-/// with difficulty rounded down, shares in the band between the two are
-/// acknowledged downstream but filtered from upstream submission.
-pub fn advertised_target_from_upstream(upstream_target: Target, rounding_threshold: f64) -> Target {
-    let advertised =
-        match sv1_advertised_difficulty_from_sv2_target(upstream_target, rounding_threshold) {
-            Ok(d) => d,
-            Err(_) => return upstream_target,
-        };
-    if advertised < rounding_threshold || advertised < 1.0 {
-        return upstream_target;
-    }
-
-    let shift = (advertised as u64).trailing_zeros() as usize;
-    // diff1 (difficulty-1 target) in big endian, right-shifted by log2(advertised)
-    let mut be = [0u8; 32];
-    be[4] = 0xff;
-    be[5] = 0xff;
-    let byte_shift = shift / 8;
-    let bit_shift = shift % 8;
-    let mut out = [0u8; 32];
-    for i in (byte_shift..32).rev() {
-        let src = i - byte_shift;
-        let mut byte = be[src] >> bit_shift;
-        if bit_shift > 0 && src > 0 {
-            byte |= be[src - 1] << (8 - bit_shift);
-        }
-        out[i] = byte;
-    }
-    let mut le = out;
-    le.reverse();
-    Target::from_le_bytes(le)
 }

--- a/miner-apps/translator/src/lib/utils.rs
+++ b/miner-apps/translator/src/lib/utils.rs
@@ -16,6 +16,7 @@ use stratum_apps::{
             merkle_root::merkle_root_from_path,
             target::{bytes_to_hex, u256_to_block_hash},
         },
+        stratum_translation::sv2_to_sv1::sv1_advertised_difficulty_from_sv2_target,
         sv1_api::{
             client_to_server::{self, Submit},
             json_rpc,
@@ -288,4 +289,46 @@ pub(crate) fn tlv_compatible_username(s: &str) -> &str {
         s, MAX_USER_IDENTITY_BYTES, len, truncated
     );
     truncated
+}
+
+/// Target corresponding to the difficulty actually advertised downstream for
+/// `upstream_target` under integer power-of-two `mining.set_difficulty`
+/// rounding. For a power-of-two difficulty `d` this is diff1 >> log2(d), which
+/// matches the target any firmware derives from the integer difficulty. Below
+/// the rounding threshold the difficulty passes through unchanged, so the
+/// upstream target itself is returned.
+///
+/// Downstream shares must be validated against this target (what the miner was
+/// told), while `upstream_target` decides which of those shares are forwarded:
+/// with difficulty rounded down, shares in the band between the two are
+/// acknowledged downstream but filtered from upstream submission.
+pub fn advertised_target_from_upstream(upstream_target: Target, rounding_threshold: f64) -> Target {
+    let advertised =
+        match sv1_advertised_difficulty_from_sv2_target(upstream_target, rounding_threshold) {
+            Ok(d) => d,
+            Err(_) => return upstream_target,
+        };
+    if advertised < rounding_threshold || advertised < 1.0 {
+        return upstream_target;
+    }
+
+    let shift = (advertised as u64).trailing_zeros() as usize;
+    // diff1 (difficulty-1 target) in big endian, right-shifted by log2(advertised)
+    let mut be = [0u8; 32];
+    be[4] = 0xff;
+    be[5] = 0xff;
+    let byte_shift = shift / 8;
+    let bit_shift = shift % 8;
+    let mut out = [0u8; 32];
+    for i in (byte_shift..32).rev() {
+        let src = i - byte_shift;
+        let mut byte = be[src] >> bit_shift;
+        if bit_shift > 0 && src > 0 {
+            byte |= be[src - 1] << (8 - bit_shift);
+        }
+        out[i] = byte;
+    }
+    let mut le = out;
+    le.reverse();
+    Target::from_le_bytes(le)
 }

--- a/pool-apps/Cargo.lock
+++ b/pool-apps/Cargo.lock
@@ -273,7 +273,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -430,7 +430,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "aes-gcm",
 ]
@@ -542,7 +542,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -612,7 +612,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "codec_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -640,7 +640,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "8.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -808,7 +808,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 
 [[package]]
 name = "digest"
@@ -937,7 +937,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.2.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -998,7 +998,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1133,7 +1133,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -1534,7 +1534,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "9.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -1654,7 +1654,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "11.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -1818,7 +1818,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2478,7 +2478,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -2545,7 +2545,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "template_distribution_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]

--- a/stratum-apps/Cargo.lock
+++ b/stratum-apps/Cargo.lock
@@ -774,7 +774,7 @@ checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
 [[package]]
 name = "binary_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "buffer_sv2",
  "derive_codec_sv2",
@@ -940,7 +940,7 @@ dependencies = [
 [[package]]
 name = "buffer_sv2"
 version = "3.0.1"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "aes-gcm",
 ]
@@ -1071,7 +1071,7 @@ dependencies = [
 [[package]]
 name = "channels_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -1117,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "codec_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1140,7 +1140,7 @@ dependencies = [
 [[package]]
 name = "common_messages_sv2"
 version = "8.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "derive_codec_sv2"
 version = "1.1.3"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 
 [[package]]
 name = "digest"
@@ -1482,7 +1482,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "extensions_sv2"
 version = "0.2.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -1540,7 +1540,7 @@ dependencies = [
 [[package]]
 name = "framing_sv2"
 version = "7.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "buffer_sv2",
@@ -1711,7 +1711,7 @@ dependencies = [
 [[package]]
 name = "handlers_sv2"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -2140,7 +2140,7 @@ dependencies = [
 [[package]]
 name = "job_declaration_sv2"
 version = "9.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -2328,7 +2328,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 [[package]]
 name = "mining_sv2"
 version = "11.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]
@@ -2368,7 +2368,7 @@ dependencies = [
 [[package]]
 name = "noise_sv2"
 version = "1.4.2"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "aes-gcm",
  "chacha20poly1305",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "parsers_sv2"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "common_messages_sv2",
@@ -3442,7 +3442,7 @@ dependencies = [
 [[package]]
 name = "stratum-core"
 version = "0.5.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -3464,8 +3464,8 @@ dependencies = [
 
 [[package]]
 name = "stratum_translation"
-version = "0.4.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+version = "0.4.1"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -3506,7 +3506,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sv1_api"
 version = "5.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
  "bitcoin",
@@ -3562,7 +3562,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 [[package]]
 name = "template_distribution_sv2"
 version = "6.0.0"
-source = "git+https://github.com/stratum-mining/stratum?branch=main#3519557cd154d471d3efeff72473735f9f4ea58c"
+source = "git+https://github.com/stratum-mining/stratum?branch=main#1ae678eac277bd9f8f5f2139a22dd36dce514873"
 dependencies = [
  "binary_sv2",
 ]


### PR DESCRIPTION
This pull request is dependent on https://github.com/stratum-mining/stratum/pull/2227

Validate downstream shares against the advertised pow2 difficulty and filter the band below the upstream target.

mining.set_difficulty is rounded to an integer power of two, but shares were validated against the exact upstream target. With difficulty rounded down (stratum fix-sv1-difficulty-rounding) shares between the advertised difficulty and the upstream target are expected: validate against the advertised target so honest miners are acknowledged, track the exact upstream target separately, and filter the band from upstream submission with debug logging. With the previous round-up behaviour the band is empty and these changes are inert; without them, round-down would surface the band as miner-visible share rejections.