### PR TITLE
Add display impl for errors variants in apps

### DIFF
--- a/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
@@ -285,7 +285,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             {
                 Ok(prefix) => prefix,
                 Err(e) => {
-                    error!(?e, "Failed to get extranonce prefix");
+                    error!(%e, "Failed to get extranonce prefix");
                     return Err(JDCError::shutdown(e));
                 }
             };
@@ -420,7 +420,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
             if let Err(e) = message.forward(&self.channel_manager_io).await {
-                tracing::error!("Failed to forward message {e:?}");
+                tracing::error!("Failed to forward message {e}");
             }
         }
 
@@ -511,7 +511,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
                 {
                     Ok(prefix) => Some(prefix),
                     Err(e) => {
-                        error!(?e, "Extranonce prefix error");
+                        error!(%e, "Extranonce prefix error");
                         messages.push(
                             (
                                 downstream_id,
@@ -689,7 +689,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
             if let Err(e) = message.forward(&self.channel_manager_io).await {
-                tracing::error!("Failed to forward message {e:?}");
+                tracing::error!("Failed to forward message {e}");
             }
         }
 
@@ -860,7 +860,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
             if let Err(e) = message.forward(&self.channel_manager_io).await {
-                tracing::error!("Failed to forward message {e:?}");
+                tracing::error!("Failed to forward message {e}");
             }
         }
 
@@ -1128,7 +1128,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
             if let Err(e) = message.forward(&self.channel_manager_io).await {
-                tracing::error!("Failed to forward message {e:?}");
+                tracing::error!("Failed to forward message {e}");
             }
         }
 
@@ -1422,7 +1422,7 @@ impl HandleMiningMessagesFromClientAsync for ChannelManager {
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
             if let Err(e) = message.forward(&self.channel_manager_io).await {
-                tracing::error!("Failed to forward message {e:?}");
+                tracing::error!("Failed to forward message {e}");
             }
         }
 

--- a/miner-apps/jd-client/src/lib/channel_manager/mod.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/mod.rs
@@ -321,51 +321,32 @@ impl ChannelManager {
         fallback_token: &CancellationToken,
     ) -> LoopControl {
         if cancellation_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error after shutdown was requested"
-            );
+            debug!(error = %e, "{context} returned an error after shutdown was requested");
             return LoopControl::Continue;
         }
 
         if fallback_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error during fallback"
-            );
+            debug!(error = %e, "{context} returned an error during fallback");
             return LoopControl::Continue;
         }
 
         match e.action {
             Action::Log => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} returned a log-only error"
-                );
+                warn!(error = %e, "{context} returned a log-only error");
                 LoopControl::Continue
             }
             Action::Fallback => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested fallback"
-                );
+                warn!(error = %e, "{context} requested fallback");
                 fallback_token.cancel();
                 LoopControl::Break
             }
             Action::Shutdown => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested shutdown"
-                );
+                warn!(error = %e, "{context} requested shutdown");
                 cancellation_token.cancel();
                 LoopControl::Break
             }
             Action::Disconnect(downstream_id) => {
-                warn!(
-                    downstream_id,
-                    error_kind = ?e.kind,
-                    "{context} requested downstream disconnect"
-                );
+                warn!(error = %e, "{context} requested downstream disconnect");
                 self.remove_downstream(downstream_id);
                 LoopControl::Continue
             }
@@ -494,7 +475,7 @@ impl ChannelManager {
             Ok(Some(prev_hash)) => prev_hash,
             Ok(None) => unreachable!("No new prevhash found after readiness check"),
             Err(e) => {
-                error!(error = ?JDCErrorKind::from(e), "Failed to access prevhash state");
+                error!(error = %JDCErrorKind::from(e), "Failed to access prevhash state");
                 return None;
             }
         };
