### PR TITLE
`bitcoin-core-sv2`: harden JDP `handle_declare_mining_job` against untrusted `DeclareMiningJob` inputs

### DIFF
--- a/bitcoin-core-sv2/src/unix_capnp/v30x/job_declaration_protocol/handlers.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/job_declaration_protocol/handlers.rs
@@ -14,8 +14,10 @@ use stratum_core::{
         hashes::Hash,
     },
     job_declaration_sv2::{
-        ERROR_CODE_DECLARE_MINING_JOB_INTERNAL_ERROR, ERROR_CODE_DECLARE_MINING_JOB_INVALID_JOB,
-        ERROR_CODE_DECLARE_MINING_JOB_STALE_CHAIN_TIP, PushSolutionOwned,
+        ERROR_CODE_DECLARE_MINING_JOB_INTERNAL_ERROR,
+        ERROR_CODE_DECLARE_MINING_JOB_INVALID_COINBASE_TX_INPUT,
+        ERROR_CODE_DECLARE_MINING_JOB_INVALID_JOB, ERROR_CODE_DECLARE_MINING_JOB_STALE_CHAIN_TIP,
+        PushSolutionOwned,
     },
 };
 use tokio::sync::oneshot;
@@ -24,7 +26,8 @@ use tracing::{debug, error, info, warn};
 impl BitcoinCoreSv2JDP {
     /// Validates a declared mining job by checking transaction availability and block structure.
     ///
-    /// Adds missing transactions to the mempool mirror, verifies all transactions are available,
+    /// Rejects a coinbase that does not carry exactly one input, adds missing transactions to the
+    /// mempool mirror, verifies all transactions are available,
     /// assembles a test block, and uses Bitcoin Core's `checkBlock` to validate the block
     /// structure. Returns success with current template parameters or an error if validation
     /// fails.
@@ -45,7 +48,7 @@ impl BitcoinCoreSv2JDP {
         );
         debug!(
             "Declared coinbase scriptSig: {:?}",
-            coinbase_tx.input[0].script_sig
+            coinbase_tx.input.first().map(|input| &input.script_sig)
         );
 
         let declared_bip34_height = coinbase_tx
@@ -85,6 +88,24 @@ impl BitcoinCoreSv2JDP {
             let initial_bip34_height = mempool_mirror
                 .get_current_bip34_height()
                 .expect("current_bip34_height must be set");
+
+            // A coinbase must carry exactly one input. Reject anything else before assembling
+            // the block: a zero-input coinbase re-serializes into bytes Bitcoin Core's
+            // deserializer reads as a SegWit marker ("Superfluous witness record"), which comes
+            // back as a capnp remote exception and tears down the whole IPC connection.
+            if coinbase_tx.input.len() != 1 {
+                warn!(
+                    "Rejecting DeclareMiningJob: declared coinbase has {} inputs, expected exactly 1",
+                    coinbase_tx.input.len()
+                );
+                // deliberately ignore potential errors
+                // we don't care if the receiver dropped the channel
+                let _ = response_tx.send(JdResponse::Error {
+                    error_code: ERROR_CODE_DECLARE_MINING_JOB_INVALID_COINBASE_TX_INPUT,
+                    validation_context: initial_validation_context,
+                });
+                return;
+            }
 
             // Now verify that all wtxids from the declared job are available
             let missing_wtxids = mempool_mirror.verify(&wtxid_list);

--- a/bitcoin-core-sv2/src/unix_capnp/v30x/job_declaration_protocol/handlers.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/job_declaration_protocol/handlers.rs
@@ -6,6 +6,7 @@ use crate::{
         BitcoinCoreSv2JDP, mempool::decode_bip34_height_from_coinbase_script_sig,
     },
 };
+use std::collections::HashMap;
 use stratum_core::{
     bitcoin::{
         Block, Transaction, TxMerkleNode, Txid, Wtxid,
@@ -26,11 +27,14 @@ use tracing::{debug, error, info, warn};
 impl BitcoinCoreSv2JDP {
     /// Validates a declared mining job by checking transaction availability and block structure.
     ///
-    /// Rejects a coinbase that does not carry exactly one input, adds missing transactions to the
-    /// mempool mirror, verifies all transactions are available,
-    /// assembles a test block, and uses Bitcoin Core's `checkBlock` to validate the block
-    /// structure. Returns success with current template parameters or an error if validation
-    /// fails.
+    /// Stages the client-supplied transactions locally, rejects a coinbase that does not carry
+    /// exactly one input, verifies all declared wtxids resolve against the mempool mirror plus
+    /// that staging area, assembles a test block, and uses Bitcoin Core's `checkBlock` to validate
+    /// the block structure. Staged transactions are only committed to the mempool mirror after
+    /// `checkBlock` succeeds and only if the chain tip did not move while `checkBlock` was in
+    /// flight, so a rejected declaration never grows shared state and stale transactions never
+    /// seed a freshly-cleared mirror. Returns success with current template parameters or an
+    /// error if validation fails.
     pub(crate) async fn handle_declare_mining_job(
         &self,
         version: Version,
@@ -63,11 +67,16 @@ impl BitcoinCoreSv2JDP {
             // stale-tip comparison signal.
             .unwrap_or_else(|| coinbase_tx.lock_time.to_consensus_u32());
 
-        let (initial_validation_context, initial_bip34_height, txdata) = {
-            let mut mempool_mirror = self.mempool_mirror.borrow_mut();
+        // Client-supplied transactions are staged locally and only committed to the process-wide
+        // mempool mirror once Bitcoin Core has validated the assembled block, so rejected
+        // declarations cannot grow shared state.
+        let mut staged_txs: HashMap<Wtxid, Transaction> = missing_txs
+            .into_iter()
+            .map(|tx| (tx.compute_wtxid(), tx))
+            .collect();
 
-            // Add the missing transactions to the mempool mirror
-            mempool_mirror.add_transactions(missing_txs);
+        let (initial_validation_context, initial_bip34_height, txdata) = {
+            let mempool_mirror = self.mempool_mirror.borrow();
 
             let prev_hash = mempool_mirror
                 .get_current_prev_hash()
@@ -107,19 +116,20 @@ impl BitcoinCoreSv2JDP {
                 return;
             }
 
-            // Now verify that all wtxids from the declared job are available
-            let missing_wtxids = mempool_mirror.verify(&wtxid_list);
-            if !missing_wtxids.is_empty() {
-                // deliberately ignore potential errors
-                // we don't care if the receiver dropped the channel
-                let _ = response_tx.send(JdResponse::MissingTransactions {
-                    missing_wtxids,
-                    validation_context: initial_validation_context,
-                });
-                return;
-            }
-
-            let txdata = mempool_mirror.get_txdata(&wtxid_list);
+            // Now verify that all wtxids from the declared job are available, either in the
+            // mirror or among the staged (still unvalidated) transactions
+            let txdata = match mempool_mirror.resolve_txdata(&wtxid_list, &staged_txs) {
+                Ok(txdata) => txdata,
+                Err(missing_wtxids) => {
+                    // deliberately ignore potential errors
+                    // we don't care if the receiver dropped the channel
+                    let _ = response_tx.send(JdResponse::MissingTransactions {
+                        missing_wtxids,
+                        validation_context: initial_validation_context,
+                    });
+                    return;
+                }
+            };
 
             info!(
                 "Using prevhash: {:?}, nbits: {:?}, min_ntime: {}, bip34_height: {} from mempool mirror",
@@ -284,6 +294,32 @@ impl BitcoinCoreSv2JDP {
                 .expect("current_bip34_height must be set");
             (latest_validation_context, latest_bip34_height)
         };
+
+        if valid_job {
+            if latest_validation_context.prev_hash == initial_validation_context.prev_hash {
+                // checkBlock validated the assembled block, so the client-supplied transactions it
+                // contained are now safe to commit to the shared mempool mirror. Staged
+                // transactions that were not declared were never part of that block, so they are
+                // dropped.
+                let validated_txs: Vec<Transaction> = wtxid_list
+                    .iter()
+                    .filter_map(|wtxid| staged_txs.remove(wtxid))
+                    .collect();
+                self.mempool_mirror
+                    .borrow_mut()
+                    .add_transactions(validated_txs);
+            } else {
+                // The chain tip moved while checkBlock was in flight: the template monitor
+                // already cleared the mirror for the new tip, and these transactions were only
+                // validated against the old one. Drop them instead of seeding the new-tip mirror
+                // with stale entries; the client will resend them if still relevant.
+                debug!(
+                    initial_prev_hash = ?initial_validation_context.prev_hash,
+                    latest_prev_hash = ?latest_validation_context.prev_hash,
+                    "Chain tip moved during checkBlock; discarding staged transactions instead of committing them to the mirror"
+                );
+            }
+        }
 
         let response = if valid_job {
             JdResponse::Success {

--- a/bitcoin-core-sv2/src/unix_capnp/v30x/job_declaration_protocol/mempool.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/job_declaration_protocol/mempool.rs
@@ -52,9 +52,10 @@ impl MempoolMirror {
         }
     }
 
-    /// Adds transactions to the mempool mirror.
+    /// Commits transactions into the mempool mirror.
     ///
-    /// Used to add missing transactions from ProvideMissingTransactionsSuccess messages.
+    /// Only call this for transactions Bitcoin Core has already accepted as part of a valid
+    /// block: unvalidated client-supplied transactions must stay staged outside the mirror.
     pub fn add_transactions(&mut self, transactions: Vec<Transaction>) {
         for tx in transactions {
             let wtxid = tx.compute_wtxid();
@@ -62,21 +63,33 @@ impl MempoolMirror {
         }
     }
 
-    /// Retrieves transactions by wtxid.
-    pub fn get_txdata(&self, wtxids: &[Wtxid]) -> Vec<Transaction> {
-        wtxids
-            .iter()
-            .filter_map(|wtxid| self.txdata.get(wtxid).cloned())
-            .collect()
-    }
+    /// Resolves `wtxids` into transactions, preferring `staged` over the mirror's own txdata.
+    ///
+    /// `staged` holds client-supplied transactions that have not been validated yet, so they are
+    /// deliberately kept out of the mirror until the caller commits them via
+    /// [`MempoolMirror::add_transactions`].
+    ///
+    /// Returns `Err` with every wtxid that could not be resolved, preserving `wtxids` order.
+    pub fn resolve_txdata(
+        &self,
+        wtxids: &[Wtxid],
+        staged: &HashMap<Wtxid, Transaction>,
+    ) -> Result<Vec<Transaction>, Vec<Wtxid>> {
+        let mut txdata = Vec::with_capacity(wtxids.len());
+        let mut missing = Vec::new();
 
-    /// Returns wtxids that are not present in the mempool.
-    pub fn verify(&self, wtxids: &[Wtxid]) -> Vec<Wtxid> {
-        wtxids
-            .iter()
-            .filter(|&wtxid| !self.txdata.contains_key(wtxid))
-            .copied()
-            .collect()
+        for wtxid in wtxids {
+            match staged.get(wtxid).or_else(|| self.txdata.get(wtxid)) {
+                Some(tx) => txdata.push(tx.clone()),
+                None => missing.push(*wtxid),
+            }
+        }
+
+        if missing.is_empty() {
+            Ok(txdata)
+        } else {
+            Err(missing)
+        }
     }
 
     /// Returns the current template's prev_hash.

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/job_declaration_protocol/handlers.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/job_declaration_protocol/handlers.rs
@@ -14,8 +14,10 @@ use stratum_core::{
         hashes::Hash,
     },
     job_declaration_sv2::{
-        ERROR_CODE_DECLARE_MINING_JOB_INTERNAL_ERROR, ERROR_CODE_DECLARE_MINING_JOB_INVALID_JOB,
-        ERROR_CODE_DECLARE_MINING_JOB_STALE_CHAIN_TIP, PushSolutionOwned,
+        ERROR_CODE_DECLARE_MINING_JOB_INTERNAL_ERROR,
+        ERROR_CODE_DECLARE_MINING_JOB_INVALID_COINBASE_TX_INPUT,
+        ERROR_CODE_DECLARE_MINING_JOB_INVALID_JOB, ERROR_CODE_DECLARE_MINING_JOB_STALE_CHAIN_TIP,
+        PushSolutionOwned,
     },
 };
 use tokio::sync::oneshot;
@@ -24,7 +26,8 @@ use tracing::{debug, error, info, warn};
 impl BitcoinCoreSv2JDP {
     /// Validates a declared mining job by checking transaction availability and block structure.
     ///
-    /// Adds missing transactions to the mempool mirror, verifies all transactions are available,
+    /// Rejects a coinbase that does not carry exactly one input, adds missing transactions to the
+    /// mempool mirror, verifies all transactions are available,
     /// assembles a test block, sets IPC thread context, and uses Bitcoin Core's `checkBlock` to
     /// validate the block structure. Returns success with current template parameters or an error
     /// if validation fails.
@@ -45,7 +48,7 @@ impl BitcoinCoreSv2JDP {
         );
         debug!(
             "Declared coinbase scriptSig: {:?}",
-            coinbase_tx.input[0].script_sig
+            coinbase_tx.input.first().map(|input| &input.script_sig)
         );
 
         let declared_bip34_height = coinbase_tx
@@ -85,6 +88,24 @@ impl BitcoinCoreSv2JDP {
             let initial_bip34_height = mempool_mirror
                 .get_current_bip34_height()
                 .expect("current_bip34_height must be set");
+
+            // A coinbase must carry exactly one input. Reject anything else before assembling
+            // the block: a zero-input coinbase re-serializes into bytes Bitcoin Core's
+            // deserializer reads as a SegWit marker ("Superfluous witness record"), which comes
+            // back as a capnp remote exception and tears down the whole IPC connection.
+            if coinbase_tx.input.len() != 1 {
+                warn!(
+                    "Rejecting DeclareMiningJob: declared coinbase has {} inputs, expected exactly 1",
+                    coinbase_tx.input.len()
+                );
+                // deliberately ignore potential errors
+                // we don't care if the receiver dropped the channel
+                let _ = response_tx.send(JdResponse::Error {
+                    error_code: ERROR_CODE_DECLARE_MINING_JOB_INVALID_COINBASE_TX_INPUT,
+                    validation_context: initial_validation_context,
+                });
+                return;
+            }
 
             // Now verify that all wtxids from the declared job are available
             let missing_wtxids = mempool_mirror.verify(&wtxid_list);

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/job_declaration_protocol/handlers.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/job_declaration_protocol/handlers.rs
@@ -6,6 +6,7 @@ use crate::{
         BitcoinCoreSv2JDP, mempool::decode_bip34_height_from_coinbase_script_sig,
     },
 };
+use std::collections::HashMap;
 use stratum_core::{
     bitcoin::{
         Block, Transaction, TxMerkleNode, Txid, Wtxid,
@@ -26,11 +27,14 @@ use tracing::{debug, error, info, warn};
 impl BitcoinCoreSv2JDP {
     /// Validates a declared mining job by checking transaction availability and block structure.
     ///
-    /// Rejects a coinbase that does not carry exactly one input, adds missing transactions to the
-    /// mempool mirror, verifies all transactions are available,
-    /// assembles a test block, sets IPC thread context, and uses Bitcoin Core's `checkBlock` to
-    /// validate the block structure. Returns success with current template parameters or an error
-    /// if validation fails.
+    /// Stages the client-supplied transactions locally, rejects a coinbase that does not carry
+    /// exactly one input, verifies all declared wtxids resolve against the mempool mirror plus
+    /// that staging area, assembles a test block, sets IPC thread context, and uses Bitcoin Core's
+    /// `checkBlock` to validate the block structure. Staged transactions are only committed to the
+    /// mempool mirror after `checkBlock` succeeds and only if the chain tip did not move while
+    /// `checkBlock` was in flight, so a rejected declaration never grows shared state and stale
+    /// transactions never seed a freshly-cleared mirror. Returns success with current template
+    /// parameters or an error if validation fails.
     pub(crate) async fn handle_declare_mining_job(
         &self,
         version: Version,
@@ -63,11 +67,16 @@ impl BitcoinCoreSv2JDP {
             // stale-tip comparison signal.
             .unwrap_or_else(|| coinbase_tx.lock_time.to_consensus_u32());
 
-        let (initial_validation_context, initial_bip34_height, txdata) = {
-            let mut mempool_mirror = self.mempool_mirror.borrow_mut();
+        // Client-supplied transactions are staged locally and only committed to the process-wide
+        // mempool mirror once Bitcoin Core has validated the assembled block, so rejected
+        // declarations cannot grow shared state.
+        let mut staged_txs: HashMap<Wtxid, Transaction> = missing_txs
+            .into_iter()
+            .map(|tx| (tx.compute_wtxid(), tx))
+            .collect();
 
-            // Add the missing transactions to the mempool mirror
-            mempool_mirror.add_transactions(missing_txs);
+        let (initial_validation_context, initial_bip34_height, txdata) = {
+            let mempool_mirror = self.mempool_mirror.borrow();
 
             let prev_hash = mempool_mirror
                 .get_current_prev_hash()
@@ -107,19 +116,20 @@ impl BitcoinCoreSv2JDP {
                 return;
             }
 
-            // Now verify that all wtxids from the declared job are available
-            let missing_wtxids = mempool_mirror.verify(&wtxid_list);
-            if !missing_wtxids.is_empty() {
-                // deliberately ignore potential errors
-                // we don't care if the receiver dropped the channel
-                let _ = response_tx.send(JdResponse::MissingTransactions {
-                    missing_wtxids,
-                    validation_context: initial_validation_context,
-                });
-                return;
-            }
-
-            let txdata = mempool_mirror.get_txdata(&wtxid_list);
+            // Now verify that all wtxids from the declared job are available, either in the
+            // mirror or among the staged (still unvalidated) transactions
+            let txdata = match mempool_mirror.resolve_txdata(&wtxid_list, &staged_txs) {
+                Ok(txdata) => txdata,
+                Err(missing_wtxids) => {
+                    // deliberately ignore potential errors
+                    // we don't care if the receiver dropped the channel
+                    let _ = response_tx.send(JdResponse::MissingTransactions {
+                        missing_wtxids,
+                        validation_context: initial_validation_context,
+                    });
+                    return;
+                }
+            };
 
             info!(
                 "Using prevhash: {:?}, nbits: {:?}, min_ntime: {}, bip34_height: {} from mempool mirror",
@@ -299,6 +309,32 @@ impl BitcoinCoreSv2JDP {
                 .expect("current_bip34_height must be set");
             (latest_validation_context, latest_bip34_height)
         };
+
+        if valid_job {
+            if latest_validation_context.prev_hash == initial_validation_context.prev_hash {
+                // checkBlock validated the assembled block, so the client-supplied transactions it
+                // contained are now safe to commit to the shared mempool mirror. Staged
+                // transactions that were not declared were never part of that block, so they are
+                // dropped.
+                let validated_txs: Vec<Transaction> = wtxid_list
+                    .iter()
+                    .filter_map(|wtxid| staged_txs.remove(wtxid))
+                    .collect();
+                self.mempool_mirror
+                    .borrow_mut()
+                    .add_transactions(validated_txs);
+            } else {
+                // The chain tip moved while checkBlock was in flight: the template monitor
+                // already cleared the mirror for the new tip, and these transactions were only
+                // validated against the old one. Drop them instead of seeding the new-tip mirror
+                // with stale entries; the client will resend them if still relevant.
+                debug!(
+                    initial_prev_hash = ?initial_validation_context.prev_hash,
+                    latest_prev_hash = ?latest_validation_context.prev_hash,
+                    "Chain tip moved during checkBlock; discarding staged transactions instead of committing them to the mirror"
+                );
+            }
+        }
 
         let response = if valid_job {
             JdResponse::Success {

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/job_declaration_protocol/mempool.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/job_declaration_protocol/mempool.rs
@@ -52,9 +52,10 @@ impl MempoolMirror {
         }
     }
 
-    /// Adds transactions to the mempool mirror.
+    /// Commits transactions into the mempool mirror.
     ///
-    /// Used to add missing transactions from ProvideMissingTransactionsSuccess messages.
+    /// Only call this for transactions Bitcoin Core has already accepted as part of a valid
+    /// block: unvalidated client-supplied transactions must stay staged outside the mirror.
     pub fn add_transactions(&mut self, transactions: Vec<Transaction>) {
         for tx in transactions {
             let wtxid = tx.compute_wtxid();
@@ -62,21 +63,33 @@ impl MempoolMirror {
         }
     }
 
-    /// Retrieves transactions by wtxid.
-    pub fn get_txdata(&self, wtxids: &[Wtxid]) -> Vec<Transaction> {
-        wtxids
-            .iter()
-            .filter_map(|wtxid| self.txdata.get(wtxid).cloned())
-            .collect()
-    }
+    /// Resolves `wtxids` into transactions, preferring `staged` over the mirror's own txdata.
+    ///
+    /// `staged` holds client-supplied transactions that have not been validated yet, so they are
+    /// deliberately kept out of the mirror until the caller commits them via
+    /// [`MempoolMirror::add_transactions`].
+    ///
+    /// Returns `Err` with every wtxid that could not be resolved, preserving `wtxids` order.
+    pub fn resolve_txdata(
+        &self,
+        wtxids: &[Wtxid],
+        staged: &HashMap<Wtxid, Transaction>,
+    ) -> Result<Vec<Transaction>, Vec<Wtxid>> {
+        let mut txdata = Vec::with_capacity(wtxids.len());
+        let mut missing = Vec::new();
 
-    /// Returns wtxids that are not present in the mempool.
-    pub fn verify(&self, wtxids: &[Wtxid]) -> Vec<Wtxid> {
-        wtxids
-            .iter()
-            .filter(|&wtxid| !self.txdata.contains_key(wtxid))
-            .copied()
-            .collect()
+        for wtxid in wtxids {
+            match staged.get(wtxid).or_else(|| self.txdata.get(wtxid)) {
+                Some(tx) => txdata.push(tx.clone()),
+                None => missing.push(*wtxid),
+            }
+        }
+
+        if missing.is_empty() {
+            Ok(txdata)
+        } else {
+            Err(missing)
+        }
     }
 
     /// Returns the current template's prev_hash.

--- a/integration-tests/tests/bitcoin_core_ipc_jdp_io.rs
+++ b/integration-tests/tests/bitcoin_core_ipc_jdp_io.rs
@@ -5,6 +5,8 @@
 //! - `DeclareMiningJob` returns `Success` for a minimal valid declaration.
 //! - `DeclareMiningJob` returns `Error(stale-chain-tip)` when the declared BIP34 height is
 //!   intentionally mismatched.
+//! - `DeclareMiningJob` rejects a coinbase that does not carry exactly one input, without
+//!   tearing down the IPC connection.
 //!
 //! File structure:
 //! - top: version-specific `#[tokio::test]` wrappers.
@@ -32,7 +34,10 @@ use stratum_apps::{
             absolute::LockTime, block::Version as BlockVersion, hashes::Hash,
             transaction::Version as TxVersion,
         },
-        job_declaration_sv2::ERROR_CODE_DECLARE_MINING_JOB_STALE_CHAIN_TIP,
+        job_declaration_sv2::{
+            ERROR_CODE_DECLARE_MINING_JOB_INVALID_COINBASE_TX_INPUT,
+            ERROR_CODE_DECLARE_MINING_JOB_STALE_CHAIN_TIP,
+        },
     },
 };
 
@@ -98,6 +103,10 @@ async fn assert_jdp_io_integration_for_version(version: BitcoinCoreVersion) {
         .expect("JDP readiness channel dropped unexpectedly");
 
     // Execute all JDP paths against the same live runtime to keep this test fully end-to-end.
+    // The malformed-coinbase path runs first on purpose: every scenario after it doubles as
+    // proof that rejecting it did not tear down the IPC connection.
+    assert_jdp_invalid_coinbase_input_scenario(&incoming_sender).await;
+
     let missing_wtxid = Wtxid::from_byte_array([0x42; 32]);
     assert_jdp_missing_transactions_scenario(&incoming_sender, coinbase_tx.clone(), missing_wtxid)
         .await;
@@ -180,6 +189,32 @@ async fn assert_jdp_stale_chain_tip_scenario(
     }
 }
 
+/// A coinbase that does not carry exactly one input must be rejected before block assembly.
+///
+/// A zero-input coinbase re-serializes into bytes Bitcoin Core's deserializer reads as a SegWit
+/// marker, so letting it reach `checkBlock` yields a capnp remote exception, which the handler
+/// answers with `internal-error` and follows by cancelling the whole IPC connection.
+async fn assert_jdp_invalid_coinbase_input_scenario(incoming_sender: &Sender<JdRequest>) {
+    let response = send_declare_mining_job_and_recv_response(
+        incoming_sender,
+        build_zero_input_coinbase_tx(),
+        vec![],
+        vec![],
+        "jdp/invalid-coinbase-tx-input",
+    )
+    .await;
+
+    match response {
+        JdResponse::Error { error_code, .. } => {
+            assert_eq!(
+                error_code, ERROR_CODE_DECLARE_MINING_JOB_INVALID_COINBASE_TX_INPUT,
+                "expected invalid-coinbase-tx-input for a zero-input declared coinbase"
+            );
+        }
+        response => panic!("expected Error(invalid-coinbase-tx-input), got: {response:?}"),
+    }
+}
+
 async fn send_declare_mining_job_and_recv_response(
     incoming_sender: &Sender<JdRequest>,
     coinbase_tx: Transaction,
@@ -224,6 +259,18 @@ fn coinbase_script_sig_for_height(height: u32) -> ScriptBuf {
     script.push(encoded_height.len() as u8);
     script.extend_from_slice(&encoded_height);
     ScriptBuf::from_bytes(script)
+}
+
+fn build_zero_input_coinbase_tx() -> Transaction {
+    Transaction {
+        version: TxVersion::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![],
+        output: vec![TxOut {
+            value: Amount::from_sat(0),
+            script_pubkey: ScriptBuf::new(),
+        }],
+    }
 }
 
 fn build_valid_coinbase_tx(next_height: u32) -> Transaction {

--- a/integration-tests/tests/bitcoin_core_ipc_jdp_io.rs
+++ b/integration-tests/tests/bitcoin_core_ipc_jdp_io.rs
@@ -5,6 +5,7 @@
 //! - `DeclareMiningJob` returns `Success` for a minimal valid declaration.
 //! - `DeclareMiningJob` returns `Error(stale-chain-tip)` when the declared BIP34 height is
 //!   intentionally mismatched.
+//! - `DeclareMiningJob` does not retain client-supplied transactions when validation fails.
 //! - `DeclareMiningJob` rejects a coinbase that does not carry exactly one input, without
 //!   tearing down the IPC connection.
 //!
@@ -30,7 +31,7 @@ use stratum_apps::{
     },
     stratum_core::{
         bitcoin::{
-            Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness, Wtxid,
+            Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid, Witness, Wtxid,
             absolute::LockTime, block::Version as BlockVersion, hashes::Hash,
             transaction::Version as TxVersion,
         },
@@ -110,8 +111,9 @@ async fn assert_jdp_io_integration_for_version(version: BitcoinCoreVersion) {
     let missing_wtxid = Wtxid::from_byte_array([0x42; 32]);
     assert_jdp_missing_transactions_scenario(&incoming_sender, coinbase_tx.clone(), missing_wtxid)
         .await;
-    assert_jdp_success_scenario(&incoming_sender, coinbase_tx).await;
+    assert_jdp_success_scenario(&incoming_sender, coinbase_tx.clone()).await;
     assert_jdp_stale_chain_tip_scenario(&incoming_sender, next_height).await;
+    assert_jdp_rejected_declaration_does_not_retain_txs(&incoming_sender, coinbase_tx).await;
 
     cancellation_token.cancel();
     jdp_thread
@@ -215,6 +217,50 @@ async fn assert_jdp_invalid_coinbase_input_scenario(incoming_sender: &Sender<JdR
     }
 }
 
+/// A declaration rejected by `checkBlock` must not leave its client-supplied transactions behind
+/// in the mempool mirror.
+async fn assert_jdp_rejected_declaration_does_not_retain_txs(
+    incoming_sender: &Sender<JdRequest>,
+    coinbase_tx: Transaction,
+) {
+    let invalid_tx = build_invalid_declared_tx();
+    let invalid_wtxid = invalid_tx.compute_wtxid();
+
+    let response = send_declare_mining_job_and_recv_response(
+        incoming_sender,
+        coinbase_tx.clone(),
+        vec![invalid_wtxid],
+        vec![invalid_tx],
+        "jdp/rejected-declaration",
+    )
+    .await;
+
+    assert!(
+        matches!(response, JdResponse::Error { .. }),
+        "expected Error for a declaration carrying an invalid transaction, got: {response:?}"
+    );
+
+    // Same wtxid, this time supplying no transactions: the rejected transaction must not be
+    // served from the mempool mirror.
+    let response = send_declare_mining_job_and_recv_response(
+        incoming_sender,
+        coinbase_tx,
+        vec![invalid_wtxid],
+        vec![],
+        "jdp/rejected-declaration-retry",
+    )
+    .await;
+
+    match response {
+        JdResponse::MissingTransactions { missing_wtxids, .. } => {
+            assert_eq!(missing_wtxids, vec![invalid_wtxid]);
+        }
+        response => panic!(
+            "expected MissingTransactions (rejected tx must not be retained), got: {response:?}"
+        ),
+    }
+}
+
 async fn send_declare_mining_job_and_recv_response(
     incoming_sender: &Sender<JdRequest>,
     coinbase_tx: Transaction,
@@ -270,6 +316,26 @@ fn build_zero_input_coinbase_tx() -> Transaction {
             value: Amount::from_sat(0),
             script_pubkey: ScriptBuf::new(),
         }],
+    }
+}
+
+fn build_invalid_declared_tx() -> Transaction {
+    Transaction {
+        version: TxVersion::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            // deliberately not `OutPoint::null()`, which would make Bitcoin Core treat this as a
+            // second coinbase instead of exercising the empty-outputs rejection
+            previous_output: OutPoint {
+                txid: Txid::from_byte_array([0x11; 32]),
+                vout: 0,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::MAX,
+            witness: Witness::new(),
+        }],
+        // no outputs, so Bitcoin Core's `checkBlock` rejects any block carrying this transaction
+        output: vec![],
     }
 }
 


### PR DESCRIPTION
close #675 
close https://github.com/project-loupe/audit-sv2-apps/issues/61
close https://github.com/project-loupe/audit-sv2-apps/issues/30