### PR TITLE
ci: add docs.rs compatibility checks

### DIFF
--- a/.github/workflows/docs-rs.yaml
+++ b/.github/workflows/docs-rs.yaml
@@ -1,0 +1,33 @@
+name: Docs.rs
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  docs-rs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Build docs.rs sandbox
+        run: docker build --file scripts/docs-rs.Dockerfile --tag sv2-docs-rs .
+
+      - name: Check docs.rs compatibility
+        run: |
+          docker run --rm --network none sv2-docs-rs \
+            stratum-apps/Cargo.toml \
+            pool-apps/pool/Cargo.toml \
+            pool-apps/jd-server/Cargo.toml \
+            miner-apps/jd-client/Cargo.toml \
+            miner-apps/translator/Cargo.toml \
+            integration-tests/Cargo.toml \
+            bitcoin-core-sv2/Cargo.toml

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,6 +51,17 @@ This directory contains utility scripts for building, testing, and publishing th
 
 ### 📊 Testing & Coverage Scripts
 
+#### `docs-rs-check.sh`
+**Run docs.rs-like builds for one or more crates**
+- Uses dependencies prefetched by the CI sandbox image
+- Runs `cargo docs-rs --offline` while the container has no network
+- Intended for CI jobs that validate docs.rs compatibility
+
+**Usage:**
+```bash
+./scripts/docs-rs-check.sh <manifest-path> [<manifest-path> ...]
+```
+
 #### `coverage-apps.sh`
 **Generate test coverage reports**
 - Uses cargo-tarpaulin for coverage analysis

--- a/scripts/docs-rs-check.sh
+++ b/scripts/docs-rs-check.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Run docs.rs-like documentation builds for one or more crates.
+# Arguments:
+#   paths to Cargo.toml files
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+  echo "Usage: $0 <manifest-path> [<manifest-path> ...]" >&2
+  exit 2
+fi
+
+for manifest_path in "$@"; do
+  if [ ! -f "$manifest_path" ]; then
+    echo "Manifest not found: $manifest_path" >&2
+    exit 1
+  fi
+
+  echo "Building docs for ${manifest_path}"
+  cargo +nightly docs-rs --manifest-path="$manifest_path" --offline
+done

--- a/scripts/docs-rs.Dockerfile
+++ b/scripts/docs-rs.Dockerfile
@@ -1,0 +1,33 @@
+FROM rustlang/rust:nightly-bookworm
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        capnproto \
+        clang \
+        cmake \
+        libcapnp-dev \
+        libssl-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cargo install cargo-docs-rs --locked
+
+RUN useradd --create-home --uid 1000 docs \
+    && chown --recursive docs:docs /usr/local/cargo
+
+WORKDIR /workspace
+COPY --chown=docs:docs . .
+
+USER docs
+
+# Populate Cargo's cache while image builds still have network access. The
+# resulting image runs the documentation build with Docker networking disabled.
+RUN cargo fetch --manifest-path=stratum-apps/Cargo.toml \
+    && cargo fetch --manifest-path=pool-apps/pool/Cargo.toml \
+    && cargo fetch --manifest-path=pool-apps/jd-server/Cargo.toml \
+    && cargo fetch --manifest-path=miner-apps/jd-client/Cargo.toml \
+    && cargo fetch --manifest-path=miner-apps/translator/Cargo.toml \
+    && cargo fetch --manifest-path=integration-tests/Cargo.toml \
+    && cargo fetch --manifest-path=bitcoin-core-sv2/Cargo.toml
+
+ENTRYPOINT ["./scripts/docs-rs-check.sh"]


### PR DESCRIPTION
## Summary

- add a GitHub Actions workflow that checks docs.rs compatibility for all seven published application crates
- prefetch dependencies, then run `cargo docs-rs --offline` inside an isolated Linux network namespace
- document the reusable `docs-rs-check.sh` helper

## Why

docs.rs builds crates without network access. A regular documentation build can therefore miss regressions where a dependency or build script attempts a download, as happened in #519.

This adds a focused regression check while keeping the implementation smaller than running the full docs.rs infrastructure.

Closes #524.

## Validation

- `cargo +nightly docs-rs --offline` passed for:
  - `stratum-apps`
  - `pool_sv2`
  - `jd_server_sv2`
  - `jd_client_sv2`
  - `translator_sv2`
  - `integration_tests_sv2`
  - `bitcoin_core_sv2`
- `actionlint .github/workflows/docs-rs.yaml`
- `shellcheck scripts/docs-rs-check.sh`
- `bash -n scripts/docs-rs-check.sh`
- `git diff --check`

The full Linux network-namespace path is exercised by the new workflow on this pull request.