@@ -515,7 +496,7 @@ impl ChannelManager {
         let coinbase_outputs = match self.coinbase_outputs.get() {
             Ok(outputs) => outputs,
             Err(e) => {
-                error!(error = ?JDCErrorKind::from(e), "Failed to access channel manager state");
+                error!(error = %JDCErrorKind::from(e), "Failed to access channel manager state");
                 return None;
             }
         };
@@ -597,7 +578,7 @@ impl ChannelManager {
 
         info!("Starting downstream server at {listening_address}");
         let server = TcpListener::bind(listening_address).await.map_err(|e| {
-            error!(error = ?e, "Failed to bind downstream server at {listening_address}");
+            error!(error = %e, "Failed to bind downstream server at {listening_address}");
             JDCError::shutdown(e)
         })?;
 
@@ -640,7 +621,7 @@ impl ChannelManager {
                                             match result {
                                                 Ok(r) => r,
                                                 Err(e) => {
-                                                    error!(error = ?e, "Noise handshake failed");
+                                                    error!(error = %e, "Noise handshake failed");
                                                     return;
                                                 }
                                             }
@@ -695,7 +676,7 @@ impl ChannelManager {
                                 }
 
                                 Err(e) => {
-                                    error!(error = ?e, "Failed to accept new downstream connection");
+                                    error!(error = %e, "Failed to accept new downstream connection");
                                 }
                             }
                     }
@@ -720,12 +701,9 @@ impl ChannelManager {
         coinbase_outputs: Vec<TxOut>,
     ) {
         if let Err(e) = self.coinbase_output_constraints(coinbase_outputs).await {
-            error!(error = ?e, "Failed to send CoinbaseOutputConstraints message to TP");
+            error!(error = %e, "Failed to send CoinbaseOutputConstraints message to TP");
             if let Action::Shutdown = e.action {
-                warn!(
-                    error_kind = ?e.kind,
-                    "CoinbaseOutputConstraints requested shutdown; cancelling global token"
-                );
+                warn!(error = %e, "CoinbaseOutputConstraints requested shutdown; cancelling global token");
                 cancellation_token.cancel();
             }
             return;
@@ -765,7 +743,7 @@ impl ChannelManager {
                             && !cm.channel_manager_io.jd_receiver.is_closed() =>
                     {
                         if let Err(e) = res {
-                            error!(error = ?e, "Error handling JDS message");
+                            error!(error = %e, "Error handling JDS message");
                             if let LoopControl::Break = cm.handle_error_action(
                                 "ChannelManager::handle_jds_message",
                                 &e,
@@ -781,7 +759,7 @@ impl ChannelManager {
                             && !cm.channel_manager_io.upstream_receiver.is_closed() =>
                     {
                         if let Err(e) = res {
-                            error!(error = ?e, "Error handling Pool message");
+                            error!(error = %e, "Error handling Pool message");
                             if let LoopControl::Break = cm.handle_error_action(
                                 "ChannelManager::handle_pool_message_frame",
                                 &e,
@@ -794,7 +772,7 @@ impl ChannelManager {
                     }
                     res = cm_template.handle_template_provider_message() => {
                         if let Err(e) = res {
-                            error!(error = ?e, "Error handling Template Receiver message");
+                            error!(error = %e, "Error handling Template Receiver message");
                             if let LoopControl::Break = cm.handle_error_action(
                                 "ChannelManager::handle_template_provider_message",
                                 &e,
@@ -807,7 +785,7 @@ impl ChannelManager {
                     }
                     res = cm_downstreams.handle_downstream_message() => {
                         if let Err(e) = res {
-                            error!(error = ?e, "Error handling Downstreams message");
+                            error!(error = %e, "Error handling Downstreams message");
                             if let LoopControl::Break = cm.handle_error_action(
                                 "ChannelManager::handle_downstream_message",
                                 &e,
@@ -1177,7 +1155,7 @@ impl ChannelManager {
                 .send(message)
                 .await
                 .map_err(|e| {
-                    info!(error = ?e, "Failed to send AllocateMiningJobToken frame");
+                    info!(error = %e, "Failed to send AllocateMiningJobToken frame");
                     JDCError::fallback(JDCErrorKind::ChannelErrorSender)
                 })?;
         }
@@ -1291,7 +1269,7 @@ impl ChannelManager {
             info!("Starting vardiff loop for downstreams");
 
             if let Err(e) = self.run_vardiff().await {
-                error!(error = ?e, "Vardiff iteration failed");
+                error!(error = %e, "Vardiff iteration failed");
             }
         }
     }
@@ -1394,7 +1372,7 @@ impl ChannelManager {
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
             if let Err(e) = message.forward(&self.channel_manager_io).await {
-                tracing::error!("Failed to forward message {e:?}");
+                tracing::error!("Failed to forward message {e}");
             }
         }
 
@@ -1452,7 +1430,7 @@ impl ChannelManager {
             .send(TemplateDistribution::CoinbaseOutputConstraints(msg))
             .await
             .map_err(|e| {
-                error!(error = ?e, "Failed to send CoinbaseOutputConstraints message to TP");
+                error!(error = %e, "Failed to send CoinbaseOutputConstraints message to TP");
                 JDCError::shutdown(JDCErrorKind::ChannelErrorSender)
             })?;
 

--- a/miner-apps/jd-client/src/lib/channel_manager/template_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/template_message_handler.rs
@@ -275,7 +275,7 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
 
         for message in messages {
             if let Err(e) = message.forward(&self.channel_manager_io).await {
-                tracing::error!("Failed to forward message {e:?}");
+                tracing::error!("Failed to forward message {e}");
             }
         }
 
@@ -687,7 +687,7 @@ impl HandleTemplateDistributionMessagesFromServerAsync for ChannelManager {
 
         for message in messages {
             if let Err(e) = message.forward(&self.channel_manager_io).await {
-                tracing::error!("Failed to forward message {e:?}");
+                tracing::error!("Failed to forward message {e}");
             }
         }
 

--- a/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
@@ -149,7 +149,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
         ) {
             Ok(allocator) => allocator,
             Err(e) => {
-                warn!("Failed to build extranonce allocator: {e:?}");
+                warn!("Failed to build extranonce allocator: {e}");
                 self.upstream_state.set(UpstreamState::NoChannel);
                 let close_channel =
                     create_close_channel_msg(msg.channel_id, "downstream not available");
@@ -378,7 +378,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
                         match ExtranoncePrefix::from_wire(msg.extranonce_prefix.to_owned_bytes()) {
                             Ok(p) => p,
                             Err(e) => {
-                                warn!("Upstream SetExtranoncePrefix rejected: {e:?}");
+                                warn!("Upstream SetExtranoncePrefix rejected: {e}");
                                 return Err(JDCError::fallback(
                                     JDCErrorKind::ExtranonceSizeTooLarge,
                                 ));
@@ -415,7 +415,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
                         Err(e) => {
                             warn!(
                                 "Failed to build extranonce allocator from SetExtranoncePrefix \
-                                     (new_prefix_len={}, full_extranonce_size={}): {e:?}",
+                                     (new_prefix_len={}, full_extranonce_size={}): {e}",
                                 new_prefix_len, full_extranonce_size
                             );
                             return Err(JDCError::fallback(e));
@@ -514,7 +514,7 @@ impl HandleMiningMessagesFromServerAsync for ChannelManager {
             // Since this is an unbounded channel, it cannot fail due to capacity
             // limits (which would only apply to bounded channels).
             if let Err(e) = message.forward(&self.channel_manager_io).await {
-                tracing::error!("Failed to forward message {e:?}");
+                tracing::error!("Failed to forward message {e}");
             }
         }
         Ok(())

--- a/miner-apps/jd-client/src/lib/downstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/downstream/mod.rs
@@ -99,7 +99,7 @@ impl Downstream {
         if cancellation_token.is_cancelled() {
             debug!(
                 downstream_id = self.downstream_id,
-                error_kind = ?e.kind,
+                error = %e,
                 "{context} returned an error after shutdown was requested"
             );
             return LoopControl::Continue;
@@ -108,7 +108,7 @@ impl Downstream {
         if fallback_token.is_cancelled() {
             debug!(
                 downstream_id = self.downstream_id,
-                error_kind = ?e.kind,
+                error = %e,
                 "{context} returned an error during fallback"
             );
             return LoopControl::Continue;
@@ -118,24 +118,20 @@ impl Downstream {
             Action::Log => {
                 warn!(
                     downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
+                    error = %e,
                     "{context} returned a log-only error"
                 );
                 LoopControl::Continue
             }
             Action::Disconnect(_) => {
-                warn!(
-                    downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
-                    "{context} requested disconnect; cancelling downstream token"
-                );
+                warn!(error = %e, "{context} requested disconnect; cancelling downstream token");
                 self.downstream_cancellation_token.cancel();
                 LoopControl::Break
             }
             Action::Shutdown => {
                 warn!(
                     downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
+                    error = %e,
                     "{context} requested shutdown; cancelling global token"
                 );
                 cancellation_token.cancel();
@@ -144,8 +140,8 @@ impl Downstream {
             other => {
                 warn!(
                     downstream_id = self.downstream_id,
-                    action = ?other,
-                    error_kind = ?e.kind,
+                    action = %other,
+                    error = %e,
                     "{context} returned an unhandled action"
                 );
                 LoopControl::Continue
@@ -226,7 +222,7 @@ impl Downstream {
         let fallback_token = fallback_coordinator.token();
         // Setup initial connection
         if let Err(e) = self.setup_connection_with_downstream().await {
-            error!(?e, "Failed to set up downstream connection");
+            error!(%e, "Failed to set up downstream connection");
 
             // sleep to make sure SetupConnectionError is sent
             // before we break the TCP connection
@@ -261,7 +257,7 @@ impl Downstream {
                     }
                     res = self_clone_1.handle_downstream_message() => {
                         if let Err(e) = res {
-                            error!(?e, "Error handling downstream message for {downstream_id}");
+                            error!(%e, "Error handling downstream message for {downstream_id}");
                             if let LoopControl::Break = self.handle_error_action(
                                 "Downstream::handle_downstream_message",
                                 &e,
@@ -274,7 +270,7 @@ impl Downstream {
                     }
                     res = self_clone_2.handle_channel_manager_message() => {
                         if let Err(e) = res {
-                            error!(?e, "Error handling channel manager message for {downstream_id}");
+                            error!(%e, "Error handling channel manager message for {downstream_id}");
                             if let LoopControl::Break = self.handle_error_action(
                                 "Downstream::handle_channel_manager_message",
                                 &e,
@@ -328,7 +324,7 @@ impl Downstream {
             Ok(msg) => msg,
             Err(e) => {
                 warn!(
-                    ?e,
+                    %e,
                     "Channel manager receiver closed - disconnecting downstream"
                 );
                 return Err(JDCError::disconnect(
@@ -346,7 +342,7 @@ impl Downstream {
             .send(sv2_frame)
             .await
             .map_err(|e| {
-                error!(?e, "Downstream send failed");
+                error!(%e, "Downstream send failed");
                 JDCError::disconnect(JDCErrorKind::ChannelErrorSender, self.downstream_id)
             })?;
 
@@ -379,7 +375,7 @@ impl Downstream {
                     .send((self.downstream_id, message, tlv_fields))
                     .await
                     .map_err(|e| {
-                        error!(?e, "Failed to send mining message to channel manager.");
+                        error!(%e, "Failed to send mining message to channel manager.");
                         JDCError::shutdown(JDCErrorKind::ChannelErrorSender)
                     })?;
             }

--- a/miner-apps/jd-client/src/lib/error.rs
+++ b/miner-apps/jd-client/src/lib/error.rs
@@ -579,7 +579,10 @@ impl<Owner> HandlerErrorType for JDCError<Owner> {
 
 impl<Owner> std::fmt::Display for JDCError<Owner> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let owner = type_name::<Owner>().rsplit("::").next().unwrap_or("Unknown");
+        let owner = type_name::<Owner>()
+            .rsplit("::")
+            .next()
+            .unwrap_or("Unknown");
         write!(f, "[{owner}] Action: {}, error: {}", self.action, self.kind)
     }
 }

--- a/miner-apps/jd-client/src/lib/error.rs
+++ b/miner-apps/jd-client/src/lib/error.rs
@@ -13,7 +13,8 @@
 //! boundaries.
 use ext_config::ConfigError;
 use std::{
-    fmt::{self, Formatter},
+    any::type_name,
+    fmt::{self, Display, Formatter},
     marker::PhantomData,
     sync::PoisonError,
 };
@@ -77,6 +78,19 @@ pub enum Action {
 pub enum LoopControl {
     Continue,
     Break,
+}
+
+impl Display for Action {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Action::Log => f.write_str("Log"),
+            Action::Disconnect(downstream_id) => {
+                write!(f, "Disconnect(downstream_id: {downstream_id})")
+            }
+            Action::Fallback => f.write_str("Fallback"),
+            Action::Shutdown => f.write_str("Shutdown"),
+        }
+    }
 }
 
 impl CanDisconnect for Downstream {}
@@ -148,6 +162,28 @@ pub enum ChannelSv2Error {
     ExtranonceError(ExtranonceAllocatorError),
     StandardChannelServerSide(StandardChannelError),
     GroupChannelServerSide(GroupChannelError),
+}
+
+impl Display for ChannelSv2Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ChannelSv2Error::ExtendedChannelClientSide(error) => {
+                write!(f, "{error:?}")
+            }
+            ChannelSv2Error::ExtendedChannelServerSide(error) => {
+                write!(f, "{error:?}")
+            }
+            ChannelSv2Error::ExtranonceError(error) => {
+                write!(f, "{error:?}")
+            }
+            ChannelSv2Error::StandardChannelServerSide(error) => {
+                write!(f, "{error:?}")
+            }
+            ChannelSv2Error::GroupChannelServerSide(error) => {
+                write!(f, "{error:?}")
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -268,22 +304,24 @@ impl fmt::Display for JDCErrorKind {
         use JDCErrorKind::*;
         match self {
             BadCliArgs => write!(f, "Bad CLI arg input"),
-            BadConfigDeserialize(ref e) => write!(f, "Bad `config` TOML deserialize: `{e:?}`"),
-            BinarySv2(ref e) => write!(f, "Binary SV2 error: `{e:?}`"),
-            CodecNoise(ref e) => write!(f, "Noise error: `{e:?}"),
-            FramingSv2(ref e) => write!(f, "Framing SV2 error: `{e:?}`"),
-            Io(ref e) => write!(f, "I/O error: `{e:?}"),
-            ParseInt(ref e) => write!(f, "Bad convert from `String` to `int`: `{e:?}`"),
+            BadConfigDeserialize(ref e) => write!(f, "Bad `config` TOML deserialize: {e}"),
+            BinarySv2(ref e) => write!(f, "Binary SV2 error: {e:?}"),
+            CodecNoise(ref e) => write!(f, "Noise error: {e:?}"),
+            FramingSv2(ref e) => write!(f, "Framing SV2 error: {e:?}"),
+            Io(ref e) => write!(f, "I/O error: {e}"),
+            ParseInt(ref e) => write!(f, "Bad convert from `String` to `int`: {e}"),
             PoisonLock => write!(f, "Mutex poison lock error"),
-            ChannelErrorReceiver(ref e) => write!(f, "Channel receive error: `{e:?}`"),
-            Parser(ref e) => write!(f, "Parser error: `{e:?}`"),
+            ChannelErrorReceiver(ref e) => write!(f, "Channel receive error: {e}"),
+            Parser(ref e) => write!(f, "Parser error: {e}"),
             ChannelErrorSender => write!(f, "Sender error"),
-            NetworkHelpersError(ref e) => write!(f, "Network error: {e:?}"),
+            NetworkHelpersError(ref e) => write!(f, "Network error: {e}"),
             UnexpectedMessage(extension_type, message_type) => {
                 write!(f, "Unexpected Message: {extension_type} {message_type}")
             }
-            InvalidUserIdentity(_) => write!(f, "User ID is invalid"),
-            BitcoinEncodeError(_) => write!(f, "Error generated during encoding"),
+            InvalidUserIdentity(user_identity) => {
+                write!(f, "User ID is invalid: {user_identity}")
+            }
+            BitcoinEncodeError(error) => write!(f, "Error generated during encoding: {error}"),
             InvalidSocketAddress(ref s) => write!(f, "Invalid socket address: {s}"),
             Timeout => write!(f, "Time out error"),
             LastDeclareJobNotFound(request_id) => {
@@ -344,7 +382,7 @@ impl fmt::Display for JDCErrorKind {
                 write!(f, "Failed to create ExtranoncePrefixFactory: {e:?}")
             }
             ChannelSv2(channel_error) => {
-                write!(f, "Channel error: {channel_error:?}")
+                write!(f, "Channel error: {channel_error}")
             }
             InvalidUnsupportedExtensionsSequence => {
                 write!(
@@ -541,6 +579,7 @@ impl<Owner> HandlerErrorType for JDCError<Owner> {
 
 impl<Owner> std::fmt::Display for JDCError<Owner> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "[{:?}/{:?}]", self.kind, self.action)
+        let owner = type_name::<Owner>().rsplit("::").next().unwrap_or("Unknown");
+        write!(f, "[{owner}] Action: {}, error: {}", self.action, self.kind)
     }
 }

--- a/miner-apps/jd-client/src/lib/job_declarator/mod.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/mod.rs
@@ -68,51 +68,32 @@ impl JobDeclarator {
         fallback_token: &CancellationToken,
     ) -> LoopControl {
         if cancellation_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error after shutdown was requested"
-            );
+            debug!(error = %e, "{context} returned an error after shutdown was requested");
             return LoopControl::Continue;
         }
 
         if fallback_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error during fallback"
-            );
+            debug!(error = %e, "{context} returned an error during fallback");
             return LoopControl::Continue;
         }
 
         match e.action {
             Action::Log => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} returned a log-only error"
-                );
+                warn!(error = %e, "{context} returned a log-only error");
                 LoopControl::Continue
             }
             Action::Fallback => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested fallback"
-                );
+                warn!(error = %e, "{context} requested fallback");
                 fallback_token.cancel();
                 LoopControl::Break
             }
             Action::Shutdown => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested shutdown"
-                );
+                warn!(error = %e, "{context} requested shutdown");
                 cancellation_token.cancel();
                 LoopControl::Break
             }
             other => {
-                warn!(
-                    action = ?other,
-                    error_kind = ?e.kind,
-                    "{context} returned an unhandled action"
-                );
+                warn!(action = %other, error = %e, "{context} returned an unhandled action");
                 LoopControl::Continue
             }
         }
@@ -232,7 +213,7 @@ impl JobDeclarator {
                     }
                     res = self_clone_1.handle_job_declarator_message() => {
                         if let Err(e) = res {
-                            error!(error = ?e, "Job Declarator message handling failed");
+                            error!(error = %e, "Job Declarator message handling failed");
                             if let LoopControl::Break = Self::handle_error_action(
                                 "JobDeclarator::handle_job_declarator_message",
                                 &e,
@@ -245,7 +226,7 @@ impl JobDeclarator {
                     }
                     res = self_clone_2.handle_channel_manager_message() => {
                         if let Err(e) = res {
-                            error!(error = ?e, "Channel Manager message handling failed");
+                            error!(error = %e, "Channel Manager message handling failed");
                             if let LoopControl::Break = Self::handle_error_action(
                                 "JobDeclarator::handle_channel_manager_message",
                                 &e,
@@ -278,12 +259,12 @@ impl JobDeclarator {
         let sv2_frame: Sv2Frame = Message::Common(setup_connection.into())
             .try_into()
             .map_err(|e| {
-                error!(error=?e, "Failed to serialize SetupConnection message.");
+                error!(error=%e, "Failed to serialize SetupConnection message.");
                 JDCError::shutdown(e)
             })?;
 
         if let Err(e) = self.job_declarator_io.jds_sender.send(sv2_frame).await {
-            error!(error=?e, "Failed to send SetupConnection frame.");
+            error!(error=%e, "Failed to send SetupConnection frame.");
             return Err(JDCError::fallback(JDCErrorKind::ChannelErrorSender));
         }
         debug!("SetupConnection frame sent successfully.");
@@ -294,7 +275,7 @@ impl JobDeclarator {
             .recv()
             .await
             .map_err(|e| {
-                error!(error=?e, "No handshake response received from Job declarator.");
+                error!(error=%e, "No handshake response received from Job declarator.");
                 JDCError::fallback(JDCErrorKind::ChannelErrorSender)
             })?;
 
@@ -326,12 +307,12 @@ impl JobDeclarator {
                     .send(sv2_frame)
                     .await
                     .map_err(|e| {
-                        error!("Failed to send message to outbound channel: {:?}", e);
+                        error!("Failed to send message to outbound channel: {e}");
                         JDCError::fallback(JDCErrorKind::ChannelErrorSender)
                     })?;
             }
             Err(e) => {
-                warn!("Channel manager receiver closed or errored: {:?}", e);
+                warn!("Channel manager receiver closed or errored: {e}");
             }
         }
         Ok(())
@@ -373,7 +354,7 @@ impl JobDeclarator {
                     .send(message)
                     .await
                     .map_err(|e| {
-                        error!(error=?e, "Failed to send Job declaration message to channel manager.");
+                        error!(error=%e, "Failed to send Job declaration message to channel manager.");
                         JDCError::shutdown(JDCErrorKind::ChannelErrorSender)
                     })?;
             }

--- a/miner-apps/jd-client/src/lib/mod.rs
+++ b/miner-apps/jd-client/src/lib/mod.rs
@@ -78,7 +78,7 @@ impl JobDeclaratorClient {
         let mode = JDMode::new(self.config.mode);
 
         if let Err(e) = miner_coinbase_outputs.consensus_encode(&mut encoded_outputs) {
-            error!(error = ?e, "Invalid coinbase output in config");
+            error!(error = %e, "Invalid coinbase output in config");
             self.cancellation_token.cancel();
             self.shutdown_notify.notify_waiters();
             self.is_alive.store(false, Ordering::Relaxed);
@@ -122,7 +122,7 @@ impl JobDeclaratorClient {
         {
             Ok(channel_manager) => channel_manager,
             Err(e) => {
-                error!(error = ?e, "Failed to initialize channel manager");
+                error!(error = %e, "Failed to initialize channel manager");
                 self.cancellation_token.cancel();
                 self.shutdown_notify.notify_waiters();
                 self.is_alive.store(false, Ordering::Relaxed);
@@ -167,7 +167,7 @@ impl JobDeclaratorClient {
                 {
                     Ok(template_receiver) => template_receiver,
                     Err(e) => {
-                        error!(error = ?e, "Failed to initialize SV2 template receiver");
+                        error!(error = %e, "Failed to initialize SV2 template receiver");
                         self.cancellation_token.cancel();
                         self.shutdown_notify.notify_waiters();
                         self.is_alive.store(false, Ordering::Relaxed);
@@ -182,7 +182,7 @@ impl JobDeclaratorClient {
                     .start(address, cancellation_token_tp, task_manager_cl)
                     .await
                 {
-                    error!(error = ?e, "Failed to start SV2 template receiver");
+                    error!(error = %e, "Failed to start SV2 template receiver");
                     self.cancellation_token.cancel();
                     self.shutdown_notify.notify_waiters();
                     self.is_alive.store(false, Ordering::Relaxed);
@@ -328,7 +328,7 @@ impl JobDeclaratorClient {
                     _ = initial_channel_manager.allocate_tokens(2).await;
                 }
                 Err(e) => {
-                    tracing::error!("Failed to initialize upstream: {:?}", e);
+                    tracing::error!("Failed to initialize upstream: {e}");
                     mode.set_solo_mining();
                 }
             };
@@ -355,7 +355,7 @@ impl JobDeclaratorClient {
                     )
                     .await
                 {
-                    tracing::error!(?e, "Downstream server task exited with error");
+                    tracing::error!(%e, "Downstream server task exited with error");
                     cancellation_token.cancel();
                 }
             }
@@ -415,7 +415,7 @@ impl JobDeclaratorClient {
                     {
                         Ok(channel_manager) => channel_manager,
                         Err(e) => {
-                            error!(error = ?e, "Failed to initialize channel manager during fallback");
+                            error!(error = %e, "Failed to initialize channel manager during fallback");
                             self.cancellation_token.cancel();
                             break;
                         }
@@ -474,7 +474,7 @@ impl JobDeclaratorClient {
                             _ = channel_manager.allocate_tokens(2).await;
                         }
                         Err(e) => {
-                            tracing::error!("Failed to initialize upstream: {:?}", e);
+                            tracing::error!("Failed to initialize upstream: {e}");
                             channel_manager
                                 .upstream_state
                                 .set(UpstreamState::SoloMining);
@@ -520,7 +520,7 @@ impl JobDeclaratorClient {
                                     config.required_extensions().to_vec(),
                                 )
                                 .await {
-                                    tracing::error!(?e, "Downstream server task exited with error");
+                                    tracing::error!(%e, "Downstream server task exited with error");
                                     cancellation_token.cancel();
                                 }
                         }
@@ -615,7 +615,7 @@ impl JobDeclaratorClient {
                 let fallback_handler = monitoring_fallback.register();
 
                 if let Err(e) = monitoring_server.run(shutdown_signal).await {
-                    error!("Monitoring server error: {:?}", e);
+                    error!("Monitoring server error: {e}");
                     cancellation_token.cancel();
                 }
 
@@ -737,7 +737,7 @@ impl JobDeclaratorClient {
                         }
 
                         warn!(
-                            "Attempt {}/{} failed for pool={}:{}, jds={}:{}: {:?}",
+                            "Attempt {}/{} failed for pool={}:{}, jds={}:{}: {}",
                             attempt,
                             MAX_RETRIES,
                             upstream_entry.pool_host,

--- a/miner-apps/jd-client/src/lib/template_receiver/bitcoin_core.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/bitcoin_core.rs
@@ -50,7 +50,7 @@ pub async fn connect_to_bitcoin_core(
         let rt = match tokio::runtime::Runtime::new() {
             Ok(rt) => rt,
             Err(e) => {
-                tracing::error!("Failed to create Tokio runtime: {:?}", e);
+                tracing::error!("Failed to create Tokio runtime: {e}");
 
                 // we can't use handle_error here because we're not in a async context yet
                 cancellation_token_clone.cancel();
@@ -74,7 +74,7 @@ pub async fn connect_to_bitcoin_core(
             {
                 Ok(sv2_bitcoin_core) => sv2_bitcoin_core,
                 Err(e) => {
-                    tracing::error!("Failed to create BitcoinCoreToSv2: {:?}", e);
+                    tracing::error!("Failed to create BitcoinCoreToSv2: {e}");
                     bitcoin_core_config.cancellation_token.cancel();
                     return;
                 }

--- a/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/mod.rs
@@ -90,35 +90,22 @@ impl Sv2Tp {
         cancellation_token: &CancellationToken,
     ) -> LoopControl {
         if cancellation_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error after shutdown was requested"
-            );
+            debug!(error = %e, "{context} returned an error after shutdown was requested");
             return LoopControl::Continue;
         }
 
         match e.action {
             Action::Log => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} returned a log-only error"
-                );
+                warn!(error = %e, "{context} returned a log-only error");
                 LoopControl::Continue
             }
             Action::Shutdown => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested shutdown"
-                );
+                warn!(error = %e, "{context} requested shutdown");
                 cancellation_token.cancel();
                 LoopControl::Break
             }
             other => {
-                warn!(
-                    action = ?other,
-                    error_kind = ?e.kind,
-                    "{context} returned an unhandled action"
-                );
+                warn!(action = %other, error = %e, "{context} returned an unhandled action");
                 LoopControl::Continue
             }
         }
@@ -200,14 +187,14 @@ impl Sv2Tp {
                                     return Err(JDCError::shutdown(JDCErrorKind::InvalidKey));
                                 }
                                 Err(e) => {
-                                    error!(attempt, error = ?e, "Noise handshake failed");
+                                    error!(attempt, error = %e, "Noise handshake failed");
                                 }
                             }
                         }
                     }
                 }
                 Err(e) => {
-                    warn!(attempt, MAX_RETRIES, error = ?e, "Failed to connect to template provider");
+                    warn!(attempt, MAX_RETRIES, error = %e, "Failed to connect to template provider");
                 }
             }
 
@@ -238,7 +225,7 @@ impl Sv2Tp {
     ) -> JDCResult<(), error::TemplateProvider> {
         info!("Initialized state for starting template receiver");
         if let Err(e) = self.setup_connection(socket_address).await {
-            error!("TemplateReceiver setup connection failed: {e:?}");
+            error!("TemplateReceiver setup connection failed: {e}");
             self.sv2_tp_io.close();
             return Err(e);
         }
@@ -257,7 +244,7 @@ impl Sv2Tp {
                     }
                     res = self_clone_1.handle_template_provider_message() => {
                         if let Err(e) = res {
-                            error!("TemplateReceiver template provider handler failed: {e:?}");
+                            error!("TemplateReceiver template provider handler failed: {e}");
                             if let LoopControl::Break = Self::handle_error_action(
                                 "TemplateReceiver::handle_template_provider_message",
                                 &e,
@@ -269,7 +256,7 @@ impl Sv2Tp {
                     }
                     res = self_clone_2.handle_channel_manager_message() => {
                         if let Err(e) = res {
-                            error!("TemplateReceiver channel manager handler failed: {e:?}");
+                            error!("TemplateReceiver channel manager handler failed: {e}");
                             if let LoopControl::Break = Self::handle_error_action(
                                 "TemplateReceiver::handle_channel_manager_message",
                                 &e,
@@ -330,7 +317,7 @@ impl Sv2Tp {
                     .send(message)
                     .await
                     .map_err(|e| {
-                        error!(error=?e, "Failed to send template distribution message to channel manager.");
+                        error!(error=%e, "Failed to send template distribution message to channel manager.");
                         JDCError::shutdown(JDCErrorKind::ChannelErrorSender)
                     })?;
             }
@@ -387,7 +374,7 @@ impl Sv2Tp {
 
         info!("Waiting for upstream handshake response");
         let mut incoming: Sv2Frame = self.sv2_tp_io.tp_receiver.recv().await.map_err(|e| {
-            error!(?e, "Upstream connection closed during handshake");
+            error!(%e, "Upstream connection closed during handshake");
             JDCError::shutdown(noise_sv2::Error::ExpectedIncomingHandshakeMessage)
         })?;
 

--- a/miner-apps/jd-client/src/lib/upstream/mod.rs
+++ b/miner-apps/jd-client/src/lib/upstream/mod.rs
@@ -81,51 +81,32 @@ impl Upstream {
         fallback_token: &CancellationToken,
     ) -> LoopControl {
         if cancellation_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error after shutdown was requested"
-            );
+            debug!(error = %e, "{context} returned an error after shutdown was requested");
             return LoopControl::Continue;
         }
 
         if fallback_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error during fallback"
-            );
+            debug!(error = %e, "{context} returned an error during fallback");
             return LoopControl::Continue;
         }
 
         match e.action {
             Action::Log => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} returned a log-only error"
-                );
+                warn!(error = %e, "{context} returned a log-only error");
                 LoopControl::Continue
             }
             Action::Fallback => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested fallback"
-                );
+                warn!(error = %e, "{context} requested fallback");
                 fallback_token.cancel();
                 LoopControl::Break
             }
             Action::Shutdown => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested shutdown"
-                );
+                warn!(error = %e, "{context} requested shutdown");
                 cancellation_token.cancel();
                 LoopControl::Break
             }
             other => {
-                warn!(
-                    action = ?other,
-                    error_kind = ?e.kind,
-                    "{context} returned an unhandled action"
-                );
+                warn!(action = %other, error = %e, "{context} returned an unhandled action");
                 LoopControl::Continue
             }
         }

--- a/miner-apps/translator/src/lib/error.rs
+++ b/miner-apps/translator/src/lib/error.rs
@@ -10,7 +10,8 @@
 
 use ext_config::ConfigError;
 use std::{
-    fmt::{self, Formatter},
+    any::type_name,
+    fmt::{self, Display, Formatter},
     marker::PhantomData,
     sync::PoisonError,
 };
@@ -64,6 +65,19 @@ pub enum Action {
 pub enum LoopControl {
     Continue,
     Break,
+}
+
+impl Display for Action {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Action::Log => f.write_str("Log"),
+            Action::Disconnect(downstream_id) => {
+                write!(f, "Disconnect(downstream_id: {downstream_id})")
+            }
+            Action::Fallback => f.write_str("Fallback"),
+            Action::Shutdown => f.write_str("Shutdown"),
+        }
+    }
 }
 
 impl CanDisconnect for Downstream {}
@@ -224,19 +238,19 @@ impl fmt::Display for TproxyErrorKind {
         match self {
             General(e) => write!(f, "{e}"),
             BadCliArgs => write!(f, "Bad CLI arg input"),
-            BadSerdeJson(ref e) => write!(f, "Bad serde json: `{e:?}`"),
-            BadConfigDeserialize(ref e) => write!(f, "Bad `config` TOML deserialize: `{e:?}`"),
-            BinarySv2(ref e) => write!(f, "Binary SV2 error: `{e:?}`"),
-            CodecNoise(ref e) => write!(f, "Noise error: `{e:?}"),
-            FramingSv2(ref e) => write!(f, "Framing SV2 error: `{e:?}`"),
-            Io(ref e) => write!(f, "I/O error: `{e:?}"),
-            ParseInt(ref e) => write!(f, "Bad convert from `String` to `int`: `{e:?}`"),
+            BadSerdeJson(ref e) => write!(f, "Bad serde json: {e}"),
+            BadConfigDeserialize(ref e) => write!(f, "Bad `config` TOML deserialize: {e}"),
+            BinarySv2(ref e) => write!(f, "Binary SV2 error: {e:?}"),
+            CodecNoise(ref e) => write!(f, "Noise error: {e:?}"),
+            FramingSv2(ref e) => write!(f, "Framing SV2 error: {e}"),
+            Io(ref e) => write!(f, "I/O error: {e}"),
+            ParseInt(ref e) => write!(f, "Bad convert from `String` to `int`: {e}"),
             PoisonLock => write!(f, "Poison Lock error"),
-            ChannelErrorReceiver(ref e) => write!(f, "Channel receive error: `{e:?}`"),
+            ChannelErrorReceiver(ref e) => write!(f, "Channel receive error: {e}"),
             ChannelErrorSender => write!(f, "Sender error"),
             Timeout => write!(f, "Operation timed out"),
             SetDifficultyToMessage(ref e) => {
-                write!(f, "Error converting SetDifficulty to Message: `{e:?}`")
+                write!(f, "Error converting SetDifficulty to Message: {e:?}")
             }
             UnexpectedMessage(extension_type, message_type) => {
                 write!(
@@ -266,13 +280,13 @@ impl fmt::Display for TproxyErrorKind {
             }
             SV1Error => write!(f, "Sv1 error"),
             TranslatorCore(ref e) => write!(f, "Translator core error: {e:?}"),
-            NetworkHelpersError(ref e) => write!(f, "Network helpers error: {e:?}"),
-            ParserError(ref e) => write!(f, "Roles logic parser error: {e:?}"),
+            NetworkHelpersError(ref e) => write!(f, "Network helpers error: {e}"),
+            ParserError(ref e) => write!(f, "Roles logic parser error: {e}"),
             DownstreamNotFound(request_id) => write!(
                 f,
                 "Downstream id associated to request id: {request_id} not found"
             ),
-            TlvError(ref e) => write!(f, "TLV error: {e:?}"),
+            TlvError(ref e) => write!(f, "TLV error: {e}"),
             OpenMiningChannelError => write!(f, "failed to open mining channel"),
             SetupConnectionError => write!(f, "failed to setup connection with upstream"),
             CouldNotInitiateSystem => write!(f, "Could not initiate subsystem"),
@@ -429,6 +443,7 @@ impl<Owner> HandlerErrorType for TproxyError<Owner> {
 
 impl<Owner> std::fmt::Display for TproxyError<Owner> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "[{:?}/{:?}]", self.kind, self.action)
+        let owner = type_name::<Owner>().rsplit("::").next().unwrap_or("Unknown");
+        write!(f, "[{owner}] Action: {}, error: {}", self.action, self.kind)
     }
 }

--- a/miner-apps/translator/src/lib/error.rs
+++ b/miner-apps/translator/src/lib/error.rs
@@ -443,7 +443,10 @@ impl<Owner> HandlerErrorType for TproxyError<Owner> {
 
 impl<Owner> std::fmt::Display for TproxyError<Owner> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let owner = type_name::<Owner>().rsplit("::").next().unwrap_or("Unknown");
+        let owner = type_name::<Owner>()
+            .rsplit("::")
+            .next()
+            .unwrap_or("Unknown");
         write!(f, "[{owner}] Action: {}, error: {}", self.action, self.kind)
     }
 }

--- a/miner-apps/translator/src/lib/sv1/downstream.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream.rs
@@ -191,7 +191,7 @@ impl Downstream {
         if cancellation_token.is_cancelled() {
             debug!(
                 downstream_id = self.downstream_id,
-                error_kind = ?e.kind,
+                error = %e,
                 "{context} returned an error after shutdown was requested"
             );
             return LoopControl::Continue;
@@ -200,7 +200,7 @@ impl Downstream {
         if fallback_token.is_cancelled() {
             debug!(
                 downstream_id = self.downstream_id,
-                error_kind = ?e.kind,
+                error = %e,
                 "{context} returned an error during fallback"
             );
             return LoopControl::Continue;
@@ -210,24 +210,20 @@ impl Downstream {
             Action::Log => {
                 warn!(
                     downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
+                    error = %e,
                     "{context} returned a log-only error"
                 );
                 LoopControl::Continue
             }
             Action::Disconnect(_) => {
-                warn!(
-                    downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
-                    "{context} requested disconnect; cancelling downstream token"
-                );
+                warn!(error = %e, "{context} requested disconnect; cancelling downstream token");
                 self.downstream_cancellation_token.cancel();
                 LoopControl::Break
             }
             Action::Shutdown => {
                 warn!(
                     downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
+                    error = %e,
                     "{context} requested shutdown; cancelling global token"
                 );
                 cancellation_token.cancel();
@@ -236,8 +232,8 @@ impl Downstream {
             other => {
                 warn!(
                     downstream_id = self.downstream_id,
-                    action = ?other,
-                    error_kind = ?e.kind,
+                    action = %other,
+                    error = %e,
                     "{context} returned an unhandled action"
                 );
                 LoopControl::Continue
@@ -324,7 +320,7 @@ impl Downstream {
                     // Handle downstream -> server message
                     res = self.handle_downstream_message() => {
                         if let Err(e) = res {
-                            error!("Downstream {downstream_id}: error in downstream message handler: {e:?}");
+                            error!("Downstream {downstream_id}: error in downstream message handler: {e}");
                             if let LoopControl::Break = self.handle_error_action(
                                 "Downstream::handle_downstream_message",
                                 &e,
@@ -339,7 +335,7 @@ impl Downstream {
                     // Handle server -> downstream message
                     res = self.handle_sv1_server_message() => {
                         if let Err(e) = res {
-                            error!("Downstream {downstream_id}: error in server message handler: {e:?}");
+                            error!("Downstream {downstream_id}: error in server message handler: {e}");
                             if let LoopControl::Break = self.handle_error_action(
                                 "Downstream::handle_sv1_server_message",
                                 &e,

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -217,51 +217,32 @@ impl Sv1Server {
         fallback_token: &CancellationToken,
     ) -> LoopControl {
         if cancellation_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error after shutdown was requested"
-            );
+            debug!(error = %e, "{context} returned an error after shutdown was requested");
             return LoopControl::Continue;
         }
 
         if fallback_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error during fallback"
-            );
+            debug!(error = %e, "{context} returned an error during fallback");
             return LoopControl::Continue;
         }
 
         match e.action {
             Action::Log => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} returned a log-only error"
-                );
+                warn!(error = %e, "{context} returned a log-only error");
                 LoopControl::Continue
             }
             Action::Disconnect(downstream_id) => {
-                warn!(
-                    downstream_id,
-                    error_kind = ?e.kind,
-                    "{context} requested disconnect; cancelling downstream token"
-                );
+                warn!(error = %e, "{context} requested disconnect; cancelling downstream token");
                 self.handle_downstream_disconnect(downstream_id).await;
                 LoopControl::Continue
             }
             Action::Fallback => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested fallback"
-                );
+                warn!(error = %e, "{context} requested fallback");
                 fallback_token.cancel();
                 LoopControl::Break
             }
             Action::Shutdown => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested shutdown; cancelling global token"
-                );
+                warn!(error = %e, "{context} requested shutdown; cancelling global token");
                 cancellation_token.cancel();
                 LoopControl::Break
             }

--- a/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
@@ -200,51 +200,32 @@ impl ChannelManager {
         fallback_token: &CancellationToken,
     ) -> LoopControl {
         if cancellation_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error after shutdown was requested"
-            );
+            debug!(error = %e, "{context} returned an error after shutdown was requested");
             return LoopControl::Continue;
         }
 
         if fallback_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error during fallback"
-            );
+            debug!(error = %e, "{context} returned an error during fallback");
             return LoopControl::Continue;
         }
 
         match e.action {
             Action::Log => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} returned a log-only error"
-                );
+                warn!(error = %e, "{context} returned a log-only error");
                 LoopControl::Continue
             }
             Action::Fallback => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested fallback"
-                );
+                warn!(error = %e, "{context} requested fallback");
                 fallback_token.cancel();
                 LoopControl::Break
             }
             Action::Shutdown => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested shutdown"
-                );
+                warn!(error = %e, "{context} requested shutdown");
                 cancellation_token.cancel();
                 LoopControl::Break
             }
-            Action::Disconnect(downstream_id) => {
-                warn!(
-                    downstream_id,
-                    error_kind = ?e.kind,
-                    "{context} requested downstream disconnect"
-                );
+            Action::Disconnect(_downstream_id) => {
+                warn!(error = %e, "{context} requested downstream disconnect");
                 LoopControl::Continue
             }
         }

--- a/miner-apps/translator/src/lib/sv2/upstream/mod.rs
+++ b/miner-apps/translator/src/lib/sv2/upstream/mod.rs
@@ -96,51 +96,32 @@ impl Upstream {
         fallback_token: &CancellationToken,
     ) -> LoopControl {
         if cancellation_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error after shutdown was requested"
-            );
+            debug!(error = %e, "{context} returned an error after shutdown was requested");
             return LoopControl::Continue;
         }
 
         if fallback_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error during fallback"
-            );
+            debug!(error = %e, "{context} returned an error during fallback");
             return LoopControl::Continue;
         }
 
         match e.action {
             Action::Log => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} returned a log-only error"
-                );
+                warn!(error = %e, "{context} returned a log-only error");
                 LoopControl::Continue
             }
             Action::Fallback => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested fallback"
-                );
+                warn!(error = %e, "{context} requested fallback");
                 fallback_token.cancel();
                 LoopControl::Break
             }
             Action::Shutdown => {
-                warn!(
-                    error_kind = ?e.kind,
-                    "{context} requested shutdown"
-                );
+                warn!(error = %e, "{context} requested shutdown");
                 cancellation_token.cancel();
                 LoopControl::Break
             }
             other => {
-                warn!(
-                    action = ?other,
-                    error_kind = ?e.kind,
-                    "{context} returned an unhandled action"
-                );
+                warn!(action = %other, error = %e, "{context} returned an unhandled action");
                 LoopControl::Continue
             }
         }
@@ -303,7 +284,7 @@ impl Upstream {
             }
             result = self.setup_connection() => {
                 if let Err(e) = result {
-                    error!("Upstream: failed to set up SV2 connection: {e:?}");
+                    error!("Upstream: failed to set up SV2 connection: {e}");
                     return Err(e);
                 }
             }

--- a/pool-apps/jd-server/src/lib/error.rs
+++ b/pool-apps/jd-server/src/lib/error.rs
@@ -12,7 +12,11 @@
 //! The `Owner` type parameter is a zero-sized marker (e.g. [`JobDeclarator`], [`Downstream`])
 //! that controls which constructors (`shutdown`, `disconnect`) are available at the type level.
 
-use std::{fmt::Debug, marker::PhantomData, sync::PoisonError};
+use std::{
+    any::type_name,
+    fmt::{Debug, Display},
+    marker::PhantomData, sync::PoisonError,
+};
 
 use stratum_apps::{
     stratum_core::{
@@ -37,6 +41,13 @@ pub struct JDSError<Owner> {
     _owner: PhantomData<Owner>,
 }
 
+impl<Owner> Display for JDSError<Owner> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let owner = type_name::<Owner>().rsplit("::").next().unwrap_or("Unknown");
+        write!(f, "[{owner}] Action: {}, error: {}", self.action, self.kind)
+    }
+}
+
 /// Recovery action attached to every [`JDSError`].
 #[derive(Debug, Clone, Copy)]
 pub enum Action {
@@ -46,6 +57,18 @@ pub enum Action {
     Disconnect(DownstreamId),
     /// Unrecoverable — the server must shut down.
     Shutdown,
+}
+
+impl Display for Action {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Action::Log => f.write_str("Log"),
+            Action::Disconnect(downstream_id) => {
+                write!(f, "Disconnect(downstream_id: {downstream_id})")
+            }
+            Action::Shutdown => f.write_str("Shutdown"),
+        }
+    }
 }
 
 /// Loop control signal for message-processing loops.
@@ -125,6 +148,43 @@ pub enum JDSErrorKind {
 impl<T> From<PoisonError<T>> for JDSErrorKind {
     fn from(_: PoisonError<T>) -> Self {
         JDSErrorKind::PoisonLock
+    }
+}
+
+impl Display for JDSErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JDSErrorKind::Io(error) => write!(f, "I/O error: {error}"),
+            JDSErrorKind::ChannelSend(error) => write!(f, "Channel send failed: {error:?}"),
+            JDSErrorKind::ChannelRecv(error) => write!(f, "Channel receive failed: {error}"),
+            JDSErrorKind::BinarySv2(error) => write!(f, "Binary SV2 error: {error:?}"),
+            JDSErrorKind::Codec(error) => write!(f, "Codec SV2 error: {error}"),
+            JDSErrorKind::Noise(error) => write!(f, "Noise error: {error:?}"),
+            JDSErrorKind::Parser(error) => write!(f, "Parser error: {error}"),
+            JDSErrorKind::BitcoinCoreIPC(error) => write!(f, "Bitcoin Core IPC error: {error}"),
+            JDSErrorKind::Framing(error) => write!(f, "Framing SV2 error: {error}"),
+            JDSErrorKind::UnexpectedMessage(extension_type, message_type) => write!(
+                f,
+                "Unexpected message: extension type {extension_type:?}, message type {message_type:?}"
+            ),
+            JDSErrorKind::ClientNotFound(downstream_id) => {
+                write!(f, "Client not found for downstream {downstream_id}")
+            }
+            JDSErrorKind::ClientSenderNotFound(downstream_id) => {
+                write!(f, "Client sender not found for downstream {downstream_id}")
+            }
+            JDSErrorKind::PendingDeclareMiningJobNotFound(request_id) => write!(
+                f,
+                "Pending DeclareMiningJob not found for request_id {request_id}"
+            ),
+            JDSErrorKind::UnsupportedProtocol => f.write_str("Unsupported protocol"),
+            JDSErrorKind::UnsupportedConnectionFlags => {
+                f.write_str("Unsupported connection flags")
+            }
+            JDSErrorKind::OneshotRecv(error) => write!(f, "Oneshot receive failed: {error}"),
+            JDSErrorKind::InvalidConfig(error) => write!(f, "Invalid config: {error}"),
+            JDSErrorKind::PoisonLock => write!(f, "Lock Poisoned")
+        }
     }
 }
 

--- a/pool-apps/jd-server/src/lib/error.rs
+++ b/pool-apps/jd-server/src/lib/error.rs
@@ -15,7 +15,8 @@
 use std::{
     any::type_name,
     fmt::{Debug, Display},
-    marker::PhantomData, sync::PoisonError,
+    marker::PhantomData,
+    sync::PoisonError,
 };
 
 use stratum_apps::{
@@ -43,7 +44,10 @@ pub struct JDSError<Owner> {
 
 impl<Owner> Display for JDSError<Owner> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let owner = type_name::<Owner>().rsplit("::").next().unwrap_or("Unknown");
+        let owner = type_name::<Owner>()
+            .rsplit("::")
+            .next()
+            .unwrap_or("Unknown");
         write!(f, "[{owner}] Action: {}, error: {}", self.action, self.kind)
     }
 }

--- a/pool-apps/jd-server/src/lib/job_declarator/downstream/mod.rs
+++ b/pool-apps/jd-server/src/lib/job_declarator/downstream/mod.rs
@@ -85,23 +85,19 @@ impl Downstream {
             error::Action::Log => {
                 warn!(
                     downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
+                    error = %e,
                     "{context} returned a log-only error"
                 );
                 LoopControl::Continue
             }
             error::Action::Disconnect(_) => {
-                warn!(
-                    downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
-                    "{context} requested disconnect"
-                );
+                warn!(error = %e, "{context} requested disconnect");
                 LoopControl::Break
             }
             error::Action::Shutdown => {
                 warn!(
                     downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
+                    error = %e,
                     "{context} requested shutdown"
                 );
                 LoopControl::Break
@@ -171,7 +167,7 @@ impl Downstream {
     ) {
         // Setup initial connection
         if let Err(e) = self.setup_connection_with_downstream().await {
-            error!(?e, "Failed to set up downstream connection");
+            error!(%e, "Failed to set up downstream connection");
 
             // sleep to make sure SetupConnectionError is sent
             // before we break the TCP connection
@@ -206,7 +202,7 @@ impl Downstream {
 
                     res = self_clone_1.handle_message_from_downstream() => {
                         if let Err(e) = res {
-                            error!(?e, "Error handling downstream message for {downstream_id}");
+                            error!(%e, "Error handling downstream message for {downstream_id}");
                             if let LoopControl::Break = self.handle_error_action(
                                 "Downstream::handle_message_from_downstream",
                                 &e,
@@ -217,7 +213,7 @@ impl Downstream {
                     }
                     res = self_clone_2.handle_job_declarator_message() => {
                         if let Err(e) = res {
-                            error!(?e, "Error handling job declarator message for {downstream_id}");
+                            error!(%e, "Error handling job declarator message for {downstream_id}");
                             if let LoopControl::Break = self.handle_error_action(
                                 "Downstream::handle_job_declarator_message",
                                 &e,

--- a/pool-apps/jd-server/src/lib/job_declarator/mod.rs
+++ b/pool-apps/jd-server/src/lib/job_declarator/mod.rs
@@ -157,20 +157,16 @@ impl JobDeclarator {
     ) -> LoopControl {
         match e.action {
             error::Action::Log => {
-                warn!(error_kind = ?e.kind, "{context} returned a log-only error");
+                warn!(error = %e, "{context} returned a log-only error");
                 LoopControl::Continue
             }
             error::Action::Disconnect(downstream_id) => {
-                warn!(
-                    downstream_id,
-                    error_kind = ?e.kind,
-                    "{context} requested downstream disconnect"
-                );
+                warn!(error = %e, "{context} requested downstream disconnect");
                 self.cleanup_downstream(downstream_id);
                 LoopControl::Continue
             }
             error::Action::Shutdown => {
-                warn!(error_kind = ?e.kind, "{context} requested shutdown");
+                warn!(error = %e, "{context} requested shutdown");
                 LoopControl::Break
             }
         }
@@ -308,7 +304,7 @@ impl JobDeclarator {
                     }
                     res = self.handle_jdp_message() => {
                         if let Err(e) = res {
-                            error!(?e, "Error handling Job Declaration message");
+                            error!(%e, "Error handling Job Declaration message");
                             if let LoopControl::Break = self.handle_error_action(
                                 "JobDeclarator::handle_jdp_message",
                                 &e,

--- a/pool-apps/pool/src/lib/channel_manager/mod.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mod.rs
@@ -125,28 +125,21 @@ impl ChannelManager {
         cancellation_token: &CancellationToken,
     ) -> LoopControl {
         if cancellation_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error after shutdown was requested"
-            );
+            debug!(error = %e, "{context} returned an error after shutdown was requested");
             return LoopControl::Continue;
         }
         match e.action {
             Action::Log => {
-                warn!(error_kind = ?e.kind, "{context} returned a log-only error");
+                warn!(error = %e, "{context} returned a log-only error");
                 LoopControl::Continue
             }
             Action::Disconnect(downstream_id) => {
-                warn!(
-                    downstream_id,
-                    error_kind = ?e.kind,
-                    "{context} requested downstream disconnect"
-                );
+                warn!(error = %e, "{context} requested downstream disconnect");
                 self.remove_downstream(downstream_id);
                 LoopControl::Continue
             }
             Action::Shutdown => {
-                warn!(error_kind = ?e.kind, "{context} requested shutdown");
+                warn!(error = %e, "{context} requested shutdown");
                 cancellation_token.cancel();
                 LoopControl::Break
             }

--- a/pool-apps/pool/src/lib/downstream/mod.rs
+++ b/pool-apps/pool/src/lib/downstream/mod.rs
@@ -93,34 +93,27 @@ impl Downstream {
         cancellation_token: &CancellationToken,
     ) -> LoopControl {
         if cancellation_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error after shutdown was requested"
-            );
+            debug!(error = %e, "{context} returned an error after shutdown was requested");
             return LoopControl::Continue;
         }
         match e.action {
             Action::Log => {
                 warn!(
                     downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
+                    error = %e,
                     "{context} returned a log-only error"
                 );
                 LoopControl::Continue
             }
             Action::Disconnect(_) => {
-                warn!(
-                    downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
-                    "{context} requested disconnect; cancelling downstream token"
-                );
+                warn!(error = %e, "{context} requested disconnect; cancelling downstream token");
                 self.downstream_connection_token.cancel();
                 LoopControl::Break
             }
             Action::Shutdown => {
                 warn!(
                     downstream_id = self.downstream_id,
-                    error_kind = ?e.kind,
+                    error = %e,
                     "{context} requested shutdown; cancelling global token"
                 );
                 cancellation_token.cancel();
@@ -197,7 +190,7 @@ impl Downstream {
     ) {
         // Setup initial connection
         if let Err(e) = self.setup_connection_with_downstream().await {
-            error!(?e, "Failed to set up downstream connection");
+            error!(%e, "Failed to set up downstream connection");
 
             // sleep to make sure SetupConnectionError is sent
             // before we break the TCP connection
@@ -226,7 +219,7 @@ impl Downstream {
                     }
                     res = self_clone_1.handle_downstream_message() => {
                         if let Err(e) = res {
-                            error!(?e, "Error handling downstream message for {downstream_id}");
+                            error!(%e, "Error handling downstream message for {downstream_id}");
                             if let LoopControl::Break = self.handle_error_action(
                                 "Downstream::handle_downstream_message",
                                 &e,
@@ -238,7 +231,7 @@ impl Downstream {
                     }
                     res = self_clone_2.handle_channel_manager_message() => {
                         if let Err(e) = res {
-                            error!(?e, "Error handling channel manager message for {downstream_id}");
+                            error!(%e, "Error handling channel manager message for {downstream_id}");
                             if let LoopControl::Break = self.handle_error_action(
                                 "Downstream::handle_channel_manager_message",
                                 &e,

--- a/pool-apps/pool/src/lib/error.rs
+++ b/pool-apps/pool/src/lib/error.rs
@@ -482,7 +482,10 @@ impl<Owner> HandlerErrorType for PoolError<Owner> {
 
 impl<Owner> std::fmt::Display for PoolError<Owner> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let owner = type_name::<Owner>().rsplit("::").next().unwrap_or("Unknown");
+        let owner = type_name::<Owner>()
+            .rsplit("::")
+            .next()
+            .unwrap_or("Unknown");
         write!(f, "[{owner}] Action: {}, error: {}", self.action, self.kind)
     }
 }

--- a/pool-apps/pool/src/lib/error.rs
+++ b/pool-apps/pool/src/lib/error.rs
@@ -1,6 +1,7 @@
 use std::{
+    any::type_name,
     convert::From,
-    fmt::{self, Debug, Formatter},
+    fmt::{self, Debug, Display, Formatter},
     marker::PhantomData,
     sync::{MutexGuard, PoisonError},
 };
@@ -56,6 +57,18 @@ pub enum Action {
 pub enum LoopControl {
     Continue,
     Break,
+}
+
+impl Display for Action {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Action::Log => f.write_str("Log"),
+            Action::Disconnect(downstream_id) => {
+                write!(f, "Disconnect(downstream_id: {downstream_id})")
+            }
+            Action::Shutdown => f.write_str("Shutdown"),
+        }
+    }
 }
 
 impl CanDisconnect for Downstream {}
@@ -114,6 +127,28 @@ pub enum ChannelSv2Error {
     GroupChannelServerSide(GroupChannelError),
     ExtranonceError(ExtranonceAllocatorError),
     ShareValidationError(ShareValidationError),
+}
+
+impl Display for ChannelSv2Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            ChannelSv2Error::ExtendedChannelServerSide(error) => {
+                write!(f, "{error:?}")
+            }
+            ChannelSv2Error::StandardChannelServerSide(error) => {
+                write!(f, "{error:?}")
+            }
+            ChannelSv2Error::GroupChannelServerSide(error) => {
+                write!(f, "{error:?}")
+            }
+            ChannelSv2Error::ExtranonceError(error) => {
+                write!(f, "{error:?}")
+            }
+            ChannelSv2Error::ShareValidationError(error) => {
+                write!(f, "{error:?}")
+            }
+        }
+    }
 }
 
 /// Represents various errors that can occur in the pool implementation.
@@ -210,28 +245,28 @@ impl std::fmt::Display for PoolErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use PoolErrorKind::*;
         match self {
-            Io(e) => write!(f, "I/O error: `{e:?}"),
-            ChannelSend(e) => write!(f, "Channel send failed: `{e:?}`"),
-            ChannelRecv(e) => write!(f, "Channel recv failed: `{e:?}`"),
-            BinarySv2(e) => write!(f, "Binary SV2 error: `{e:?}`"),
-            Codec(e) => write!(f, "Codec SV2 error: `{e:?}"),
-            CoinbaseOutput(e) => write!(f, "Coinbase output error: `{e:?}"),
-            Framing(e) => write!(f, "Framing SV2 error: `{e:?}`"),
-            Noise(e) => write!(f, "Noise SV2 error: `{e:?}"),
-            PoisonLock(e) => write!(f, "Poison lock: {e:?}"),
-            ComponentShutdown(e) => write!(f, "Component shutdown: {e:?}"),
-            Custom(e) => write!(f, "Custom SV2 error: `{e:?}`"),
+            Io(e) => write!(f, "I/O error: {e}"),
+            ChannelSend(e) => write!(f, "Channel send failed: {e:?}"),
+            ChannelRecv(e) => write!(f, "Channel recv failed: {e}"),
+            BinarySv2(e) => write!(f, "Binary SV2 error: {e:?}"),
+            Codec(e) => write!(f, "Codec SV2 error: {e:?}"),
+            CoinbaseOutput(e) => write!(f, "Coinbase output error: {e}"),
+            Framing(e) => write!(f, "Framing SV2 error: {e:?}"),
+            Noise(e) => write!(f, "Noise SV2 error: {e:?}"),
+            PoisonLock(e) => write!(f, "Poison lock: {e}"),
+            ComponentShutdown(e) => write!(f, "Component shutdown: {e}"),
+            Custom(e) => write!(f, "Custom SV2 error: {e}"),
             Sv2ProtocolError(e) => {
                 write!(f, "Received Sv2 Protocol Error from upstream: `{e:?}`")
             }
             PoolErrorKind::Vardiff(e) => {
-                write!(f, "Received Vardiff Error : {e:?}")
+                write!(f, "Received Vardiff Error: {e:?}")
             }
-            Parser(e) => write!(f, "Parser error: `{e:?}`"),
+            Parser(e) => write!(f, "Parser error: {e}"),
             UnexpectedMessage(extension_type, message_type) => write!(f, "Unexpected message: extension type: {extension_type:?}, message type: {message_type:?}"),
             ChannelErrorSender => write!(f, "Channel sender error"),
-            InvalidSocketAddress(address) => write!(f, "Invalid socket address: {address:?}"),
-            BitcoinEncodeError(_) => write!(f, "Error generated during encoding"),
+            InvalidSocketAddress(address) => write!(f, "Invalid socket address: {address}"),
+            BitcoinEncodeError(error) => write!(f, "Error generated during encoding: {error}"),
             DownstreamNotFoundWithChannelId(channel_id) => {
                 write!(f, "Downstream not found for channel id: {channel_id}")
             }
@@ -246,9 +281,9 @@ impl std::fmt::Display for PoolErrorKind {
                 f,
                 "Vardiff not found available for downstream id: {downstream_id}"
             ),
-            ParseInt(e) => write!(f, "Conversion error: {e:?}"),
+            ParseInt(e) => write!(f, "Conversion error: {e}"),
             ChannelSv2(channel_error) => {
-                write!(f, "Channel error: {channel_error:?}")
+                write!(f, "Channel error: {channel_error}")
             }
             InvalidUnsupportedExtensionsSequence(e) => {
                 write!(
@@ -295,7 +330,7 @@ impl std::fmt::Display for PoolErrorKind {
             JobNotFound => write!(f, "Job not found"),
             InvalidKey => write!(f, "Invalid key used during noise handshake"),
             PayoutModeError(e) => write!(f, "Unable to parse the PayoutMode: {e}"),
-            Jds(e) => write!(f, "JDS error: {e:?}"),
+            Jds(e) => write!(f, "JDS error: {e}"),
             Timeout => write!(f, "Time out error"),
         }
     }
@@ -447,7 +482,8 @@ impl<Owner> HandlerErrorType for PoolError<Owner> {
 
 impl<Owner> std::fmt::Display for PoolError<Owner> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "[{:?}/{:?}]", self.kind, self.action)
+        let owner = type_name::<Owner>().rsplit("::").next().unwrap_or("Unknown");
+        write!(f, "[{owner}] Action: {}, error: {}", self.action, self.kind)
     }
 }
 

--- a/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
+++ b/pool-apps/pool/src/lib/template_receiver/sv2_tp/mod.rs
@@ -56,24 +56,21 @@ impl Sv2Tp {
         cancellation_token: &CancellationToken,
     ) -> LoopControl {
         if cancellation_token.is_cancelled() {
-            debug!(
-                error_kind = ?e.kind,
-                "{context} returned an error after shutdown was requested"
-            );
+            debug!(error = %e, "{context} returned an error after shutdown was requested");
             return LoopControl::Continue;
         }
         match e.action {
             Action::Log => {
-                warn!(error_kind = ?e.kind, "{context} returned a log-only error");
+                warn!(error = %e, "{context} returned a log-only error");
                 LoopControl::Continue
             }
             Action::Shutdown => {
-                warn!(error_kind = ?e.kind, "{context} requested shutdown");
+                warn!(error = %e, "{context} requested shutdown");
                 cancellation_token.cancel();
                 LoopControl::Break
             }
             other => {
-                warn!(action = ?other, error_kind = ?e.kind, "{context} returned an unhandled action");
+                warn!(action = %other, error = %e, "{context} returned an unhandled action");
                 LoopControl::Continue
             }
         }
@@ -207,7 +204,7 @@ impl Sv2Tp {
                     }
                     res = self_clone_1.handle_template_provider_message() => {
                         if let Err(e) = res {
-                            error!("TemplateReceiver template provider handler failed: {e:?}");
+                            error!("TemplateReceiver template provider handler failed: {e}");
                             if let LoopControl::Break = Self::handle_error_action(
                                 "Sv2Tp::handle_template_provider_message",
                                 &e,
@@ -219,7 +216,7 @@ impl Sv2Tp {
                     }
                     res = self_clone_2.handle_channel_manager_message() => {
                         if let Err(e) = res {
-                            error!("TemplateReceiver channel manager handler failed: {e:?}");
+                            error!("TemplateReceiver channel manager handler failed: {e}");
                             if let LoopControl::Break = Self::handle_error_action(
                                 "Sv2Tp::handle_channel_manager_message",
                                 &e,


### PR DESCRIPTION
I don't really like seeing phantom types in error. Its an internal detail, and shouldn't be exposed in logs. This PR adds impl display trait for error variants across apps.