### PR TITLE
Fix tproxy open channel lifecycle

### DIFF
--- a/integration-tests/tests/translator_integration.rs
+++ b/integration-tests/tests/translator_integration.rs
@@ -851,11 +851,19 @@ async fn aggregated_translator_correctly_deals_with_group_channels() {
         )
         .await;
 
-    let share_channel_id = match sniffer.next_message_from_downstream() {
-        Some((_, AnyMessageOwned::Mining(parsers_sv2::MiningOwned::SubmitSharesExtended(msg)))) => {
-            msg.channel_id
+    let share_channel_id = loop {
+        match sniffer.next_message_from_downstream() {
+            Some((
+                _,
+                AnyMessageOwned::Mining(parsers_sv2::MiningOwned::SubmitSharesExtended(msg)),
+            )) => break msg.channel_id,
+            // Opening an aggregated downstream or vardiff may enqueue an UpdateChannel before the
+            // share.
+            Some((_, AnyMessageOwned::Mining(parsers_sv2::MiningOwned::UpdateChannel(_)))) => {
+                continue;
+            }
+            msg => panic!("Expected SubmitSharesExtended message, found: {:?}", msg),
         }
-        msg => panic!("Expected SubmitSharesExtended message, found: {:?}", msg),
     };
 
     assert_eq!(
@@ -886,11 +894,16 @@ async fn aggregated_translator_correctly_deals_with_group_channels() {
             MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB,
         )
         .await;
-    let new_extended_mining_job = match sniffer.next_message_from_upstream() {
-        Some((_, AnyMessageOwned::Mining(parsers_sv2::MiningOwned::NewExtendedMiningJob(msg)))) => {
-            msg
+    let new_extended_mining_job = loop {
+        match sniffer.next_message_from_upstream() {
+            Some((
+                _,
+                AnyMessageOwned::Mining(parsers_sv2::MiningOwned::NewExtendedMiningJob(msg)),
+            )) => break msg,
+            // Every aggregate UpdateChannel is answered with SetTarget on this queue.
+            Some((_, AnyMessageOwned::Mining(parsers_sv2::MiningOwned::SetTarget(_)))) => continue,
+            msg => panic!("Expected NewExtendedMiningJob message, found: {:?}", msg),
         }
-        msg => panic!("Expected NewExtendedMiningJob message, found: {:?}", msg),
     };
 
     // here we're actually asserting pool behavior, not tProxy
@@ -910,6 +923,11 @@ async fn aggregated_translator_correctly_deals_with_group_channels() {
                 _,
                 AnyMessageOwned::Mining(parsers_sv2::MiningOwned::SubmitSharesExtended(msg)),
             )) => msg,
+            // Opening an aggregated downstream or vardiff may enqueue an UpdateChannel before the
+            // share.
+            Some((_, AnyMessageOwned::Mining(parsers_sv2::MiningOwned::UpdateChannel(_)))) => {
+                continue;
+            }
             msg => panic!("Expected SubmitSharesExtended message, found: {:?}", msg),
         };
 
@@ -932,11 +950,16 @@ async fn aggregated_translator_correctly_deals_with_group_channels() {
             MESSAGE_TYPE_NEW_EXTENDED_MINING_JOB,
         )
         .await;
-    let new_extended_mining_job = match sniffer.next_message_from_upstream() {
-        Some((_, AnyMessageOwned::Mining(parsers_sv2::MiningOwned::NewExtendedMiningJob(msg)))) => {
-            msg
+    let new_extended_mining_job = loop {
+        match sniffer.next_message_from_upstream() {
+            Some((
+                _,
+                AnyMessageOwned::Mining(parsers_sv2::MiningOwned::NewExtendedMiningJob(msg)),
+            )) => break msg,
+            // Every aggregate UpdateChannel is answered with SetTarget on this queue.
+            Some((_, AnyMessageOwned::Mining(parsers_sv2::MiningOwned::SetTarget(_)))) => continue,
+            msg => panic!("Expected NewExtendedMiningJob message, found: {:?}", msg),
         }
-        msg => panic!("Expected NewExtendedMiningJob message, found: {:?}", msg),
     };
 
     // again, asserting pool behavior, not tProxy
@@ -950,9 +973,15 @@ async fn aggregated_translator_correctly_deals_with_group_channels() {
             MESSAGE_TYPE_MINING_SET_NEW_PREV_HASH,
         )
         .await;
-    let set_new_prev_hash = match sniffer.next_message_from_upstream() {
-        Some((_, AnyMessageOwned::Mining(parsers_sv2::MiningOwned::SetNewPrevHash(msg)))) => msg,
-        msg => panic!("Expected SetNewPrevHash message, found: {:?}", msg),
+    let set_new_prev_hash = loop {
+        match sniffer.next_message_from_upstream() {
+            Some((_, AnyMessageOwned::Mining(parsers_sv2::MiningOwned::SetNewPrevHash(msg)))) => {
+                break msg;
+            }
+            // Every aggregate UpdateChannel is answered with SetTarget on this queue.
+            Some((_, AnyMessageOwned::Mining(parsers_sv2::MiningOwned::SetTarget(_)))) => continue,
+            msg => panic!("Expected SetNewPrevHash message, found: {:?}", msg),
+        }
     };
 
     // again, asserting pool behavior, not tProxy
@@ -972,6 +1001,11 @@ async fn aggregated_translator_correctly_deals_with_group_channels() {
                 _,
                 AnyMessageOwned::Mining(parsers_sv2::MiningOwned::SubmitSharesExtended(msg)),
             )) => msg,
+            // Opening an aggregated downstream or vardiff may enqueue an UpdateChannel before the
+            // share.
+            Some((_, AnyMessageOwned::Mining(parsers_sv2::MiningOwned::UpdateChannel(_)))) => {
+                continue;
+            }
             msg => panic!("Expected SubmitSharesExtended message, found: {:?}", msg),
         };
 

--- a/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
@@ -24,11 +24,15 @@ use stratum_apps::{
 use tracing::{debug, error, info, trace, warn};
 
 enum AggregatedSnapshot {
+    /// Aggregate hashrate and minimum target of all downstreams with an open channel.
     Active {
         total_hashrate: Hashrate,
         min_target: Target,
     },
-    NoDownstreams,
+    /// No downstream has an open channel yet.
+    NoOpenChannels,
+    /// Open channels exist, but no exact target could be computed for any of them.
+    NoValidTargets,
 }
 
 #[cfg_attr(not(test), hotpath::measure_all)]
@@ -274,7 +278,7 @@ impl Sv1Server {
         }
     }
 
-    async fn send_aggregated_update_channel(
+    pub(super) async fn send_aggregated_update_channel(
         &self,
         all_updates: Vec<(DownstreamId, ChannelId, Target, Hashrate)>,
     ) -> TproxyResult<(), error::Sv1Server> {
@@ -283,48 +287,17 @@ impl Sv1Server {
             return Ok(());
         };
 
-        if self.downstreams.is_empty() {
-            return Ok(());
-        }
-
-        let mut min_target: Option<Target> = None;
-        let mut total_hashrate: Hashrate = 0.0;
-        let shares_per_minute = self.shares_per_minute as f64;
-
-        self.downstreams.try_for_each(|downstream_id, downstream| {
-            let hashrate = downstream.downstream_data.with(|d| {
-                d.pending_hashrate
-                    .unwrap_or_else(|| d.hashrate.expect("vardiff implies hashrate"))
-            }).map_err(TproxyError::shutdown)?;
-
-            // UpdateChannel is upstream-facing, so rebuild the exact target from
-            // hashrate instead of reusing the rounded SV1 advertised target.
-            // A failure is specific to this downstream's hashrate, so exclude it
-            // from the aggregate instead of shutting down the whole proxy.
-            let target = match hash_rate_to_target(hashrate as f64, shares_per_minute) {
-                Ok(target) => target,
-                Err(e) => {
-                    error!(
-                        "Failed to calculate exact target for downstream {downstream_id} hashrate {hashrate}: {e:?}; excluding from aggregated UpdateChannel"
-                    );
-                    return Ok(());
-                }
-            };
-
-            min_target = Some(match min_target {
-                Some(current) => current.min(target),
-                None => target,
-            });
-
-            total_hashrate += hashrate;
-            Ok::<(), TproxyError<error::Sv1Server>>(())
-        })?;
-
-        let Some(min_target) = min_target else {
-            warn!("Skipping aggregated UpdateChannel: no exact downstream target is available");
-            return Ok(());
+        let (total_hashrate, min_target) = match self.aggregated_downstream_snapshot()? {
+            AggregatedSnapshot::Active {
+                total_hashrate,
+                min_target,
+            } => (total_hashrate, min_target),
+            AggregatedSnapshot::NoOpenChannels => return Ok(()),
+            AggregatedSnapshot::NoValidTargets => {
+                warn!("Skipping aggregated UpdateChannel: no exact downstream target is available");
+                return Ok(());
+            }
         };
-        let downstream_count = self.downstreams.len();
 
         let update_channel = UpdateChannelOwned {
             channel_id: *channel_id,
@@ -333,11 +306,10 @@ impl Sv1Server {
         };
 
         debug!(
-            "Sending aggregated UpdateChannel: channel_id={}, total_hashrate={}, min_target={}, downstreams={}, vardiff_updates={}",
+            "Sending aggregated UpdateChannel: channel_id={}, total_hashrate={}, min_target={}, vardiff_updates={}",
             channel_id,
             total_hashrate,
             min_target,
-            downstream_count,
             all_updates.len()
         );
 
@@ -380,6 +352,70 @@ impl Sv1Server {
                 })?;
         }
         Ok(())
+    }
+
+    /// Returns aggregate difficulty state for downstreams with an opened mining channel.
+    #[allow(clippy::result_large_err)]
+    fn aggregated_downstream_snapshot(&self) -> TproxyResult<AggregatedSnapshot, error::Sv1Server> {
+        let mut total_hashrate: Hashrate = 0.0;
+        let mut min_target: Option<Target> = None;
+        let mut has_open_downstream = false;
+        let shares_per_minute = self.shares_per_minute as f64;
+
+        self.downstreams.try_for_each(|downstream_id, downstream| {
+            let hashrate = downstream
+                .downstream_data
+                .with(|data| {
+                    data.channel_id.map(|_| {
+                        data.pending_hashrate.unwrap_or_else(|| {
+                            data.hashrate
+                                .expect("vardiff implies downstream must have a hashrate")
+                        })
+                    })
+                })
+                .map_err(TproxyError::shutdown)?;
+
+            let Some(hashrate) = hashrate else {
+                trace!(
+                    "Excluding downstream {downstream_id} from aggregated UpdateChannel: channel is not open"
+                );
+                return Ok(());
+            };
+            has_open_downstream = true;
+
+            // UpdateChannel is upstream-facing, so rebuild the exact target from
+            // hashrate instead of reusing the rounded SV1 advertised target.
+            // A failure is specific to this downstream's hashrate, so exclude it
+            // from the aggregate instead of shutting down the whole proxy.
+            let target = match hash_rate_to_target(hashrate as f64, shares_per_minute) {
+                Ok(target) => target,
+                Err(e) => {
+                    error!(
+                        "Failed to calculate exact target for downstream {downstream_id} hashrate {hashrate}: {e:?}; excluding from aggregated UpdateChannel"
+                    );
+                    return Ok(());
+                }
+            };
+
+            total_hashrate += hashrate;
+            min_target = Some(match min_target {
+                Some(current) => current.min(target),
+                None => target,
+            });
+            Ok::<(), TproxyError<error::Sv1Server>>(())
+        })?;
+
+        if !has_open_downstream {
+            return Ok(AggregatedSnapshot::NoOpenChannels);
+        }
+
+        Ok(match min_target {
+            Some(min_target) => AggregatedSnapshot::Active {
+                total_hashrate,
+                min_target,
+            },
+            None => AggregatedSnapshot::NoValidTargets,
+        })
     }
 
     /// Handles SetTarget messages from the ChannelManager.
@@ -560,9 +596,8 @@ impl Sv1Server {
         Ok(())
     }
 
-    /// Sends an UpdateChannel message for aggregated mode when downstream state changes
-    /// (e.g., disconnect). Calculates total hashrate and minimum target among all remaining
-    /// downstreams.
+    /// Sends an UpdateChannel message for aggregated mode when a downstream channel opens or
+    /// closes. Calculates total hashrate and minimum target among all active downstreams.
     pub async fn send_update_channel_on_downstream_state_change(
         &self,
     ) -> TproxyResult<(), error::Sv1Server> {
@@ -570,59 +605,7 @@ impl Sv1Server {
             return Ok(());
         }
 
-        let is_empty = self.downstreams.is_empty();
-
-        let snapshot = if is_empty {
-            AggregatedSnapshot::NoDownstreams
-        } else {
-            let mut total_hashrate: Hashrate = 0.0;
-            let mut min_target: Option<Target> = None;
-            let shares_per_minute = self.shares_per_minute as f64;
-
-            self.downstreams.try_for_each(|downstream_id, downstream| {
-                let hashrate = downstream.downstream_data.with(|d| {
-                    d.pending_hashrate.unwrap_or_else(|| {
-                        d.hashrate
-                            .expect("vardiff implies downstream must have a hashrate")
-                    })
-                }).map_err(TproxyError::shutdown)?;
-
-                // UpdateChannel is upstream-facing, so rebuild the exact target from
-                // hashrate instead of reusing the rounded SV1 advertised target.
-                // A failure is specific to this downstream's hashrate, so exclude it
-                // from the aggregate instead of shutting down the whole proxy.
-                let target = match hash_rate_to_target(hashrate as f64, shares_per_minute) {
-                    Ok(target) => target,
-                    Err(e) => {
-                        error!(
-                            "Failed to calculate exact target for downstream {downstream_id} hashrate {hashrate}: {e:?}; excluding from aggregated UpdateChannel"
-                        );
-                        return Ok(());
-                    }
-                };
-
-                total_hashrate += hashrate;
-                min_target = Some(match min_target {
-                    Some(current) => current.min(target),
-                    None => target,
-                });
-                Ok::<(), TproxyError<error::Sv1Server>>(())
-            })?;
-
-            let Some(min_target) = min_target else {
-                warn!(
-                    "Skipping aggregated UpdateChannel after downstream state change: no exact downstream target is available"
-                );
-                return Ok(());
-            };
-
-            AggregatedSnapshot::Active {
-                total_hashrate,
-                min_target,
-            }
-        };
-
-        let update = match snapshot {
+        let update = match self.aggregated_downstream_snapshot()? {
             AggregatedSnapshot::Active {
                 total_hashrate,
                 min_target,
@@ -632,11 +615,18 @@ impl Sv1Server {
                 maximum_target: min_target.to_le_bytes().into(),
             },
 
-            AggregatedSnapshot::NoDownstreams => UpdateChannelOwned {
+            // Connected-but-unopened miners deliberately count as zero hashrate upstream.
+            AggregatedSnapshot::NoOpenChannels => UpdateChannelOwned {
                 channel_id: 0,
                 nominal_hash_rate: 0.0,
                 maximum_target: [0xFF; 32].into(),
             },
+            AggregatedSnapshot::NoValidTargets => {
+                warn!(
+                    "Skipping aggregated UpdateChannel after downstream state change: no exact downstream target is available"
+                );
+                return Ok(());
+            }
         };
 
         self.sv1_server_io

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -1045,6 +1045,16 @@ impl Sv1Server {
                                 )
                             })?;
                         }
+
+                        // Opening a downstream changes the aggregate just like disconnecting one.
+                        // Refresh it now so the newly active hashrate is not left out until the
+                        // next vardiff update.
+                        if self.mode.is_aggregated()
+                            && self.config.downstream_difficulty_config.enable_vardiff
+                        {
+                            self.send_update_channel_on_downstream_state_change()
+                                .await?;
+                        }
                     }
                     Err(e) => {
                         if matches!(e.kind, TproxyErrorKind::DownstreamNotPresent(_)) {
@@ -1781,6 +1791,40 @@ mod tests {
         Sv1Server::new(addr, cm_receiver, cm_sender, config, tproxy_mode)
     }
 
+    fn register_test_downstream(
+        server: &Sv1Server,
+        downstream_id: DownstreamId,
+        channel_id: Option<ChannelId>,
+        hashrate: Hashrate,
+    ) {
+        let (downstream_sv1_sender, _downstream_sv1_receiver) = unbounded();
+        let (_miner_sender, miner_receiver) = unbounded();
+        let (_sv1_server_sender, sv1_server_receiver) = unbounded();
+        let target = hash_rate_to_target(hashrate as f64, 5.0).unwrap();
+        let downstream = Downstream::new(
+            downstream_id,
+            downstream_sv1_sender,
+            miner_receiver,
+            server.sv1_server_io.downstream_to_sv1_server_sender.clone(),
+            sv1_server_receiver,
+            target,
+            Some(hashrate),
+            #[cfg(feature = "monitoring")]
+            "127.0.0.1".parse().unwrap(),
+            CancellationToken::new(),
+        );
+        downstream
+            .downstream_data
+            .with(|data| data.channel_id = channel_id)
+            .unwrap();
+        server.downstreams.insert(downstream_id, downstream);
+        if let Some(channel_id) = channel_id {
+            server
+                .channel_id_to_downstream_id
+                .insert(channel_id, downstream_id);
+        }
+    }
+
     #[test]
     fn test_sv1_server_creation() {
         let server = create_test_sv1_server();
@@ -1938,6 +1982,117 @@ mod tests {
             .expect("the orphaned channel should be closed");
         assert!(matches!(message, MiningOwned::CloseChannel(close) if close.channel_id == 9));
         assert!(server.request_id_to_downstream_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn aggregated_state_change_ignores_unopened_downstreams() {
+        let (channel_manager_sender, channel_manager_receiver) = unbounded();
+        let (_upstream_sender, upstream_receiver) = unbounded();
+        let config = create_test_config();
+        let addr = "127.0.0.1:3333".parse().unwrap();
+        let mode = TproxyMode::from(config.aggregate_channels);
+        let server = Sv1Server::new(
+            addr,
+            upstream_receiver,
+            channel_manager_sender,
+            config,
+            mode,
+        );
+        register_test_downstream(&server, 1, Some(1), 100.0);
+        register_test_downstream(&server, 2, None, 100.0);
+
+        server
+            .send_update_channel_on_downstream_state_change()
+            .await
+            .unwrap();
+
+        let (message, _) = channel_manager_receiver.recv().await.unwrap();
+        let MiningOwned::UpdateChannel(update) = message else {
+            panic!("expected UpdateChannel");
+        };
+        assert_eq!(update.nominal_hash_rate, 100.0);
+    }
+
+    #[tokio::test]
+    async fn aggregated_vardiff_update_ignores_unopened_downstreams() {
+        let (channel_manager_sender, channel_manager_receiver) = unbounded();
+        let (_upstream_sender, upstream_receiver) = unbounded();
+        let config = create_test_config();
+        let addr = "127.0.0.1:3333".parse().unwrap();
+        let mode = TproxyMode::from(config.aggregate_channels);
+        let server = Sv1Server::new(
+            addr,
+            upstream_receiver,
+            channel_manager_sender,
+            config,
+            mode,
+        );
+        register_test_downstream(&server, 1, Some(1), 100.0);
+        register_test_downstream(&server, 2, None, 100.0);
+        let target = hash_rate_to_target(100.0, 5.0).unwrap();
+
+        server
+            .send_aggregated_update_channel(vec![(1, 1, target, 100.0)])
+            .await
+            .unwrap();
+
+        let (message, _) = channel_manager_receiver.recv().await.unwrap();
+        let MiningOwned::UpdateChannel(update) = message else {
+            panic!("expected UpdateChannel");
+        };
+        assert_eq!(update.nominal_hash_rate, 100.0);
+    }
+
+    #[tokio::test]
+    async fn aggregated_channel_open_refreshes_hashrate() {
+        let (channel_manager_sender, channel_manager_receiver) = unbounded();
+        let (upstream_sender, upstream_receiver) = unbounded();
+        let config = create_test_config();
+        let addr = "127.0.0.1:3333".parse().unwrap();
+        let mode = TproxyMode::from(config.aggregate_channels);
+        let server = Sv1Server::new(
+            addr,
+            upstream_receiver,
+            channel_manager_sender,
+            config,
+            mode,
+        );
+        register_test_downstream(&server, 1, Some(1), 100.0);
+        register_test_downstream(&server, 2, None, 100.0);
+
+        server
+            .send_update_channel_on_downstream_state_change()
+            .await
+            .unwrap();
+        let (message, _) = channel_manager_receiver.recv().await.unwrap();
+        let MiningOwned::UpdateChannel(update) = message else {
+            panic!("expected UpdateChannel");
+        };
+        assert_eq!(update.nominal_hash_rate, 100.0);
+
+        let target = hash_rate_to_target(100.0, 5.0).unwrap();
+        server.request_id_to_downstream_id.insert(42, 2);
+        upstream_sender
+            .send(MiningOwned::OpenExtendedMiningChannelSuccess(
+                OpenExtendedMiningChannelSuccessOwned {
+                    request_id: 42,
+                    channel_id: 2,
+                    target: target.to_le_bytes().into(),
+                    extranonce_size: 4,
+                    extranonce_prefix: vec![0; 4].try_into().unwrap(),
+                    group_channel_id: 0,
+                },
+            ))
+            .await
+            .unwrap();
+
+        server.handle_upstream_message(target).await.unwrap();
+
+        let (message, _) = channel_manager_receiver.recv().await.unwrap();
+        let MiningOwned::UpdateChannel(update) = message else {
+            panic!("expected UpdateChannel");
+        };
+        assert_eq!(update.nominal_hash_rate, 200.0);
     }
 
     #[test]

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -865,6 +865,17 @@ impl Sv1Server {
         self.request_id_to_downstream_id
             .insert(request_id, downstream_id);
 
+        self.forward_pending_open_channel_request(request_id, downstream_id)
+            .await
+    }
+
+    /// Forwards an open request that has already been registered, removing its mapping if the
+    /// request cannot be sent.
+    async fn forward_pending_open_channel_request(
+        &self,
+        request_id: RequestId,
+        downstream_id: DownstreamId,
+    ) -> TproxyResult<(), error::Sv1Server> {
         if let Err(e) = self
             .open_extended_mining_channel(request_id, downstream_id)
             .await
@@ -1146,7 +1157,10 @@ impl Sv1Server {
                 "Downstream {} disconnected before channel could be opened, skipping",
                 downstream_id
             );
-            return Ok(());
+            return Err(TproxyError::disconnect(
+                TproxyErrorKind::DownstreamNotPresent(downstream_id),
+                downstream_id,
+            ));
         }
 
         let hashrate = config.min_individual_miner_hashrate as f64;
@@ -1173,24 +1187,23 @@ impl Sv1Server {
             format!("{user_identity}.miner{miner_id}")
         };
 
-        if let Ok(open_channel_msg) = build_sv2_open_extended_mining_channel(
+        let open_channel_msg = build_sv2_open_extended_mining_channel(
             request_id,
             user_identity.clone(),
             hashrate as Hashrate,
             max_target,
             min_extranonce_size,
-        ) {
-            self.sv1_server_io
-                .channel_manager_sender
-                .send((
-                    MiningOwned::OpenExtendedMiningChannel(open_channel_msg),
-                    None,
-                ))
-                .await
-                .map_err(|_| TproxyError::shutdown(TproxyErrorKind::ChannelErrorSender))?;
-        } else {
-            error!("Failed to build OpenExtendedMiningChannel message");
-        }
+        )
+        .map_err(TproxyError::shutdown)?;
+
+        self.sv1_server_io
+            .channel_manager_sender
+            .send((
+                MiningOwned::OpenExtendedMiningChannel(open_channel_msg),
+                None,
+            ))
+            .await
+            .map_err(|_| TproxyError::shutdown(TproxyErrorKind::ChannelErrorSender))?;
 
         Ok(())
     }
@@ -1856,6 +1869,33 @@ mod tests {
 
         // Test should not panic and should handle the message
         _ = server.handle_set_target_without_vardiff(set_target).await;
+    }
+
+    #[tokio::test]
+    async fn missing_downstream_requests_disconnect() {
+        let server = create_test_sv1_server();
+
+        let error = server.handle_open_channel_request(7).await.unwrap_err();
+
+        assert!(matches!(error.action, Action::Disconnect(7)));
+    }
+
+    #[tokio::test]
+    async fn downstream_removed_before_open_forwarding_clears_pending_request() {
+        let server = create_test_sv1_server();
+        server.request_id_to_downstream_id.insert(42, 7);
+
+        let error = server
+            .forward_pending_open_channel_request(42, 7)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error.action, Action::Disconnect(7)));
+        assert!(matches!(
+            error.kind,
+            TproxyErrorKind::DownstreamNotPresent(7)
+        ));
+        assert!(server.request_id_to_downstream_id.is_empty());
     }
 
     #[test]

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -1738,7 +1738,10 @@ mod tests {
     use crate::config::{DownstreamDifficultyConfig, TranslatorConfig, Upstream};
     use async_channel::unbounded;
     use std::str::FromStr;
-    use stratum_apps::{key_utils::Secp256k1PublicKey, stratum_core::mining_sv2::SetTargetOwned};
+    use stratum_apps::{
+        key_utils::Secp256k1PublicKey,
+        stratum_core::mining_sv2::{OpenExtendedMiningChannelSuccessOwned, SetTargetOwned},
+    };
 
     fn create_test_config() -> TranslatorConfig {
         let pubkey_str = "9bDuixKmZqAJnrmP746n8zU1wyAQRrus7th9dxnkPg6RzQvCnan";
@@ -1895,6 +1898,45 @@ mod tests {
             error.kind,
             TproxyErrorKind::DownstreamNotPresent(7)
         ));
+        assert!(server.request_id_to_downstream_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn late_open_success_closes_channel_for_disconnected_downstream() {
+        let (server_to_channel_manager_sender, server_to_channel_manager_receiver) = unbounded();
+        let (channel_manager_to_server_sender, channel_manager_to_server_receiver) = unbounded();
+        let config = create_test_config();
+        let addr = "127.0.0.1:3333".parse().unwrap();
+        let mode = TproxyMode::from(config.aggregate_channels);
+        let server = Sv1Server::new(
+            addr,
+            channel_manager_to_server_receiver,
+            server_to_channel_manager_sender,
+            config,
+            mode,
+        );
+        let target = hash_rate_to_target(200.0, 5.0).unwrap();
+        server.request_id_to_downstream_id.insert(42, 7);
+        channel_manager_to_server_sender
+            .send(MiningOwned::OpenExtendedMiningChannelSuccess(
+                OpenExtendedMiningChannelSuccessOwned {
+                    request_id: 42,
+                    channel_id: 9,
+                    target: target.to_le_bytes().into(),
+                    extranonce_size: 4,
+                    extranonce_prefix: vec![0; 4].try_into().unwrap(),
+                    group_channel_id: 0,
+                },
+            ))
+            .await
+            .unwrap();
+
+        server.handle_upstream_message(target).await.unwrap();
+
+        let (message, _) = server_to_channel_manager_receiver
+            .try_recv()
+            .expect("the orphaned channel should be closed");
+        assert!(matches!(message, MiningOwned::CloseChannel(close) if close.channel_id == 9));
         assert!(server.request_id_to_downstream_id.is_empty());
     }
 


### PR DESCRIPTION
This PR addresses three related tProxy findings, organized as three independent commits.

### Clean up failed channel-open requests
- Remove the pending request-to-downstream mapping when an extended-channel request cannot be forwarded.
- Treat a missing downstream as a disconnection instead of silently succeeding.
- Propagate failures while building or forwarding `OpenExtendedMiningChannel`, allowing the pending request mapping to be removed.
- Add regression tests for both failure paths.

Closes #671  
Closes project-loupe/audit-sv2-apps#40

### Cover late channel-open success after disconnection
- The behavior reported in #620 and project-loupe/audit-sv2-apps#42 was already fixed as part of #530, but that PR did not reference either issue.
- Add regression coverage for an `OpenExtendedMiningChannelSuccess` received after the requesting downstream has disconnected.
- Verify that tProxy closes the resulting orphaned channel and removes the pending request mapping.

The cleanup behavior already existed; this commit demonstrates and protects it with a test.

Closes #620  
Closes project-loupe/audit-sv2-apps#42

### Ignore unopened miners in aggregate hashrate
- Include only downstreams with an open channel in aggregate hashrate and target calculations.
- Apply the same filtering to state-change and vardiff-driven updates.
- Share the aggregation logic between both update paths.
- Add regression tests for both paths.

Closes #670  
Closes project-loupe/audit-sv2-apps#58