### PR TITLE
refactor(translator): replace monolithic start loop with TranslatorRuntime typestate machine

### DIFF
--- a/integration-tests/lib/mod.rs
+++ b/integration-tests/lib/mod.rs
@@ -451,7 +451,7 @@ pub async fn start_sv2_translator_with_user_identities(
     let translator_v2 = translator_sv2::TranslatorSv2::new(config);
     let clone_translator_v2 = translator_v2.clone();
     tokio::spawn(async move {
-        clone_translator_v2.start().await;
+        let _ = clone_translator_v2.start().await;
     });
     (translator_v2, listening_address, monitoring_address)
 }
@@ -528,7 +528,7 @@ pub async fn start_sv2_translator_with_user_identity(
     let translator_v2 = translator_sv2::TranslatorSv2::new(config);
     let clone_translator_v2 = translator_v2.clone();
     tokio::spawn(async move {
-        clone_translator_v2.start().await;
+        let _ = clone_translator_v2.start().await;
     });
     (translator_v2, listening_address, monitoring_address)
 }

--- a/miner-apps/translator/src/lib/error.rs
+++ b/miner-apps/translator/src/lib/error.rs
@@ -61,6 +61,12 @@ pub enum Action {
     Shutdown,
 }
 
+impl Action {
+    pub fn is_shutdown(self) -> bool {
+        matches!(self, Self::Shutdown)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LoopControl {
     Continue,

--- a/miner-apps/translator/src/lib/mod.rs
+++ b/miner-apps/translator/src/lib/mod.rs
@@ -10,36 +10,22 @@
 //! provides the `start` method as the main entry point for running the translator service.
 //! It relies on several sub-modules (`config`, `downstream_sv1`, `upstream_sv2`, `proxy`, `status`,
 //! etc.) for specialized functionalities.
-#![allow(clippy::module_inception)]
-use async_channel::{Receiver, Sender, unbounded};
-use std::{
-    net::SocketAddr,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    time::Duration,
-};
-use stratum_apps::{
-    fallback_coordinator::FallbackCoordinator,
-    payout::PayoutMode,
-    task_manager::TaskManager,
-    utils::types::{GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS, Sv2Frame},
+use error::TproxyErrorKind;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
 };
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info};
 
 pub use stratum_apps::stratum_core::sv1_api::server_to_client;
 
 use config::TranslatorConfig;
 
-use crate::{
-    error::TproxyErrorKind,
-    sv1::Sv1Server,
-    sv2::{ChannelManager, Upstream},
-    utils::{TproxyMode, UpstreamEntry},
-};
+use crate::utils::TproxyMode;
+
+use translator_runtime::{Init, RuntimeEvent, TranslatorRuntime};
 
 pub mod config;
 pub mod error;
@@ -48,6 +34,7 @@ mod io_task;
 mod monitoring;
 pub mod sv1;
 pub mod sv2;
+mod translator_runtime;
 pub mod utils;
 
 /// The main struct that manages the SV1/SV2 translator.
@@ -74,337 +61,77 @@ impl TranslatorSv2 {
         }
     }
 
-    fn payout_mode(&self, user_identity: &str) -> Result<Option<PayoutMode>, TproxyErrorKind> {
-        let expected_payout_distribution = self
-            .config
-            .expected_payout_distribution(user_identity)
-            .map_err(|e| {
-                TproxyErrorKind::InvalidUserIdentity(format!(
-                    "invalid payout user_identity `{user_identity}`: {e}"
-                ))
-            })?;
-        if let Some(distribution) = &expected_payout_distribution {
-            info!(
-                "Payout verification enabled for configured user_identity: {}",
-                distribution
-            );
-        }
-        Ok(expected_payout_distribution)
+    /// Marks the Translator Proxy as stopped and releases anyone blocked on
+    /// [`TranslatorSv2::shutdown`].
+    ///
+    /// Called by [`TranslatorRuntime::shutdown`] once teardown completes, and directly by
+    /// [`TranslatorSv2::start`] on the failure path where no runtime exists to tear down.
+    fn mark_stopped(&self) {
+        self.is_alive.store(false, Ordering::Release);
+        self.cancellation_token.cancel();
+        self.shutdown_notify.notify_waiters();
     }
 
-    /// Starts the translator.
+    /// Starts the main event loop for the Translator Proxy.
     ///
-    /// This method starts the main event loop, which handles connections,
-    /// protocol translation, job management, and status reporting.
-    pub async fn start(self) {
+    /// The startup and execution sequence follows:
+    /// 1. **Initialize:** Sets up the translator runtime state machine ([`TranslatorRuntime`]).
+    /// 2. **Bootstrap:** Configures internal channels, initializes the Channel Manager,
+    ///    instantiates the SV1 server, and establishes upstream SV2 connections.
+    /// 3. **Run & Loop:** Activates all background loops/servers (SV1, Channel Manager, Monitoring)
+    ///    and handles fallbacks or graceful shutdown.
+    /// 4. **Teardown:** Performs a coordinated graceful cleanup of all services and tasks upon
+    ///    termination.
+    pub async fn start(&self) -> Result<(), TproxyErrorKind> {
         info!("Starting Translator Proxy...");
 
-        let cancellation_token = self.cancellation_token.clone();
-        let mut fallback_coordinator = FallbackCoordinator::new();
-        let tproxy_mode = TproxyMode::from(self.config.aggregate_channels);
-
-        let task_manager = Arc::new(TaskManager::new());
-
-        let (channel_manager_to_upstream_sender, channel_manager_to_upstream_receiver) =
-            unbounded();
-        let (upstream_to_channel_manager_sender, upstream_to_channel_manager_receiver) =
-            unbounded();
-        let (channel_manager_to_sv1_server_sender, channel_manager_to_sv1_server_receiver) =
-            unbounded();
-        let (sv1_server_to_channel_manager_sender, sv1_server_to_channel_manager_receiver) =
-            unbounded();
-
-        debug!("All inter-subsystem channels initialized");
-
-        let mut upstream_addresses = self
-            .config
-            .upstreams
-            .iter()
-            .map(|u| UpstreamEntry {
-                host: u.address.clone(),
-                port: u.port,
-                authority_pubkey: u.authority_pubkey,
-                tried_or_flagged: false,
-                user_identity: u.user_identity.clone(),
-            })
-            .collect::<Vec<_>>();
-
-        let downstream_addr: SocketAddr = SocketAddr::new(
-            self.config.downstream_address.parse().unwrap(),
-            self.config.downstream_port,
-        );
-
-        let mut sv1_server = Arc::new(Sv1Server::new(
-            downstream_addr,
-            channel_manager_to_sv1_server_receiver,
-            sv1_server_to_channel_manager_sender,
-            self.config.clone(),
-            tproxy_mode,
-        ));
-
-        info!("Initializing upstream connection...");
-
-        let mut channel_manager: Arc<ChannelManager> = Arc::new(ChannelManager::new(
-            channel_manager_to_upstream_sender,
-            upstream_to_channel_manager_receiver,
-            channel_manager_to_sv1_server_sender.clone(),
-            sv1_server_to_channel_manager_receiver,
-            self.config.supported_extensions.clone(),
-            self.config.required_extensions.clone(),
-            tproxy_mode,
-            #[cfg(feature = "monitoring")]
-            self.config.downstream_difficulty_config.enable_vardiff,
-        ));
-
-        if let Err(e) = self
-            .initialize_upstream(
-                &mut upstream_addresses,
-                channel_manager_to_upstream_receiver.clone(),
-                upstream_to_channel_manager_sender.clone(),
-                cancellation_token.clone(),
-                fallback_coordinator.clone(),
-                task_manager.clone(),
-                sv1_server.clone(),
-                self.config.required_extensions.clone(),
-                channel_manager.clone(),
-            )
-            .await
-        {
-            error!("Failed to initialize any upstream connection: {e:?}");
-            self.shutdown_notify.notify_waiters();
-            self.is_alive.store(false, Ordering::Release);
-            return;
-        }
-
-        info!("Launching ChannelManager tasks...");
-        ChannelManager::run_channel_manager_tasks(
-            channel_manager.clone(),
-            cancellation_token.clone(),
-            fallback_coordinator.clone(),
-            task_manager.clone(),
-        )
-        .await;
-
-        // Start monitoring tasks if configured
-        #[cfg(feature = "monitoring")]
-        if let Some(monitoring_addr) = self.config.monitoring_address() {
-            info!("Initializing monitoring server on http://{monitoring_addr}");
-            if let Err(e) = self.start_monitoring_tasks(
-                monitoring_addr,
-                channel_manager.clone(),
-                sv1_server.clone(),
-                cancellation_token.clone(),
-                fallback_coordinator.clone(),
-                task_manager.clone(),
-            ) {
-                error!("Failed to initialize monitoring tasks: {e}");
-                cancellation_token.cancel();
-            }
-        }
-
-        let mut fallback_token = fallback_coordinator.token();
-
-        loop {
-            tokio::select! {
-                biased;
-                _ = cancellation_token.cancelled() => {
-                    break;
-                }
-                _ = fallback_token.cancelled() => {
-                    info!("Preparing fallback");
-                                // Trigger fallback and wait for all components to finish cleanup
-                                fallback_coordinator.trigger_fallback_and_wait().await;
-                                info!("All components finished fallback cleanup");
-
-                                // Create a fresh FallbackCoordinator for the reconnection attempt
-                                fallback_coordinator = FallbackCoordinator::new();
-                                fallback_token = fallback_coordinator.token();
-
-                                // Recreate channels and components (old ones were closed during fallback)
-                                let (channel_manager_to_upstream_sender, channel_manager_to_upstream_receiver) =
-                                    unbounded();
-                                let (upstream_to_channel_manager_sender, upstream_to_channel_manager_receiver) =
-                                    unbounded();
-                                let (channel_manager_to_sv1_server_sender, channel_manager_to_sv1_server_receiver) =
-                                    unbounded();
-                                let (sv1_server_to_channel_manager_sender, sv1_server_to_channel_manager_receiver) =
-                                    unbounded();
-
-                                sv1_server = Arc::new(Sv1Server::new(
-                                    downstream_addr,
-                                    channel_manager_to_sv1_server_receiver,
-                                    sv1_server_to_channel_manager_sender,
-                                    self.config.clone(),
-                                    tproxy_mode
-                                ));
-
-                                channel_manager = Arc::new(ChannelManager::new(
-                                    channel_manager_to_upstream_sender,
-                                    upstream_to_channel_manager_receiver,
-                                    channel_manager_to_sv1_server_sender,
-                                    sv1_server_to_channel_manager_receiver,
-                                    self.config.supported_extensions.clone(),
-                                    self.config.required_extensions.clone(),
-                                    tproxy_mode,
-                                    #[cfg(feature = "monitoring")]
-                                    self.config.downstream_difficulty_config.enable_vardiff,
-                                ));
-
-                                if let Err(e) = self.initialize_upstream(
-                                    &mut upstream_addresses,
-                                    channel_manager_to_upstream_receiver,
-                                    upstream_to_channel_manager_sender,
-                                    cancellation_token.clone(),
-                                    fallback_coordinator.clone(),
-                                    task_manager.clone(),
-                                    sv1_server.clone(),
-                                    self.config.required_extensions.clone(),
-                                    channel_manager.clone(),
-                                )
-                                .await
-                                {
-                                    error!("Couldn't perform fallback, shutting system down: {e:?}");
-                                    cancellation_token.cancel();
-                                    break;
-                                }
-
-                                info!("Launching ChannelManager tasks...");
-                                ChannelManager::run_channel_manager_tasks(
-                                    channel_manager.clone(),
-                                    cancellation_token.clone(),
-                                    fallback_coordinator.clone(),
-                                    task_manager.clone(),
-                                )
-                                .await;
-
-                                // Recreate monitoring tasks with new components
-                                #[cfg(feature = "monitoring")]
-                                if let Some(monitoring_addr) = self.config.monitoring_address() {
-                                    info!("Reinitializing monitoring server on http://{monitoring_addr}");
-                                    if let Err(e) = self.start_monitoring_tasks(
-                                        monitoring_addr,
-                                        channel_manager.clone(),
-                                        sv1_server.clone(),
-                                        cancellation_token.clone(),
-                                        fallback_coordinator.clone(),
-                                        task_manager.clone(),
-                                    ) {
-                                        error!("Failed to reinitialize monitoring tasks: {e}");
-                                        cancellation_token.cancel();
-                                        break;
-                                    }
-                                }
-
-                                info!("Upstream and ChannelManager restarted successfully.");
-                }
-            }
-        }
-
-        warn!(
-            "Graceful shutdown: waiting {} seconds for tasks to finish",
-            GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
-        );
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS),
-            task_manager.join_all(),
-        )
-        .await
-        {
-            Ok(_) => {
-                info!("All tasks joined cleanly");
-            }
-            Err(_) => {
-                warn!(
-                    "Tasks did not finish within {} seconds, aborting",
-                    GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
-                );
-                task_manager.abort_all().await;
-                info!("Joining aborted tasks...");
-                task_manager.join_all().await;
-                warn!("Forced shutdown complete");
-            }
-        }
-        self.shutdown_notify.notify_waiters();
-        self.is_alive.store(false, Ordering::Release);
-        info!("TranslatorSv2 shutdown complete.");
-    }
-
-    #[cfg(feature = "monitoring")]
-    fn start_monitoring_tasks(
-        &self,
-        monitoring_addr: SocketAddr,
-        channel_manager: Arc<ChannelManager>,
-        sv1_server: Arc<Sv1Server>,
-        cancellation_token: CancellationToken,
-        fallback_coordinator: FallbackCoordinator,
-        task_manager: Arc<TaskManager>,
-    ) -> Result<(), TproxyErrorKind> {
-        let refresh_interval =
-            Duration::from_secs(self.config.monitoring_cache_refresh_secs().unwrap_or(15));
-
-        let monitoring_server = stratum_apps::monitoring::MonitoringServer::new(
-            monitoring_addr,
-            Some(channel_manager.clone()), // SV2 channels opened with servers
-            None,                          /* no SV2 channels opened with clients (SV1
-                                            * handled separately) */
-            refresh_interval,
-        )
-        .map_err(|e| {
-            TproxyErrorKind::General(format!("failed to initialize monitoring server: {e}"))
-        })?
-        .with_sv1_monitoring(sv1_server.clone()) // SV1 client connections
-        .map_err(|e| TproxyErrorKind::General(format!("failed to add SV1 monitoring: {e}")))?;
-
-        // Create shutdown signal using cancellation token
-        let cancellation_token_clone = cancellation_token.clone();
-        let fallback_coordinator_token = fallback_coordinator.token();
-        let shutdown_signal = async move {
-            tokio::select! {
-                _ = cancellation_token_clone.cancelled() => {
-                    info!("Monitoring server: received shutdown signal.");
-                }
-                _ = fallback_coordinator_token.cancelled() => {
-                    info!("Monitoring server: fallback triggered.");
-                }
+        let runtime = match TranslatorRuntime::<Init>::new(self.clone()) {
+            Ok(runtime) => runtime,
+            Err(e) => {
+                self.mark_stopped();
+                return Err(e);
             }
         };
 
-        let monitoring_fallback = fallback_coordinator.clone();
-        task_manager.spawn({
-            let cancellation_token = cancellation_token.clone();
-            async move {
-                // we just spawned a new task that's relevant to fallback coordination
-                // so register it with the fallback coordinator
-                let fallback_handler = monitoring_fallback.register();
+        let mut running = match runtime.bootstrap().await {
+            Ok(running) => running,
+            Err(bootstrap_err) => {
+                let (kind, runtime) = bootstrap_err.into_parts();
+                error!(?kind, "Failed to bootstrap Translator Proxy");
+                runtime.shutdown().await;
+                return Err(kind);
+            }
+        };
 
-                if let Err(e) = monitoring_server.run(shutdown_signal).await {
-                    error!("Monitoring server error: {:?}", e);
-                    cancellation_token.cancel();
+        loop {
+            match running.wait().await {
+                RuntimeEvent::Shutdown => {
+                    running.shutdown().await;
+                    return Ok(());
                 }
+                RuntimeEvent::Fallback => {
+                    let sv1_ready_runtime = running.cleanup_for_fallback().await;
 
-                // signal fallback coordinator that this task has completed its cleanup
-                fallback_handler.done();
-                info!("Monitoring server task exited and signaled fallback coordinator");
+                    running = match sv1_ready_runtime.try_upstream().await {
+                        Ok(new_running) => match new_running.start_services().await {
+                            Ok(running) => running,
+                            Err(bootstrap_err) => {
+                                let (kind, runtime) = bootstrap_err.into_parts();
+                                error!(?kind, "Failed to start services for Translator Proxy");
+                                runtime.shutdown().await;
+                                return Err(kind);
+                            }
+                        },
+                        Err(bootstrap_err) => {
+                            let (kind, runtime) = bootstrap_err.into_parts();
+                            error!(?kind, "Failed to reconnect Translator Proxy");
+                            runtime.shutdown().await;
+                            return Err(kind);
+                        }
+                    };
+                }
             }
-        });
-
-        let telemetry_fallback = fallback_coordinator.clone();
-        task_manager.spawn({
-            let cancellation_token = cancellation_token.clone();
-            async move {
-                let fallback_token = telemetry_fallback.token();
-                let fallback_handler = telemetry_fallback.register();
-
-                sv1_server
-                    .run_miner_telemetry_loop(refresh_interval, cancellation_token, fallback_token)
-                    .await;
-
-                fallback_handler.done();
-                info!("SV1 miner telemetry task exited and signaled fallback coordinator");
-            }
-        });
-
-        Ok(())
+        }
     }
 
     pub async fn shutdown(&self) {
@@ -417,137 +144,6 @@ impl TranslatorSv2 {
         self.cancellation_token.cancel();
         notified.await;
     }
-
-    /// Initializes the upstream connection list, handling retries, fallbacks, and flagging.
-    ///
-    /// Upstreams are tried sequentially, each receiving a fixed number of retries before we
-    /// advance to the next entry. This ensures we exhaust every healthy upstream before shutting
-    /// the translator down.
-    ///
-    /// The `tried_or_flagged` flag in the `UpstreamEntry` acts as the upstream's state machine:
-    ///  `false` means "never tried", while `true` means "already connected or marked as
-    /// malicious". Once an upstream is flagged we skip it on future loops
-    /// to avoid hammering known-bad endpoints during failover.
-    #[allow(clippy::too_many_arguments)]
-    pub async fn initialize_upstream(
-        &self,
-        upstreams: &mut [UpstreamEntry],
-        channel_manager_to_upstream_receiver: Receiver<Sv2Frame>,
-        upstream_to_channel_manager_sender: Sender<Sv2Frame>,
-        cancellation_token: CancellationToken,
-        fallback_coordinator: FallbackCoordinator,
-        task_manager: Arc<TaskManager>,
-        sv1_server_instance: Arc<Sv1Server>,
-        required_extensions: Vec<u16>,
-        channel_manager_instance: Arc<ChannelManager>,
-    ) -> Result<(), TproxyErrorKind> {
-        const MAX_RETRIES: usize = 3;
-        let upstream_len = upstreams.len();
-        for (i, upstream_entry) in upstreams.iter_mut().enumerate() {
-            // Skip upstreams already marked as malicious. We’ve previously failed or
-            // blacklisted them, so no need to warn or attempt reconnecting again.
-            if upstream_entry.tried_or_flagged {
-                debug!(
-                    "Upstream previously marked as malicious, skipping initial attempt warnings."
-                );
-                continue;
-            }
-
-            info!(
-                "Trying upstream {} of {}: {}:{}",
-                i + 1,
-                upstream_len,
-                upstream_entry.host,
-                upstream_entry.port
-            );
-            for attempt in 1..=MAX_RETRIES {
-                info!("Connection attempt {}/{}...", attempt, MAX_RETRIES);
-                tokio::time::sleep(Duration::from_secs(1)).await;
-
-                match try_initialize_upstream(
-                    upstream_entry,
-                    upstream_to_channel_manager_sender.clone(),
-                    channel_manager_to_upstream_receiver.clone(),
-                    cancellation_token.clone(),
-                    fallback_coordinator.clone(),
-                    task_manager.clone(),
-                    required_extensions.clone(),
-                )
-                .await
-                {
-                    Ok(()) => {
-                        let user_identity = upstream_entry.user_identity.to_string();
-                        let payout_mode = self.payout_mode(&user_identity)?;
-
-                        channel_manager_instance.set_expected_payout_distribution(payout_mode);
-                        sv1_server_instance.set_user_identity(user_identity);
-
-                        // starting sv1 server instance
-                        if let Err(e) = sv1_server_instance
-                            .clone()
-                            .start(
-                                cancellation_token.clone(),
-                                fallback_coordinator.clone(),
-                                task_manager.clone(),
-                            )
-                            .await
-                        {
-                            error!("SV1 server startup failed: {e:?}");
-                            return Err(e.kind);
-                        }
-
-                        upstream_entry.tried_or_flagged = true;
-                        return Ok(());
-                    }
-                    Err(e) => {
-                        warn!(
-                            "Attempt {}/{} failed for {}:{}: {:?}",
-                            attempt, MAX_RETRIES, upstream_entry.host, upstream_entry.port, e
-                        );
-                        if attempt == MAX_RETRIES {
-                            warn!(
-                                "Max retries reached for {}:{}, moving to next upstream",
-                                upstream_entry.host, upstream_entry.port
-                            );
-                        }
-                    }
-                }
-            }
-            upstream_entry.tried_or_flagged = true;
-        }
-
-        tracing::error!("All upstreams failed after {} retries each", MAX_RETRIES);
-        Err(TproxyErrorKind::CouldNotInitiateSystem)
-    }
-}
-
-// Attempts to initialize a single upstream.
-#[allow(clippy::too_many_arguments)]
-#[cfg_attr(not(test), hotpath::measure)]
-async fn try_initialize_upstream(
-    upstream_addr: &UpstreamEntry,
-    upstream_to_channel_manager_sender: Sender<Sv2Frame>,
-    channel_manager_to_upstream_receiver: Receiver<Sv2Frame>,
-    cancellation_token: CancellationToken,
-    fallback_coordinator: FallbackCoordinator,
-    task_manager: Arc<TaskManager>,
-    required_extensions: Vec<u16>,
-) -> Result<(), TproxyErrorKind> {
-    let upstream = Upstream::new(
-        upstream_addr,
-        upstream_to_channel_manager_sender,
-        channel_manager_to_upstream_receiver,
-        cancellation_token.clone(),
-        fallback_coordinator.clone(),
-        task_manager.clone(),
-        required_extensions,
-    )
-    .await?;
-
-    upstream
-        .start(cancellation_token, fallback_coordinator, task_manager)
-        .await?;
-    Ok(())
 }
 
 impl Drop for TranslatorSv2 {

--- a/miner-apps/translator/src/lib/translator_runtime.rs
+++ b/miner-apps/translator/src/lib/translator_runtime.rs
@@ -1,0 +1,592 @@
+//! ## Translator Runtime Module
+//!
+//! Provides [`TranslatorRuntime`], a structured state-machine orchestrating the translator proxy's
+//! initialization, bootstrap stages, background service loops, and graceful teardown or fallback.
+
+use std::{net::SocketAddr, sync::Arc, time::Duration};
+
+use async_channel::{Receiver, Sender, unbounded};
+use stratum_apps::{
+    fallback_coordinator::FallbackCoordinator,
+    payout::PayoutMode,
+    stratum_core::parsers_sv2::MiningOwned,
+    task_manager::TaskManager,
+    utils::types::{GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS, Sv2Frame},
+};
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    TranslatorSv2,
+    error::{TproxyError, TproxyErrorKind},
+    sv1::Sv1Server,
+    sv2::{ChannelManager, Upstream},
+    utils::{TproxyMode, UpstreamEntry},
+};
+
+struct Io {
+    channel_manager_to_upstream_sender: Sender<Sv2Frame>,
+    channel_manager_to_upstream_receiver: Receiver<Sv2Frame>,
+    upstream_to_channel_manager_sender: Sender<Sv2Frame>,
+    upstream_to_channel_manager_receiver: Receiver<Sv2Frame>,
+    channel_manager_to_sv1_server_sender: Sender<MiningOwned>,
+    channel_manager_to_sv1_server_receiver: Receiver<MiningOwned>,
+    sv1_server_to_channel_manager_sender: Sender<(MiningOwned, Option<String>)>,
+    sv1_server_to_channel_manager_receiver: Receiver<(MiningOwned, Option<String>)>,
+}
+
+/// The core coordinator of the Translator runtime, parameterized by its current bootstrap `State`.
+///
+/// It manages the lifecycle of essential sub-services and channels, ensuring resources
+/// are correctly initialized, passed to background executors, and cleanly torn down.
+pub(super) struct TranslatorRuntime<State> {
+    tproxy_mode: TproxyMode,
+    fallback_coordinator: FallbackCoordinator,
+    task_manager: Arc<TaskManager>,
+    translator: TranslatorSv2,
+    upstream_addresses: Vec<UpstreamEntry>,
+    listen_addr: SocketAddr,
+    state: State,
+}
+
+pub(super) struct Init;
+
+struct IoReady {
+    io: Io,
+}
+
+struct ChannelManagerReady {
+    io: Io,
+    channel_manager: Arc<ChannelManager>,
+}
+
+pub(super) struct Sv1ServerReady {
+    io: Io,
+    channel_manager: Arc<ChannelManager>,
+    sv1_server: Arc<Sv1Server>,
+}
+
+pub(super) struct UpstreamReady {
+    sv1_server: Arc<Sv1Server>,
+    channel_manager: Arc<ChannelManager>,
+}
+
+pub(super) struct Running;
+
+pub(super) struct Failed;
+
+#[must_use = "bootstrap errors include a partially initialized runtime that must be shut down"]
+pub(super) struct BootstrapError {
+    kind: TproxyErrorKind,
+    runtime: TranslatorRuntime<Failed>,
+}
+
+impl BootstrapError {
+    pub(super) fn into_parts(self) -> (TproxyErrorKind, TranslatorRuntime<Failed>) {
+        (self.kind, self.runtime)
+    }
+}
+
+impl<State> From<(TproxyErrorKind, TranslatorRuntime<State>)> for BootstrapError {
+    fn from((kind, runtime): (TproxyErrorKind, TranslatorRuntime<State>)) -> Self {
+        Self {
+            kind,
+            runtime: runtime.into_failed(),
+        }
+    }
+}
+
+impl<State> TranslatorRuntime<State> {
+    fn into_failed(self) -> TranslatorRuntime<Failed> {
+        TranslatorRuntime {
+            tproxy_mode: self.tproxy_mode,
+            fallback_coordinator: self.fallback_coordinator,
+            task_manager: self.task_manager,
+            translator: self.translator,
+            upstream_addresses: self.upstream_addresses,
+            listen_addr: self.listen_addr,
+            state: Failed,
+        }
+    }
+
+    /// Performs a coordinated, graceful shutdown of the runtime.
+    ///
+    /// Signals cancellation to all active sub-services and background tasks, awaiting
+    /// their clean termination up to a configured graceful timeout, and finally marks the
+    /// owning [`TranslatorSv2`] as stopped — callers do not need to do so themselves.
+    pub(super) async fn shutdown(self) {
+        self.translator.cancellation_token.cancel();
+
+        warn!(
+            "Graceful shutdown: waiting {} seconds for tasks to finish",
+            GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
+        );
+        match tokio::time::timeout(
+            Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS),
+            self.task_manager.join_all(),
+        )
+        .await
+        {
+            Ok(_) => {
+                info!("All tasks joined cleanly");
+            }
+            Err(_) => {
+                warn!(
+                    "Tasks did not finish within {} seconds, aborting",
+                    GRACEFUL_SHUTDOWN_TIMEOUT_SECONDS
+                );
+                self.task_manager.abort_all().await;
+                info!("Joining aborted tasks...");
+                self.task_manager.join_all().await;
+                warn!("Forced shutdown complete");
+            }
+        }
+        self.translator.mark_stopped();
+        info!("TranslatorSv2 shutdown complete.");
+    }
+
+    fn payout_mode(&self, user_identity: &str) -> Result<Option<PayoutMode>, TproxyErrorKind> {
+        let expected_payout_distribution = self
+            .translator
+            .config
+            .expected_payout_distribution(user_identity)
+            .map_err(|e| {
+                TproxyErrorKind::InvalidUserIdentity(format!(
+                    "invalid payout user_identity `{user_identity}`: {e}"
+                ))
+            })?;
+        if let Some(distribution) = &expected_payout_distribution {
+            info!(
+                "Payout verification enabled for configured user_identity: {}",
+                distribution
+            );
+        }
+        Ok(expected_payout_distribution)
+    }
+}
+
+impl TranslatorRuntime<Init> {
+    pub(super) fn new(translator: TranslatorSv2) -> Result<Self, TproxyErrorKind> {
+        let tproxy_mode = TproxyMode::from(translator.config.aggregate_channels);
+
+        let downstream_addr_ip = translator
+            .config
+            .downstream_address
+            .parse::<std::net::IpAddr>()
+            .map_err(|e| TproxyErrorKind::General(format!("Invalid downstream address: {e}")))?;
+
+        let listen_addr = SocketAddr::new(downstream_addr_ip, translator.config.downstream_port);
+
+        let upstream_addresses = translator
+            .config
+            .upstreams
+            .iter()
+            .map(|u| UpstreamEntry {
+                host: u.address.clone(),
+                port: u.port,
+                authority_pubkey: u.authority_pubkey,
+                tried_or_flagged: false,
+                user_identity: u.user_identity.clone(),
+            })
+            .collect();
+
+        Ok(TranslatorRuntime {
+            tproxy_mode,
+            fallback_coordinator: FallbackCoordinator::new(),
+            task_manager: Arc::new(TaskManager::new()),
+            translator,
+            upstream_addresses,
+            listen_addr,
+            state: Init,
+        })
+    }
+
+    /// Drives the linear bootstrap sequence of the translator proxy, transitioning the runtime
+    /// from [`Init`] to the active [`Running`] state.
+    ///
+    /// If an intermediate phase fails, the caller receives the partially initialized
+    /// runtime and is responsible for shutting down any resources that were already started.
+    pub(super) async fn bootstrap(self) -> Result<TranslatorRuntime<Running>, BootstrapError> {
+        let runtime = self.bootstrap_io();
+        let runtime = runtime.bootstrap_channel_manager();
+        let runtime = runtime.bootstrap_sv1_server();
+        let runtime = runtime.try_upstream().await?;
+        runtime.start_services().await
+    }
+
+    fn bootstrap_io(self) -> TranslatorRuntime<IoReady> {
+        let (channel_manager_to_upstream_sender, channel_manager_to_upstream_receiver) =
+            unbounded();
+        let (upstream_to_channel_manager_sender, upstream_to_channel_manager_receiver) =
+            unbounded();
+        let (channel_manager_to_sv1_server_sender, channel_manager_to_sv1_server_receiver) =
+            unbounded();
+        let (sv1_server_to_channel_manager_sender, sv1_server_to_channel_manager_receiver) =
+            unbounded();
+
+        TranslatorRuntime {
+            tproxy_mode: self.tproxy_mode,
+            fallback_coordinator: self.fallback_coordinator,
+            task_manager: self.task_manager,
+            translator: self.translator,
+            upstream_addresses: self.upstream_addresses,
+            listen_addr: self.listen_addr,
+            state: IoReady {
+                io: Io {
+                    channel_manager_to_upstream_sender,
+                    channel_manager_to_upstream_receiver,
+                    upstream_to_channel_manager_sender,
+                    upstream_to_channel_manager_receiver,
+                    channel_manager_to_sv1_server_sender,
+                    channel_manager_to_sv1_server_receiver,
+                    sv1_server_to_channel_manager_sender,
+                    sv1_server_to_channel_manager_receiver,
+                },
+            },
+        }
+    }
+}
+
+impl TranslatorRuntime<IoReady> {
+    fn bootstrap_channel_manager(self) -> TranslatorRuntime<ChannelManagerReady> {
+        let channel_manager = Arc::new(ChannelManager::new(
+            self.state.io.channel_manager_to_upstream_sender.clone(),
+            self.state.io.upstream_to_channel_manager_receiver.clone(),
+            self.state.io.channel_manager_to_sv1_server_sender.clone(),
+            self.state.io.sv1_server_to_channel_manager_receiver.clone(),
+            self.translator.config.supported_extensions.clone(),
+            self.translator.config.required_extensions.clone(),
+            self.tproxy_mode,
+            #[cfg(feature = "monitoring")]
+            self.translator
+                .config
+                .downstream_difficulty_config
+                .enable_vardiff,
+        ));
+
+        TranslatorRuntime {
+            tproxy_mode: self.tproxy_mode,
+            fallback_coordinator: self.fallback_coordinator,
+            task_manager: self.task_manager,
+            translator: self.translator,
+            upstream_addresses: self.upstream_addresses,
+            listen_addr: self.listen_addr,
+            state: ChannelManagerReady {
+                io: self.state.io,
+                channel_manager,
+            },
+        }
+    }
+}
+
+impl TranslatorRuntime<ChannelManagerReady> {
+    fn bootstrap_sv1_server(self) -> TranslatorRuntime<Sv1ServerReady> {
+        let sv1_server = Arc::new(Sv1Server::new(
+            self.listen_addr,
+            self.state.io.channel_manager_to_sv1_server_receiver.clone(),
+            self.state.io.sv1_server_to_channel_manager_sender.clone(),
+            self.translator.config.clone(),
+            self.tproxy_mode,
+        ));
+
+        TranslatorRuntime {
+            tproxy_mode: self.tproxy_mode,
+            fallback_coordinator: self.fallback_coordinator,
+            task_manager: self.task_manager,
+            translator: self.translator,
+            upstream_addresses: self.upstream_addresses,
+            listen_addr: self.listen_addr,
+            state: Sv1ServerReady {
+                io: self.state.io,
+                channel_manager: self.state.channel_manager,
+                sv1_server,
+            },
+        }
+    }
+}
+
+impl TranslatorRuntime<Sv1ServerReady> {
+    pub(super) async fn try_upstream(
+        mut self,
+    ) -> Result<TranslatorRuntime<UpstreamReady>, BootstrapError> {
+        if let Err(kind) = self.initialize_upstream().await {
+            return Err(BootstrapError::from((kind, self)));
+        }
+
+        Ok(TranslatorRuntime {
+            tproxy_mode: self.tproxy_mode,
+            fallback_coordinator: self.fallback_coordinator,
+            task_manager: self.task_manager,
+            translator: self.translator,
+            upstream_addresses: self.upstream_addresses,
+            listen_addr: self.listen_addr,
+            state: UpstreamReady {
+                sv1_server: self.state.sv1_server,
+                channel_manager: self.state.channel_manager,
+            },
+        })
+    }
+
+    /// Initializes the upstream connection list, handling retries, fallbacks, and flagging.
+    ///
+    /// Upstreams are tried sequentially, each receiving a fixed number of retries before we
+    /// advance to the next entry. This ensures we exhaust every healthy upstream before shutting
+    /// the translator down.
+    ///
+    /// The `tried_or_flagged` flag in the `UpstreamEntry` acts as the upstream's state machine:
+    ///  `false` means "never tried", while `true` means "already connected or marked as
+    /// malicious". Once an upstream is flagged we skip it on future loops
+    /// to avoid hammering known-bad endpoints during failover.
+    async fn initialize_upstream(&mut self) -> Result<(), TproxyErrorKind> {
+        const MAX_RETRIES: usize = 3;
+        let upstream_len = self.upstream_addresses.len();
+
+        for i in 0..upstream_len {
+            if self.upstream_addresses[i].tried_or_flagged {
+                debug!(
+                    "Upstream previously marked as malicious, skipping initial attempt warnings."
+                );
+                continue;
+            }
+
+            info!(
+                "Trying upstream {} of {}: {}:{}",
+                i + 1,
+                upstream_len,
+                self.upstream_addresses[i].host,
+                self.upstream_addresses[i].port
+            );
+
+            for attempt in 1..=MAX_RETRIES {
+                info!("Connection attempt {}/{}...", attempt, MAX_RETRIES);
+                tokio::time::sleep(Duration::from_secs(1)).await;
+
+                let upstream_entry = &self.upstream_addresses[i];
+                match self.try_initialize_upstream_single(upstream_entry).await {
+                    Ok(()) => {
+                        let user_identity = self.upstream_addresses[i].user_identity.to_string();
+                        let payout_mode = self.payout_mode(&user_identity)?;
+
+                        self.state
+                            .channel_manager
+                            .set_expected_payout_distribution(payout_mode);
+                        self.state.sv1_server.set_user_identity(user_identity);
+
+                        self.upstream_addresses[i].tried_or_flagged = true;
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        if e.action.is_shutdown() {
+                            error!("Fatal shutdown signal during upstream setup: {:?}", e.kind);
+                            return Err(e.kind);
+                        }
+
+                        warn!(
+                            "Attempt {}/{} failed for {}:{}: {:?}",
+                            attempt,
+                            MAX_RETRIES,
+                            self.upstream_addresses[i].host,
+                            self.upstream_addresses[i].port,
+                            e
+                        );
+                        if attempt == MAX_RETRIES {
+                            warn!(
+                                "Max retries reached for {}:{}, moving to next upstream",
+                                self.upstream_addresses[i].host, self.upstream_addresses[i].port
+                            );
+                        }
+                    }
+                }
+            }
+            self.upstream_addresses[i].tried_or_flagged = true;
+        }
+
+        tracing::error!("All upstreams failed after {} retries each", MAX_RETRIES);
+        Err(TproxyErrorKind::CouldNotInitiateSystem)
+    }
+
+    // Attempts to initialize a single upstream.
+    #[cfg_attr(not(test), hotpath::measure)]
+    async fn try_initialize_upstream_single(
+        &self,
+        upstream_addr: &UpstreamEntry,
+    ) -> Result<(), TproxyError<crate::error::Upstream>> {
+        let upstream = Upstream::new(
+            upstream_addr,
+            self.state.io.upstream_to_channel_manager_sender.clone(),
+            self.state.io.channel_manager_to_upstream_receiver.clone(),
+            self.translator.cancellation_token.clone(),
+            self.fallback_coordinator.clone(),
+            self.task_manager.clone(),
+            self.translator.config.required_extensions.clone(),
+        )
+        .await?;
+
+        upstream
+            .start(
+                self.translator.cancellation_token.clone(),
+                self.fallback_coordinator.clone(),
+                self.task_manager.clone(),
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+impl TranslatorRuntime<UpstreamReady> {
+    /// Activates the background execution loops of the SV1 server, [`ChannelManager`], and
+    /// monitoring server, transitioning the runtime to [`Running`].
+    pub(super) async fn start_services(self) -> Result<TranslatorRuntime<Running>, BootstrapError> {
+        info!("Launching SV1 server...");
+        if let Err(e) = self
+            .state
+            .sv1_server
+            .clone()
+            .start(
+                self.translator.cancellation_token.clone(),
+                self.fallback_coordinator.clone(),
+                self.task_manager.clone(),
+            )
+            .await
+        {
+            error!("SV1 server startup failed: {e:?}");
+            return Err(BootstrapError::from((e.kind, self)));
+        }
+
+        info!("Launching ChannelManager tasks...");
+        ChannelManager::run_channel_manager_tasks(
+            self.state.channel_manager.clone(),
+            self.translator.cancellation_token.clone(),
+            self.fallback_coordinator.clone(),
+            self.task_manager.clone(),
+        )
+        .await;
+
+        #[cfg(feature = "monitoring")]
+        if let Some(monitoring_addr) = self.translator.config.monitoring_address() {
+            info!("Initializing monitoring server on http://{monitoring_addr}");
+            if let Err(e) = self.start_monitoring_tasks(monitoring_addr) {
+                error!("Failed to initialize monitoring tasks: {e}");
+                return Err(BootstrapError::from((e, self)));
+            }
+        }
+
+        Ok(TranslatorRuntime {
+            tproxy_mode: self.tproxy_mode,
+            fallback_coordinator: self.fallback_coordinator,
+            task_manager: self.task_manager,
+            translator: self.translator,
+            upstream_addresses: self.upstream_addresses,
+            listen_addr: self.listen_addr,
+            state: Running,
+        })
+    }
+
+    #[cfg(feature = "monitoring")]
+    fn start_monitoring_tasks(&self, monitoring_addr: SocketAddr) -> Result<(), TproxyErrorKind> {
+        let refresh_interval = Duration::from_secs(
+            self.translator
+                .config
+                .monitoring_cache_refresh_secs()
+                .unwrap_or(15),
+        );
+
+        let monitoring_server = stratum_apps::monitoring::MonitoringServer::new(
+            monitoring_addr,
+            Some(self.state.channel_manager.clone()),
+            None,
+            refresh_interval,
+        )
+        .map_err(|e| {
+            TproxyErrorKind::General(format!("failed to initialize monitoring server: {e}"))
+        })?
+        .with_sv1_monitoring(self.state.sv1_server.clone())
+        .map_err(|e| TproxyErrorKind::General(format!("failed to add SV1 monitoring: {e}")))?;
+
+        let cancellation_token_clone = self.translator.cancellation_token.clone();
+        let fallback_coordinator_token = self.fallback_coordinator.token();
+        let shutdown_signal = async move {
+            tokio::select! {
+                _ = cancellation_token_clone.cancelled() => {
+                    info!("Monitoring server: received shutdown signal.");
+                }
+                _ = fallback_coordinator_token.cancelled() => {
+                    info!("Monitoring server: fallback triggered.");
+                }
+            }
+        };
+
+        let monitoring_fallback = self.fallback_coordinator.clone();
+        self.task_manager.spawn({
+            let cancellation_token = self.translator.cancellation_token.clone();
+            async move {
+                let fallback_handler = monitoring_fallback.register();
+
+                if let Err(e) = monitoring_server.run(shutdown_signal).await {
+                    error!("Monitoring server error: {:?}", e);
+                    cancellation_token.cancel();
+                }
+
+                fallback_handler.done();
+                info!("Monitoring server task exited and signaled fallback coordinator");
+            }
+        });
+
+        let telemetry_fallback = self.fallback_coordinator.clone();
+        self.task_manager.spawn({
+            let cancellation_token = self.translator.cancellation_token.clone();
+            let sv1_server = self.state.sv1_server.clone();
+            async move {
+                let fallback_token = telemetry_fallback.token();
+                let fallback_handler = telemetry_fallback.register();
+
+                sv1_server
+                    .run_miner_telemetry_loop(refresh_interval, cancellation_token, fallback_token)
+                    .await;
+
+                fallback_handler.done();
+                info!("SV1 miner telemetry task exited and signaled fallback coordinator");
+            }
+        });
+
+        Ok(())
+    }
+}
+
+pub(super) enum RuntimeEvent {
+    Shutdown,
+    Fallback,
+}
+
+impl TranslatorRuntime<Running> {
+    pub(super) async fn wait(&self) -> RuntimeEvent {
+        let fallback_token = self.fallback_coordinator.token();
+        let cancellation_token = self.translator.cancellation_token.clone();
+
+        tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => RuntimeEvent::Shutdown,
+            _ = fallback_token.cancelled() => RuntimeEvent::Fallback,
+        }
+    }
+
+    pub(super) async fn cleanup_for_fallback(self) -> TranslatorRuntime<Sv1ServerReady> {
+        info!("Preparing fallback");
+        self.fallback_coordinator.trigger_fallback_and_wait().await;
+        info!("All components finished fallback cleanup");
+
+        let fresh_fallback_coordinator = FallbackCoordinator::new();
+
+        TranslatorRuntime {
+            tproxy_mode: self.tproxy_mode,
+            fallback_coordinator: fresh_fallback_coordinator,
+            task_manager: self.task_manager,
+            translator: self.translator,
+            upstream_addresses: self.upstream_addresses,
+            listen_addr: self.listen_addr,
+            state: Init,
+        }
+        .bootstrap_io()
+        .bootstrap_channel_manager()
+        .bootstrap_sv1_server()
+    }
+}

--- a/miner-apps/translator/src/main.rs
+++ b/miner-apps/translator/src/main.rs
@@ -40,5 +40,7 @@ async fn inner_main() {
         }
     });
 
-    translator.start().await;
+    if translator.start().await.is_err() {
+        std::process::exit(1);
+    };
 }


### PR DESCRIPTION
Refactors the monolithic `start` function inside the Pool (`miner-apps/translator`) into a structured, typestate-based state machine (`TranslatorRuntime`) to manage bootstrap, component lifecycles, and graceful shutdown.

This PR also properly handles errors instead of calling `unwrap` or `expect`

Fixes https://github.com/stratum-mining/sv2-apps/issues/527