### PR TITLE
perf(stratum-apps): make TaskManager::spawn tracking constant-time

### DIFF
--- a/stratum-apps/src/task_manager.rs
+++ b/stratum-apps/src/task_manager.rs
@@ -1,13 +1,34 @@
 use std::sync::Mutex as StdMutex;
-use tokio::task::JoinHandle;
+use tokio::task::JoinSet;
 
 /// Manages a collection of spawned tokio tasks.
 ///
 /// This struct provides a centralized way to spawn, track, and manage the lifecycle
-/// of async tasks in the translator. It maintains a list of join handles that can
-/// be used to wait for all tasks to complete or abort them during shutdown.
+/// of async tasks in the translator. Tasks are tracked in a [`tokio::task::JoinSet`],
+/// which can be used to wait for all tasks to complete or abort them during shutdown.
+///
+/// # Tracking cost
+///
+/// Tracking must stay cheap on the hot path, because callers spawn several tasks per
+/// downstream connection. A `Vec<JoinHandle<()>>` pruned with `retain(|h|
+/// !h.is_finished())` on every spawn costs a linear scan of every live handle per
+/// spawn, which makes reaching N concurrent connections quadratic in N and serializes
+/// that scan on one mutex.
+///
+/// A `JoinSet` inserts in constant time. Because a `JoinSet` only releases an entry
+/// when that entry is joined, and [`Self::join_all`] runs only at shutdown, spawn
+/// also drains already-finished tasks with the non-blocking
+/// [`tokio::task::JoinSet::try_join_next`]. That drain touches only tasks the runtime
+/// has already marked complete, never live ones, so it costs O(tasks finished since
+/// the previous spawn) — amortized constant per task — and keeps the set bounded to
+/// roughly the live task count. Without it the set would retain one task
+/// control-block per task ever spawned, growing with cumulative rather than
+/// concurrent tasks.
+///
+/// The mutex itself is retained, so spawns still serialize on it; what this removes
+/// is the per-spawn scan over all live handles.
 pub struct TaskManager {
-    tasks: StdMutex<Vec<JoinHandle<()>>>,
+    tasks: StdMutex<JoinSet<()>>,
 }
 
 impl Default for TaskManager {
@@ -22,7 +43,7 @@ impl TaskManager {
     /// Initializes an empty task manager ready to spawn and track tasks.
     pub fn new() -> Self {
         Self {
-            tasks: StdMutex::new(Vec::new()),
+            tasks: StdMutex::new(JoinSet::new()),
         }
     }
 
@@ -47,36 +68,130 @@ impl TaskManager {
             column = location.column(),
         );
 
-        let handle = tokio::spawn(fut.instrument(span));
+        // `JoinSet::spawn` schedules the future on the current runtime, as the prior
+        // `tokio::spawn` did, and retains an abort handle internally. The lock is held
+        // for the insert and the drain below and never across an `.await`, so `spawn`
+        // stays synchronous.
         let mut tasks = self.tasks.lock().unwrap();
-        tasks.retain(|h| !h.is_finished());
-        tasks.push(handle);
+        tasks.spawn(fut.instrument(span));
+
+        // Release entries for tasks that have already completed.
+        while tasks.try_join_next().is_some() {}
     }
 
     /// Waits for all managed tasks to complete.
     ///
     /// This method will block until all tasks that were spawned through this
-    /// manager have finished executing. Tasks are joined in reverse order
-    /// (most recently spawned first).
+    /// manager have finished executing. Tasks are awaited in completion order.
     pub async fn join_all(&self) {
-        let handles = {
+        // `JoinSet::join_next` borrows mutably and is awaited, and a
+        // `std::sync::Mutex` guard must not be held across an `.await`. Move the set
+        // out under the lock, leaving an empty one behind, then drain it unlocked.
+        // Tasks spawned after this point land in the fresh set and are covered by a
+        // later `join_all` or `abort_all`.
+        let mut owned = {
             let mut tasks = self.tasks.lock().unwrap();
             std::mem::take(&mut *tasks)
         };
 
-        for handle in handles {
-            let _ = handle.await;
-        }
+        while owned.join_next().await.is_some() {}
     }
 
     /// Aborts all managed tasks.
     ///
     /// This method immediately cancels all tasks that were spawned through this
     /// manager. The tasks will be terminated without waiting for them to complete.
+    ///
+    /// Aborted entries remain in the set until they are joined, so callers that need
+    /// the tasks reaped should follow this with [`Self::join_all`].
     pub async fn abort_all(&self) {
         let mut tasks = self.tasks.lock().unwrap();
-        for handle in tasks.drain(..) {
-            handle.abort();
+        tasks.abort_all();
+    }
+
+    /// Number of tasks currently tracked, for tests asserting the set stays bounded.
+    #[cfg(test)]
+    fn tracked_len(&self) -> usize {
+        self.tasks.lock().unwrap().len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TaskManager;
+
+    /// `join_all` must release every tracked entry. This is exact rather than
+    /// approximate: after draining, nothing may remain.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn join_all_drains_every_tracked_task() {
+        let task_manager = TaskManager::new();
+        for _ in 0..64 {
+            task_manager.spawn(async {});
         }
+
+        task_manager.join_all().await;
+
+        assert_eq!(
+            task_manager.tracked_len(),
+            0,
+            "join_all left entries behind"
+        );
+    }
+
+    /// `spawn` must release finished entries, so the set tracks roughly the live task
+    /// count rather than every task ever spawned. An implementation that never reaped
+    /// would end at the full cumulative count.
+    ///
+    /// This runs on a current-thread runtime deliberately, so the reap is observable
+    /// without depending on wall-clock time or on how many worker threads happen to be
+    /// free — the suite runs tests in parallel, so a multi-threaded variant is not
+    /// reliable. Each spawned future here is ready immediately, and the batch is kept
+    /// well under the scheduler's per-tick poll budget so one `yield_now` drives the
+    /// whole batch to completion before this task is polled again.
+    ///
+    /// The bound is asserted every round rather than once at the end: if reaping works,
+    /// the tracked count returns to roughly zero each round no matter how many rounds
+    /// run, so accumulation shows up immediately.
+    #[tokio::test]
+    async fn spawn_reaps_finished_tasks_and_stays_bounded() {
+        const ROUNDS: usize = 40;
+        const PER_ROUND: usize = 25;
+        const TOLERANCE: usize = 8;
+
+        let task_manager = TaskManager::new();
+        for round in 0..ROUNDS {
+            for _ in 0..PER_ROUND {
+                task_manager.spawn(async {});
+            }
+
+            // Let the queued batch run to completion, then reap it on the next spawn.
+            tokio::task::yield_now().await;
+            task_manager.spawn(async {});
+
+            let tracked = task_manager.tracked_len();
+            assert!(
+                tracked <= TOLERANCE,
+                "round {round}: {tracked} tasks still tracked after spawning \
+                 {PER_ROUND}, so finished tasks are not being released"
+            );
+        }
+    }
+
+    /// A panicking task must not poison tracking: the entry is still released, and the
+    /// manager keeps working afterwards.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn panicking_task_is_reaped() {
+        let task_manager = TaskManager::new();
+        task_manager.spawn(async {
+            panic!("intentional panic from a managed task");
+        });
+
+        task_manager.join_all().await;
+
+        assert_eq!(
+            task_manager.tracked_len(),
+            0,
+            "panicked task was not reaped"
+        );
     }
 }

--- a/stratum-apps/src/task_manager.rs
+++ b/stratum-apps/src/task_manager.rs
@@ -68,15 +68,36 @@ impl TaskManager {
             column = location.column(),
         );
 
-        // `JoinSet::spawn` schedules the future on the current runtime, as the prior
-        // `tokio::spawn` did, and retains an abort handle internally. The lock is held
-        // for the insert and the drain below and never across an `.await`, so `spawn`
-        // stays synchronous.
-        let mut tasks = self.tasks.lock().unwrap();
-        tasks.spawn(fut.instrument(span));
+        // Collect abnormal exits under the lock and report them after releasing it.
+        // Reporting while holding the lock would put subscriber work on the contended
+        // path, and would deadlock if a subscriber ever spawned through this manager,
+        // because the lock is not reentrant. `Vec::new` does not allocate, so the
+        // common case of no failures costs nothing.
+        let mut abnormal_exits = Vec::new();
 
-        // Release entries for tasks that have already completed.
-        while tasks.try_join_next().is_some() {}
+        {
+            // `JoinSet::spawn` schedules the future on the current runtime, as the prior
+            // `tokio::spawn` did, and retains an abort handle internally. The lock is
+            // held for the insert and the drain and never across an `.await`, so `spawn`
+            // stays synchronous.
+            let mut tasks = self.tasks.lock().unwrap();
+            tasks.spawn(fut.instrument(span));
+
+            // Release entries for tasks that have already completed. A task that
+            // panicked would otherwise fail silently here. Cancellations are expected
+            // during shutdown, so they stay quiet.
+            while let Some(joined) = tasks.try_join_next() {
+                if let Err(join_error) = joined {
+                    if !join_error.is_cancelled() {
+                        abnormal_exits.push(join_error);
+                    }
+                }
+            }
+        }
+
+        for join_error in abnormal_exits {
+            tracing::warn!(error = %join_error, "managed task terminated abnormally");
+        }
     }
 
     /// Waits for all managed tasks to complete.
