### PR TITLE
fix: remove useless conversion after `stratum-core` bump

### DIFF
--- a/miner-apps/translator/src/lib/utils.rs
+++ b/miner-apps/translator/src/lib/utils.rs
@@ -93,9 +93,7 @@ pub fn validate_sv1_share(
         full_extranonce.as_ref(),
         job.merkle_branch.as_ref(),
     )
-    .ok_or(TproxyErrorKind::InvalidMerkleRoot)?
-    .try_into()
-    .map_err(|_| TproxyErrorKind::InvalidMerkleRoot)?;
+    .ok_or(TproxyErrorKind::InvalidMerkleRoot)?;
 
     // create the header for validation
     let header = Header {


### PR DESCRIPTION
https://github.com/stratum-mining/stratum/pull/2285 should have had this as a companion

I merged https://github.com/stratum-mining/sv2-apps/pull/690 but started getting this kind of failure:
https://github.com/stratum-mining/sv2-apps/actions/runs/31106372569/job/92636877422