### PR TITLE
`bitcoin-core-sv2`: fix `u32` overflow in `coinbase_weight`

### DIFF
--- a/bitcoin-core-sv2/src/unix_capnp/mod.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/mod.rs
@@ -14,7 +14,7 @@ pub mod v31x;
 const MIN_BLOCK_RESERVED_WEIGHT: u64 = 2000;
 
 /// BIP141 weight factor (witness scale factor), used to convert vsize to weight units.
-const WEIGHT_FACTOR: u32 = 4;
+const WEIGHT_FACTOR: u64 = 4;
 
 /// Grace period before stale template data is retired after a chain tip change, in seconds.
 ///

--- a/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/mod.rs
@@ -527,8 +527,8 @@ impl BitcoinCoreSv2TDP {
                 e
             })?;
 
-        let coinbase_weight = (coinbase_output_constraints.coinbase_output_max_additional_size
-            * WEIGHT_FACTOR) as u64;
+        let coinbase_weight =
+            coinbase_output_constraints.coinbase_output_max_additional_size as u64 * WEIGHT_FACTOR;
         let block_reserved_weight = coinbase_weight.max(MIN_BLOCK_RESERVED_WEIGHT); // 2000 is the minimum block reserved weight
         debug!("Setting block_reserved_weight: {block_reserved_weight}");
         template_ipc_client_request_options.set_block_reserved_weight(block_reserved_weight);

--- a/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/mod.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v31x/template_distribution_protocol/mod.rs
@@ -544,8 +544,8 @@ impl BitcoinCoreSv2TDP {
                 e
             })?;
 
-        let coinbase_weight = (coinbase_output_constraints.coinbase_output_max_additional_size
-            * WEIGHT_FACTOR) as u64;
+        let coinbase_weight =
+            coinbase_output_constraints.coinbase_output_max_additional_size as u64 * WEIGHT_FACTOR;
         let block_reserved_weight = coinbase_weight.max(MIN_BLOCK_RESERVED_WEIGHT); // 2000 is the minimum block reserved weight
         debug!("Setting block_reserved_weight: {block_reserved_weight}");
         template_ipc_client_request_options.set_block_reserved_weight(block_reserved_weight);


### PR DESCRIPTION
close #676
close https://github.com/project-loupe/audit-sv2-apps/issues/16