@@ -94,7 +115,14 @@ impl TaskManager {
             std::mem::take(&mut *tasks)
         };
 
-        while owned.join_next().await.is_some() {}
+        // The lock is already released here, so reporting inline is safe.
+        while let Some(joined) = owned.join_next().await {
+            if let Err(join_error) = joined {
+                if !join_error.is_cancelled() {
+                    tracing::warn!(error = %join_error, "managed task terminated abnormally");
+                }
+            }
+        }
     }
 
     /// Aborts all managed tasks.

--- a/stratum-apps/src/task_manager.rs
+++ b/stratum-apps/src/task_manager.rs
@@ -1,32 +1,13 @@
 use std::sync::Mutex as StdMutex;
 use tokio::task::JoinSet;
 
-/// Manages a collection of spawned tokio tasks.
+/// Spawns and tracks tokio tasks so they can be awaited or aborted at shutdown.
 ///
-/// This struct provides a centralized way to spawn, track, and manage the lifecycle
-/// of async tasks in the translator. Tasks are tracked in a [`tokio::task::JoinSet`],
-/// which can be used to wait for all tasks to complete or abort them during shutdown.
-///
-/// # Tracking cost
-///
-/// Tracking must stay cheap on the hot path, because callers spawn several tasks per
-/// downstream connection. A `Vec<JoinHandle<()>>` pruned with `retain(|h|
-/// !h.is_finished())` on every spawn costs a linear scan of every live handle per
-/// spawn, which makes reaching N concurrent connections quadratic in N and serializes
-/// that scan on one mutex.
-///
-/// A `JoinSet` inserts in constant time. Because a `JoinSet` only releases an entry
-/// when that entry is joined, and [`Self::join_all`] runs only at shutdown, spawn
-/// also drains already-finished tasks with the non-blocking
-/// [`tokio::task::JoinSet::try_join_next`]. That drain touches only tasks the runtime
-/// has already marked complete, never live ones, so it costs O(tasks finished since
-/// the previous spawn) — amortized constant per task — and keeps the set bounded to
-/// roughly the live task count. Without it the set would retain one task
-/// control-block per task ever spawned, growing with cumulative rather than
-/// concurrent tasks.
-///
-/// The mutex itself is retained, so spawns still serialize on it; what this removes
-/// is the per-spawn scan over all live handles.
+/// Tasks are held in a [`tokio::task::JoinSet`]. Because a `JoinSet` releases an entry
+/// only when that entry is joined, and [`Self::join_all`] runs only at shutdown,
+/// [`Self::spawn`] also drains already-finished entries with
+/// [`tokio::task::JoinSet::try_join_next`]. That drain is what keeps the set bounded to
+/// roughly the live task count rather than to every task ever spawned.
 pub struct TaskManager {
     tasks: StdMutex<JoinSet<()>>,
 }
