### PR TITLE
revert logging Sv2 messages with `Display` instead of `Debug`

### DIFF
--- a/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/monitors.rs
+++ b/bitcoin-core-sv2/src/unix_capnp/v30x/template_distribution_protocol/monitors.rs
@@ -261,7 +261,7 @@ impl BitcoinCoreSv2TDP {
                         break;
                     }
                     Ok(incoming_message) = self_clone.incoming_messages.recv() => {
-                        info!("Received: {:?}", incoming_message);
+                        info!("Received: {}", incoming_message);
                         debug!("monitor_incoming_messages() processing message");
 
                         match incoming_message {
@@ -293,7 +293,7 @@ impl BitcoinCoreSv2TDP {
                                 }
                             }
                             _ => {
-                                error!("Received unexpected message: {:?}", incoming_message);
+                                error!("Received unexpected message: {}", incoming_message);
                                 warn!("Ignoring message");
                                 continue;
                             }

--- a/integration-tests/lib/mining_device/mod.rs
+++ b/integration-tests/lib/mining_device/mod.rs
@@ -540,7 +540,7 @@ impl Device {
             m.job_id,
             m.is_future()
         );
-        debug!("NewMiningJob: {:?}", m);
+        debug!("NewMiningJob: {}", m);
         match (m.is_future(), self.prev_hash.as_ref()) {
             (false, Some(p_h)) => {
                 self.miner.with(|miner| miner.new_header(p_h, &m)).unwrap();
@@ -559,7 +559,7 @@ impl Device {
             "Received SetNewPrevHash channel id: {}, job id: {}",
             m.channel_id, m.job_id
         );
-        debug!("SetNewPrevHash: {:?}", m);
+        debug!("SetNewPrevHash: {}", m);
         let jobs: Vec<&NewMiningJobOwned> = self
             .jobs
             .iter()
@@ -583,7 +583,7 @@ impl Device {
 
     fn handle_set_target(&mut self, m: SetTargetOwned) {
         info!("Received SetTarget for channel id: {}", m.channel_id);
-        debug!("SetTarget: {:?}", m);
+        debug!("SetTarget: {}", m);
         self.miner
             .with(|miner| miner.new_target(m.maximum_target.to_owned_bytes()))
             .unwrap();

--- a/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/downstream_message_handler.rs
@@ -184,7 +184,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         msg: CloseChannelOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         let downstream_id =
             client_id.expect("client_id must be present for downstream_id extraction");
         self.with_registered_downstream(downstream_id, |downstream| {
@@ -238,7 +238,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         let mut coinbase_outputs = deserialize_outputs(coinbase_outputs)
             .map_err(|_| JDCError::shutdown(JDCErrorKind::ChannelManagerHasBadCoinbaseOutputs))?;
 
-        info!(downstream_id, "Received: {:?}", msg);
+        info!(downstream_id, "Received: {}", msg);
 
         let build_error = |code: &str| {
             MiningOwned::OpenMiningChannelError(OpenMiningChannelErrorOwned {
@@ -456,7 +456,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         let downstream_id =
             client_id.expect("client_id must be present for downstream_id extraction");
 
-        info!(downstream_id, "Received: {:?}", msg);
+        info!(downstream_id, "Received: {}", msg);
         let request_id = msg.request_id;
 
         let nominal_hash_rate = msg.nominal_hash_rate;
@@ -719,7 +719,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         msg: UpdateChannelOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         let channel_id = msg.channel_id;
         let new_nominal_hash_rate = msg.nominal_hash_rate;
         let requested_maximum_target = Target::from_le_bytes(msg.maximum_target.to_array());
@@ -1441,7 +1441,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         msg: SetCustomMiningJobOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         Err(JDCError::log(JDCErrorKind::UnexpectedMessage(
             0,
             MESSAGE_TYPE_SET_CUSTOM_MINING_JOB,

--- a/miner-apps/jd-client/src/lib/channel_manager/jd_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/jd_message_handler.rs
@@ -54,7 +54,7 @@ impl HandleJobDeclarationMessagesFromServerOwnedAsync for ChannelManager {
         msg: AllocateMiningJobTokenSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         let new_coinbase_outputs = msg.coinbase_outputs.to_owned_bytes();
         let coinbase_changed = self
@@ -140,7 +140,7 @@ impl HandleJobDeclarationMessagesFromServerOwnedAsync for ChannelManager {
         msg: DeclareMiningJobErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
 
         let error_code = msg.error_code.as_utf8_or_hex();
         if error_code == ERROR_CODE_DECLARE_MINING_JOB_STALE_CHAIN_TIP {
@@ -179,7 +179,7 @@ impl HandleJobDeclarationMessagesFromServerOwnedAsync for ChannelManager {
         msg: DeclareMiningJobSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         let Some(last_declare_job) = self.last_declare_job_store.get_cloned(&msg.request_id) else {
             error!(
@@ -285,7 +285,7 @@ impl HandleJobDeclarationMessagesFromServerOwnedAsync for ChannelManager {
     ) -> Result<(), Self::Error> {
         let request_id = msg.request_id;
 
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         let tx_store_entry = self.last_declare_job_store.get_cloned(&request_id);
 

--- a/miner-apps/jd-client/src/lib/channel_manager/template_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/template_message_handler.rs
@@ -43,7 +43,7 @@ impl HandleTemplateDistributionMessagesFromServerOwnedAsync for ChannelManager {
         msg: NewTemplateOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         self.template_store.insert(msg.template_id, msg.clone());
         if msg.future_template {
@@ -293,7 +293,7 @@ impl HandleTemplateDistributionMessagesFromServerOwnedAsync for ChannelManager {
         msg: RequestTransactionDataErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         let error_code = msg.error_code.as_utf8_or_hex();
 
         if matches!(
@@ -461,7 +461,7 @@ impl HandleTemplateDistributionMessagesFromServerOwnedAsync for ChannelManager {
         msg: SetNewPrevHashTdpOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         let outputs = deserialize_outputs(self.coinbase_outputs.get().map_err(JDCError::shutdown)?)
             .map_err(|_| JDCError::shutdown(JDCErrorKind::ChannelManagerHasBadCoinbaseOutputs))?;

--- a/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/channel_manager/upstream_message_handler.rs
@@ -71,7 +71,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: OpenStandardMiningChannelSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         info!(
             "⚠️ JDC can only open extended channels with the upstream server, preparing fallback."
         );
@@ -97,7 +97,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: OpenExtendedMiningChannelSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         let coinbase_outputs = self.coinbase_outputs.get().map_err(JDCError::shutdown)?;
 
@@ -328,7 +328,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: OpenMiningChannelErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         warn!("⚠️ Cannot open extended channel with the upstream server, preparing fallback.");
 
         Err(JDCError::fallback(JDCErrorKind::OpenMiningChannelError))
@@ -341,7 +341,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: UpdateChannelErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         Ok(())
     }
 
@@ -355,7 +355,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: CloseChannelOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         self.upstream_channel
             .set(None)
@@ -374,7 +374,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: SetExtranoncePrefixOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         let mut messages_results: Vec<Result<RouteMessageTo, Self::Error>> = vec![];
         self.upstream_channel
             .with(|upstream_channel| -> Result<(), Self::Error> {
@@ -539,7 +539,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: SubmitSharesSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?} ✅", msg);
+        info!("Received: {} ✅", msg);
 
         self.upstream_channel
             .with(|upstream_channel| {
@@ -562,7 +562,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: SubmitSharesErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?} ❌", msg);
+        warn!("Received: {} ❌", msg);
         let error_code = msg.error_code.as_utf8_or_hex();
 
         self.upstream_channel
@@ -583,7 +583,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: NewMiningJobOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         warn!("⚠️ JDC does not expect jobs from the upstream server — ignoring.");
         Ok(())
     }
@@ -595,7 +595,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: NewExtendedMiningJobOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         warn!("⚠️ JDC does not expect jobs from the upstream server — ignoring.");
         Ok(())
     }
@@ -607,7 +607,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: SetNewPrevHashOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         warn!("⚠️ JDC does not expect prevhash updates from the upstream server — ignoring.");
         Ok(())
     }
@@ -624,7 +624,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: SetCustomMiningJobSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?} ✅", msg);
+        info!("Received: {} ✅", msg);
 
         let mut shares_to_submit_upstream = Vec::new();
 
@@ -720,7 +720,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: SetCustomMiningJobErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
 
         let error_code = msg.error_code.as_utf8_or_hex();
         if error_code == ERROR_CODE_SET_CUSTOM_MINING_JOB_STALE_CHAIN_TIP {
@@ -750,7 +750,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: SetTargetOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         self.upstream_channel
             .with(|upstream_channel| {
                 if let Some(upstream) = upstream_channel.as_mut() {
@@ -770,7 +770,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         msg: SetGroupChannelOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         warn!("⚠️ JDC does not expect group channel updates from the upstream server — ignoring.");
         Ok(())
     }

--- a/miner-apps/jd-client/src/lib/downstream/common_message_handler.rs
+++ b/miner-apps/jd-client/src/lib/downstream/common_message_handler.rs
@@ -56,7 +56,7 @@ impl HandleCommonMessagesFromClientOwnedAsync for Downstream {
         msg: SetupConnectionOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         if msg.protocol != Protocol::MiningProtocol {
             info!(

--- a/miner-apps/jd-client/src/lib/job_declarator/message_handler.rs
+++ b/miner-apps/jd-client/src/lib/job_declarator/message_handler.rs
@@ -30,7 +30,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for JobDeclarator {
         msg: SetupConnectionSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         self.mode.activate();
         Ok(())
     }
@@ -41,7 +41,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for JobDeclarator {
         msg: ChannelEndpointChangedOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         Ok(())
     }
 
@@ -51,7 +51,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for JobDeclarator {
         msg: ReconnectOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         Ok(())
     }
 
@@ -61,7 +61,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for JobDeclarator {
         msg: SetupConnectionErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         Err(JDCError::fallback(JDCErrorKind::SetupConnectionError))
     }
 }

--- a/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/message_handler.rs
+++ b/miner-apps/jd-client/src/lib/template_receiver/sv2_tp/message_handler.rs
@@ -30,7 +30,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Sv2Tp {
         msg: SetupConnectionSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         Ok(())
     }
@@ -41,7 +41,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Sv2Tp {
         msg: ChannelEndpointChangedOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         Ok(())
     }
 
@@ -51,7 +51,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Sv2Tp {
         msg: ReconnectOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         Ok(())
     }
 
@@ -61,7 +61,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Sv2Tp {
         msg: SetupConnectionErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         Err(JDCError::shutdown(JDCErrorKind::SetupConnectionError))
     }
 }

--- a/miner-apps/jd-client/src/lib/upstream/message_handler.rs
+++ b/miner-apps/jd-client/src/lib/upstream/message_handler.rs
@@ -30,7 +30,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Upstream {
         msg: SetupConnectionSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         Ok(())
     }
@@ -41,7 +41,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Upstream {
         msg: ChannelEndpointChangedOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         Ok(())
     }
 
@@ -51,7 +51,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Upstream {
         msg: ReconnectOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         Ok(())
     }
 
@@ -61,7 +61,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Upstream {
         msg: SetupConnectionErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         Err(JDCError::fallback(JDCErrorKind::SetupConnectionError))
     }
 }

--- a/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
@@ -56,7 +56,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: OpenStandardMiningChannelSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", m);
+        warn!("Received: {}", m);
         Err(TproxyError::log(TproxyErrorKind::UnexpectedMessage(
             0,
             MESSAGE_TYPE_OPEN_STANDARD_MINING_CHANNEL_SUCCESS,
@@ -409,7 +409,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: OpenMiningChannelErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", m);
+        warn!("Received: {}", m);
         Err(TproxyError::fallback(
             TproxyErrorKind::OpenMiningChannelError,
         ))
@@ -421,7 +421,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: UpdateChannelErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", m);
+        warn!("Received: {}", m);
         Ok(())
     }
 
@@ -431,7 +431,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: CloseChannelOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", m);
+        info!("Received: {}", m);
         // are we working in aggregated mode?
         if self.mode.is_aggregated() {
             // even if aggregated channel_id != m.channel_id, we should trigger fallback
@@ -479,7 +479,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: SetExtranoncePrefixOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", m);
+        warn!("Received: {}", m);
         warn!(
             "⚠️ Cannot process SetExtranoncePrefix since set_extranonce is not supported for majority of sv1 clients. Ignoring."
         );
@@ -492,7 +492,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: SubmitSharesSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?} ✅", m);
+        info!("Received: {} ✅", m);
 
         // In aggregated mode, the Pool responds with the upstream channel ID, but the
         // channel is stored under AGGREGATED_CHANNEL_ID in the DashMap.
@@ -517,7 +517,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: SubmitSharesErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?} ❌", m);
+        warn!("Received: {} ❌", m);
         let error_code = m.error_code.as_utf8_or_hex();
 
         let key = if self.mode.is_aggregated() {
@@ -540,7 +540,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: NewMiningJobOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", m);
+        warn!("Received: {}", m);
         warn!(
             "⚠️ Cannot process NewMiningJob since Translator Proxy supports only extended mining jobs. Ignoring."
         );
@@ -553,7 +553,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: NewExtendedMiningJobOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", m);
+        info!("Received: {}", m);
         let m_static = m.clone();
 
         // we update the channel states and keep track of the messages that need to be sent to the
@@ -710,7 +710,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: SetNewPrevHashOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", m);
+        info!("Received: {}", m);
         let mut m_static = m.clone();
 
         // we update the channel states and keep track of the messages that need to be sent to the
@@ -891,7 +891,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: SetCustomMiningJobSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", m);
+        warn!("Received: {}", m);
         warn!(
             "⚠️ Cannot process SetCustomMiningJobSuccess since Translator Proxy does not support custom mining jobs. Ignoring."
         );
@@ -907,7 +907,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: SetCustomMiningJobErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", m);
+        warn!("Received: {}", m);
         warn!(
             "⚠️ Cannot process SetCustomMiningJobError since Translator Proxy does not support custom mining jobs. Ignoring."
         );
@@ -923,7 +923,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: SetTargetOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", m);
+        info!("Received: {}", m);
 
         let m_static = m.clone();
 
@@ -1028,7 +1028,7 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
         m: SetGroupChannelOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", m);
+        info!("Received: {}", m);
 
         // remove every channel from any group channels that end up empty
         let mut group_channels_to_remove = Vec::new();

--- a/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
@@ -718,7 +718,7 @@ impl ChannelManager {
                 }
             }
             MiningOwned::UpdateChannel(mut m) => {
-                debug!("Received UpdateChannel from SV1Server: {:?}", m);
+                debug!("Received UpdateChannel from SV1Server: {}", m);
 
                 if self.mode.is_aggregated() {
                     // Update the aggregated channel's nominal hashrate so
@@ -763,7 +763,7 @@ impl ChannelManager {
                     })?;
             }
             MiningOwned::CloseChannel(m) => {
-                debug!("Received CloseChannel from Sv1Server: {m:?}");
+                debug!("Received CloseChannel from Sv1Server: {m}");
 
                 // Guard: never remove the aggregated upstream sentinel entry
                 // here. `AGGREGATED_CHANNEL_ID` represents the single shared

--- a/miner-apps/translator/src/lib/sv2/upstream/common_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv2/upstream/common_message_handler.rs
@@ -29,7 +29,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Upstream {
         msg: SetupConnectionErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        error!("Received: {:?}", msg);
+        error!("Received: {}", msg);
         Err(TproxyError::fallback(TproxyErrorKind::SetupConnectionError))
     }
 
@@ -39,7 +39,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Upstream {
         msg: SetupConnectionSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         Ok(())
     }
 
@@ -49,7 +49,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Upstream {
         msg: ChannelEndpointChangedOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         todo!()
     }
 
@@ -59,7 +59,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Upstream {
         msg: ReconnectOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         todo!()
     }
 }

--- a/pool-apps/jd-server/src/lib/job_declarator/job_declaration_message_handler.rs
+++ b/pool-apps/jd-server/src/lib/job_declarator/job_declaration_message_handler.rs
@@ -53,7 +53,7 @@ impl HandleJobDeclarationMessagesFromClientOwnedAsync for JobDeclarator {
         msg: AllocateMiningJobTokenOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         // Shutdown: client_id is always Some; None indicates a bug.
         let client_id =
             client_id.ok_or_else(|| JDSError::shutdown(error::JDSErrorKind::ClientNotFound(0)))?;
@@ -111,7 +111,7 @@ impl HandleJobDeclarationMessagesFromClientOwnedAsync for JobDeclarator {
         msg: DeclareMiningJobOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         // Shutdown: client_id is always Some; None indicates a bug.
         let client_id =
             client_id.ok_or_else(|| JDSError::shutdown(error::JDSErrorKind::ClientNotFound(0)))?;
@@ -287,7 +287,7 @@ impl HandleJobDeclarationMessagesFromClientOwnedAsync for JobDeclarator {
         msg: ProvideMissingTransactionsSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         // Shutdown: client_id is always Some; None indicates a bug.
         let client_id =
             client_id.ok_or_else(|| JDSError::shutdown(error::JDSErrorKind::ClientNotFound(0)))?;
@@ -427,7 +427,7 @@ impl HandleJobDeclarationMessagesFromClientOwnedAsync for JobDeclarator {
         msg: PushSolutionOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         // Shutdown: client_id is always Some; None indicates a bug.
         let client_id =

--- a/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
+++ b/pool-apps/pool/src/lib/channel_manager/mining_message_handler.rs
@@ -80,7 +80,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         msg: CloseChannelOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received Close Channel: {msg:?}");
+        info!("Received Close Channel: {msg}");
         let downstream_id =
             client_id.expect("client_id must be present for downstream_id extraction");
         self.with_registered_downstream(downstream_id, |downstream| {
@@ -111,7 +111,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         let downstream_id =
             client_id.expect("client_id must be present for downstream_id extraction");
 
-        info!("Received OpenStandardMiningChannel: {:?}", msg);
+        info!("Received OpenStandardMiningChannel: {}", msg);
 
         let messages = self.with_registered_downstream(downstream_id, |downstream| {
                 if downstream.requires_custom_work.load(Ordering::SeqCst) {
@@ -347,7 +347,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         let user_identity = msg.user_identity.as_utf8_or_hex();
         let downstream_id =
             client_id.expect("client_id must be present for downstream_id extraction");
-        info!("Received OpenExtendedMiningChannel: {:?}", msg);
+        info!("Received OpenExtendedMiningChannel: {}", msg);
 
         let nominal_hash_rate = msg.nominal_hash_rate;
         let requested_max_target = Target::from_le_bytes(msg.max_target.to_array());
@@ -495,7 +495,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
                     group_channel_id,
                 }
                 ;
-                info!("Sending OpenExtendedMiningChannel.Success (downstream_id: {downstream_id}): {open_extended_mining_channel_success:?}");
+                info!("Sending OpenExtendedMiningChannel.Success (downstream_id: {downstream_id}): {open_extended_mining_channel_success}");
 
                 messages.push(
                     (
@@ -630,7 +630,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         msg: SubmitSharesStandardOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received SubmitSharesStandard: {msg:?}");
+        info!("Received SubmitSharesStandard: {msg}");
         let downstream_id =
             client_id.expect("client_id must be present for downstream_id extraction");
 
@@ -869,7 +869,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         msg: SubmitSharesExtendedOwned,
         tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received SubmitSharesExtended: {msg:?}");
+        info!("Received SubmitSharesExtended: {msg}");
         let downstream_id =
             client_id.expect("client_id must be present for downstream_id extraction");
 
@@ -1137,7 +1137,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         msg: UpdateChannelOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         let downstream_id =
             client_id.expect("client_id must be present for downstream_id extraction");
@@ -1268,7 +1268,7 @@ impl HandleMiningMessagesFromClientOwnedAsync for ChannelManager {
         msg: SetCustomMiningJobOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         let downstream_id =
             client_id.expect("client_id must be present for downstream_id extraction");
 

--- a/pool-apps/pool/src/lib/channel_manager/template_distribution_message_handler.rs
+++ b/pool-apps/pool/src/lib/channel_manager/template_distribution_message_handler.rs
@@ -36,7 +36,7 @@ impl HandleTemplateDistributionMessagesFromServerOwnedAsync for ChannelManager {
         msg: NewTemplateOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         if msg.future_template {
             self.last_future_template
@@ -189,7 +189,7 @@ impl HandleTemplateDistributionMessagesFromServerOwnedAsync for ChannelManager {
         msg: RequestTransactionDataErrorOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        warn!("Received: {:?}", msg);
+        warn!("Received: {}", msg);
         Ok(())
     }
 
@@ -199,7 +199,7 @@ impl HandleTemplateDistributionMessagesFromServerOwnedAsync for ChannelManager {
         msg: RequestTransactionDataSuccessOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         Ok(())
     }
 
@@ -209,7 +209,7 @@ impl HandleTemplateDistributionMessagesFromServerOwnedAsync for ChannelManager {
         msg: SetNewPrevHashTdp,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
 
         self.last_new_prev_hash
             .set(Some(msg.clone()))

--- a/pool-apps/pool/src/lib/template_receiver/sv2_tp/common_message_handler.rs
+++ b/pool-apps/pool/src/lib/template_receiver/sv2_tp/common_message_handler.rs
@@ -56,7 +56,7 @@ impl HandleCommonMessagesFromServerOwnedAsync for Sv2Tp {
         msg: ReconnectOwned,
         _tlv_fields: Option<&[Tlv]>,
     ) -> Result<(), Self::Error> {
-        info!("Received: {:?}", msg);
+        info!("Received: {}", msg);
         Ok(())
     }
 


### PR DESCRIPTION
follow-up to #616

790199d0 unintendedly introduced changes like this:
```diff
- info!("Received: {}", incoming_message);
+ info!("Received: {:?}", incoming_message)
```

which not only completely defeats the purpose of having `impl Display` on the types, but also makes apps logs completely polluted:
```
2026-08-04T22:19:27.978949Z  INFO pool_sv2::channel_manager::template_distribution_message_handler: Received: NewTemplateOwned { template_id: 0, future_template: true, version: 536870912, coinbase_tx_version: 2, coinbase_prefix: InnerOwned { data: [3, 54, 170, 14] }, coinbase_tx_input_sequence: 4294967294, coinbase_tx_value_remaining: 314626620, coinbase_tx_outputs_count: 1, coinbase_tx_outputs: InnerOwned { data: [0, 0, 0, 0, 0, 0, 0, 0, 38, 106, 36, 170, 33, 169, 237, 152, 113, 87, 9, 156, 152, 30, 208, 77, 245, 192, 58, 51, 228, 69, 137, 238, 181, 21, 120, 14, 25, 194, 124, 83, 105, 64, 36, 252, 75, 36, 12] }, coinbase_tx_locktime: 961077, merkle_path: Seq0255Owned([InnerOwned { data: [100, 106, 14, 241, 90, 139, 66, 61, 15, 201, 244, 116, 65, 35, 87, 42, 88, 219, 201, 143, 179, 239, 79, 108, 16, 88, 97, 39, 28, 60, 80, 233] }, InnerOwned { data: [205, 21, 191, 140, 68, 122, 62, 6, 132, 139, 219, 51, 210, 95, 213, 167, 20, 195, 132, 193, 172, 152, 249, 47, 76, 139, 11, 235, 200, 209, 41, 211] }, InnerOwned { data: [181, 241, 231, 215, 40, 183, 71, 111, 183, 117, 121, 71, 113, 113, 248, 100, 78, 50, 194, 135, 13, 73, 47, 14, 232, 37, 182, 42, 209, 88, 237, 92] }, InnerOwned { data: [79, 208, 190, 207, 203, 159, 177, 207, 76, 226, 54, 45, 254, 29, 13, 86, 72, 7, 101, 167, 34, 81, 56, 111, 7, 126, 125, 156, 61, 17, 0, 20] }, InnerOwned { data: [19, 100, 225, 69, 236, 130, 74, 56, 142, 41, 235, 40, 116, 163, 38, 9, 17, 37, 74, 223, 139, 93, 105, 230, 106, 95, 164, 227, 88, 32, 77, 200] }, InnerOwned { data: [169, 135, 237, 135, 180, 134, 158, 61, 115, 151, 19, 208, 110, 147, 70, 242, 39, 181, 109, 73, 88, 203, 17, 201, 236, 188, 171, 245, 204, 231, 223, 210] }, InnerOwned { data: [199, 201, 51, 10, 154, 60, 123, 120, 189, 142, 252, 74, 120, 54, 36, 190, 89, 206, 19, 204, 141, 224, 170, 246, 54, 11, 241, 169, 7, 163, 84, 31] }, InnerOwned { data: [68, 195, 165, 142, 254, 138, 99, 195, 60, 126, 72, 221, 167, 42, 108, 115, 81, 9, 221, 28, 203, 82, 108, 181, 27, 253, 60, 14, 42, 49, 252, 144] }, InnerOwned { data: [205, 29, 216, 206, 7, 129, 40, 220, 190, 167, 95, 252, 250, 63, 137, 185, 116, 62, 156, 169, 162, 134, 164, 49, 37, 15, 197, 228, 36, 56, 146, 91] }, InnerOwned { data: [219, 126, 36, 200, 176, 223, 238, 154, 122, 22, 137, 203, 28, 2, 222, 32, 5, 129, 124, 67, 85, 244, 36, 61, 42, 54, 119, 242, 65, 115, 61, 191] }, InnerOwned { data: [54, 139, 61, 170, 255, 106, 105, 166, 67, 203, 122, 202, 227, 52, 46, 59, 15, 53, 208, 44, 236, 66, 217, 85, 149, 53, 64, 237, 143, 136, 74, 77] }, InnerOwned { data: [101, 236, 3, 117, 21, 151, 225, 100, 170, 149, 16, 106, 212, 208, 153, 155, 23, 154, 239, 112, 60, 93, 3, 151, 245, 200, 65, 237, 74, 187, 21, 55] }, InnerOwned { data: [172, 151, 169, 11, 156, 61, 65, 227, 112, 181, 14, 130, 27, 27, 227, 4, 214, 211, 56, 116, 212, 245, 124, 19, 139, 196, 148, 235, 223, 204, 169, 159] }]) }
2026-08-04T22:19:27.979025Z  INFO pool_sv2::channel_manager::template_distribution_message_handler: Received: SetNewPrevHashOwned { template_id: 0, prev_hash: InnerOwned { data: [233, 123, 15, 102, 80, 203, 231, 250, 42, 83, 7, 209, 77, 243, 130, 240, 126, 110, 151, 125, 182, 241, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0] }, header_timestamp: 1785881967, n_bits: 386022100, target: InnerOwned { data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 212, 58, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0] } }
```

this PR allows logs to like normal again:
```
2026-08-04T22:40:22.292206Z  INFO pool_sv2::channel_manager::template_distribution_message_handler: Received: NewTemplate(template_id: 0, future_template: true, version: 0x20000000, coinbase_tx_version: 0x00000002, coinbase_prefix: B0255(0337aa0e), coinbase_tx_input_sequence: 0xfffffffe, coinbase_tx_value_remaining: 314330390, coinbase_tx_outputs_count: 1, coinbase_tx_outputs: B064K(0000000000000000266a24aa21a9ed238c4b268e9c2f5ba59098f0ca0577683cea0fdeb7697aa578f18d0011e8de6a), coinbase_tx_locktime: 961078, merkle_path: Seq0255<len=13: [32c250a4212eed7263bfb8bf69f5ed180f00b0452ff3fba174aca743e3829f44, 0edeb0743176d0ab3f7d80e88e23dc983d276901f15dd74704bcb159caed2414, ... , 5ced83398a740f53108470f1cb7f6e77ec6185517bcba06ee8ba919dd6069d63, d7f1a70fa4dd25a059918cfdd2b634536113a2570e963be5959639170d8ed7c4])
2026-08-04T22:40:22.292278Z  INFO pool_sv2::channel_manager::template_distribution_message_handler: Received: SetNewPrevHash { template_id: 0, prev_hash: U256(000000000000000000010ca0e38df66243d6aaa37597d93f2e875e79e30280b1), header_timestamp: 1785883222, n_bits: 0x17023ad4, target: U256(000000000000000000023ad40000000000000000000000000000000000000000) }
```