@@ -68,18 +49,13 @@ impl TaskManager {
             column = location.column(),
         );
 
-        // Collect abnormal exits under the lock and report them after releasing it.
-        // Reporting while holding the lock would put subscriber work on the contended
-        // path, and would deadlock if a subscriber ever spawned through this manager,
-        // because the lock is not reentrant. `Vec::new` does not allocate, so the
-        // common case of no failures costs nothing.
+        // Collected under the lock, reported after releasing it: the lock is not
+        // reentrant, so reporting while held would deadlock if a subscriber ever spawned
+        // through this manager.
         let mut abnormal_exits = Vec::new();
 
         {
-            // `JoinSet::spawn` schedules the future on the current runtime, as the prior
-            // `tokio::spawn` did, and retains an abort handle internally. The lock is
-            // held for the insert and the drain and never across an `.await`, so `spawn`
-            // stays synchronous.
+            // Held across the insert and the drain, never across an `.await`.
             let mut tasks = self.tasks.lock().unwrap();
             tasks.spawn(fut.instrument(span));
 


### PR DESCRIPTION
Relates to #492; not `Closes`.

This removes one *candidate* cause of the plateau ([analysis](https://github.com/stratum-mining/sv2-apps/issues/492#issuecomment-5281969056)). The attribution is inferred, not confirmed: the measurement below was taken on a patched tree, and nothing here rules out other contributors. #492 should stay open until the plateau is confirmed gone on stock upstream.

## Problem

`TaskManager::spawn` pruned its `Vec<JoinHandle<()>>` with `retain(|h| !h.is_finished())` on every spawn — a linear scan of every live handle, taken under the tracking mutex. Callers spawn several tasks per downstream connection, so reaching N concurrent connections costs O(N²) and serializes that scan on one lock.

The observable symptom is a connection-accept plateau **at low total CPU**, because a single core saturates on the scan while the rest idle.

## Fix

Track tasks in a `tokio::task::JoinSet`. Insertion is constant time. Because a `JoinSet` releases an entry only when that entry is joined, and `join_all` runs only at shutdown, `spawn` also drains already-finished tasks with the non-blocking `try_join_next`. That drain touches only tasks the runtime has already marked complete, costs O(tasks finished since the previous spawn) — amortized constant per task — and keeps the set bounded to roughly the live task count.

The drain is load-bearing rather than an optimisation: without it the set would retain one task control-block per task *ever* spawned, growing with cumulative rather than concurrent tasks.

## Measurement

`r7i.4xlarge`, pool isolated on its own host, one variable changed:

| | connections | pool CPU |
|---|---|---|
| `Vec` + `retain` | plateau at **34,543** | 25.3% |
| `JoinSet` | **61,259** | 99.6% |

The measured tree was this repo vendored at `14bb42d888fb` (an ancestor of `main`) with a local patch stack, so it was not stock upstream — but the tracking change was the only variable between the two runs. The measurement covers the first commit only; the second postdates it.

## Behavioural changes to be aware of

Nothing in this repo relies on any of these, but they are real deltas:

- **`join_all` awaits in completion order**, not reverse-spawn order. The previous doc comment promised the latter; `join_next` does not provide it, and no caller depends on ordering.
- **`abort_all` leaves aborted entries in the set** until they are joined, where the old `drain(..)` emptied it. Callers wanting them reaped should follow with `join_all`, which shutdown already does.
- **The mutex is retained.** This removes the per-spawn scan, not the lock; spawns still serialize on it. It simply stops being the binding constraint at this scale.

## Commits

1. `perf(stratum-apps): make TaskManager::spawn tracking constant-time` — the change the measurement above covers, plus three tests (`TaskManager` had none): `join_all` drains every entry, `spawn` releases finished entries so the set stays bounded under churn, and a panicking task is still reaped.
2. `feat(stratum-apps): surface tasks that exit abnormally` — both the old `Vec` and the new `JoinSet` discard join results, so a panicking task vanished silently. This logs a warning for non-cancellation join errors, collecting them under the lock and reporting after release, because reporting inline would put subscriber work on the contended path and would deadlock if a subscriber ever spawned through this manager. Split out deliberately so it can be dropped without touching the measured fix.

## Notes

- The bounded-set test runs on a current-thread runtime with batches kept under the scheduler's per-tick poll budget. A multi-threaded variant passed in isolation but failed under the parallel suite, which is worth knowing if this test is ever revisited.
- No version bump: `stratum-apps` is at `0.8.0` while crates.io has `0.7.0`, so the crate is already bumped since last publish, and this change is API-compatible (per CONTRIBUTING factor 2).
- No new dependency; `tokio` already carries `full`, which includes `JoinSet`.

## Validation

Run locally against `main` (`2e40be08`) on the pinned 1.85.0 toolchain:

- `cargo +nightly fmt --all --manifest-path=stratum-apps/Cargo.toml -- --check` — pass (CI formats with nightly)
- `cargo clippy --manifest-path=stratum-apps/Cargo.toml --all-features -- -D warnings` — pass
- `cargo test --manifest-path=stratum-apps/Cargo.toml --all-features` — 142 passed, stable across repeated runs

I did not run the other manifests' clippy/fmt or the integration tests locally; the change is confined to one file in one crate with no API or dependency change.

