### PR TITLE
Fix tProxy issues found by Loupe

### DIFF
--- a/integration-tests/tests/bitcoin_core_ipc_jdp_io.rs
+++ b/integration-tests/tests/bitcoin_core_ipc_jdp_io.rs
@@ -6,8 +6,8 @@
 //! - `DeclareMiningJob` returns `Error(stale-chain-tip)` when the declared BIP34 height is
 //!   intentionally mismatched.
 //! - `DeclareMiningJob` does not retain client-supplied transactions when validation fails.
-//! - `DeclareMiningJob` rejects a coinbase that does not carry exactly one input, without
-//!   tearing down the IPC connection.
+//! - `DeclareMiningJob` rejects a coinbase that does not carry exactly one input, without tearing
+//!   down the IPC connection.
 //!
 //! File structure:
 //! - top: version-specific `#[tokio::test]` wrappers.

--- a/miner-apps/translator/README.md
+++ b/miner-apps/translator/README.md
@@ -95,8 +95,11 @@ Make sure the machine running the Translator Proxy has its clock synced with an 
   address as the username.
 
 #### **Solo/Donation Payout Verification**
-Payout verification is disabled by default. Set `verify_payout = true` for solo mining or
-donation configurations where `user_identity` intentionally encodes an on-chain payout address:
+Payout verification defaults to `false` for compatibility with standard pool mining. When payout
+verification is disabled, tProxy trusts the upstream server's coinbase payout policy and does not
+verify that jobs pay the miner.
+Set `verify_payout = true` for solo mining, or donation configurations where `user_identity`
+intentionally encodes an on-chain payout address:
 
 - `sri/solo/<payout_address>/<worker>`: tProxy verifies every upstream extended job pays 100% of spendable coinbase outputs to `<payout_address>`
 - `<payout_address>[.worker]`: legacy solo mode, verified by checking that at least 90% of spendable coinbase outputs go to `<payout_address>`

--- a/miner-apps/translator/README.md
+++ b/miner-apps/translator/README.md
@@ -115,6 +115,14 @@ If verification fails, tProxy triggers upstream fallback instead of forwarding t
   - When `true`: Translator manages difficulty adjustments based on share submission rates
   - When `false`: Upstream manages difficulty, translator forwards SetTarget messages to miners
 
+- `job_keepalive_interval_secs`: Idle interval before a miner receives a keepalive
+  `mining.notify`; `0` disables keepalives. Only miners whose own interval has elapsed
+  receive one. In aggregated mode, tProxy generates at most one new shared keepalive
+  per interval. A miner becoming due between advances receives the existing
+  shared job. A late joiner also receives the current shared job without resetting
+  shared history or the keepalive schedule. Normal upstream jobs are forwarded
+  without waiting for keepalive deadlines.
+
 #### **Miner Telemetry**
 Translator Proxy can enrich the monitoring API with telemetry from the ASICs connected to its SV1
 port. This is useful when you want the UI to show each miner's management IP, firmware, hashrate,

--- a/miner-apps/translator/src/lib/config.rs
+++ b/miner-apps/translator/src/lib/config.rs
@@ -37,7 +37,8 @@ pub struct TranslatorConfig {
     /// The size of the extranonce2 field for downstream mining connections.
     pub downstream_extranonce2_size: u16,
     /// Whether to verify upstream coinbase outputs against a payout address encoded in each
-    /// upstream `user_identity`.
+    /// upstream `user_identity`. Defaults to `false` for standard pool-mining configurations,
+    /// which trust the upstream's payout policy.
     #[serde(default)]
     pub verify_payout: bool,
     /// Configuration settings for managing difficulty on the downstream connection.
@@ -581,6 +582,7 @@ mod tests {
         assert_eq!(config.upstreams.len(), 2);
         assert_eq!(config.upstreams[0].user_identity, "sri/solo/bc1qprimary");
         assert_eq!(config.upstreams[1].user_identity, "bc1qbackup.worker");
+        assert!(!config.verify_payout);
     }
 }
 

--- a/miner-apps/translator/src/lib/config.rs
+++ b/miner-apps/translator/src/lib/config.rs
@@ -212,10 +212,13 @@ pub struct DownstreamDifficultyConfig {
     /// Whether to enable variable difficulty adjustment mechanism.
     /// If false, difficulty will be managed by upstream (useful with JDC).
     pub enable_vardiff: bool,
-    /// Interval in seconds for sending keepalive jobs to downstream miners.
+    /// Minimum idle interval in seconds before sending a miner a keepalive job.
     /// The translator will send periodic mining.notify messages with updated time
     /// to prevent SV1 miners from timing out when the upstream doesn't send new jobs
     /// frequently enough (e.g., due to low Bitcoin mempool activity).
+    /// Only miners whose individual interval has elapsed receive a keepalive. Aggregated
+    /// keepalive generation advances nTime at most once per interval; other overdue miners
+    /// reuse the latest shared keepalive. Normal upstream jobs are not delayed by this interval.
     /// Set to 0 to disable keepalive jobs.
     pub job_keepalive_interval_secs: u16,
 }

--- a/miner-apps/translator/src/lib/error.rs
+++ b/miner-apps/translator/src/lib/error.rs
@@ -183,6 +183,8 @@ pub enum TproxyErrorKind {
     ChannelErrorReceiver(async_channel::RecvError),
     /// Channel sender error
     ChannelErrorSender,
+    /// A downstream sent too many SV1 messages while waiting for its SV2 channel to open.
+    Sv1HandshakeMessageQueueFull,
     /// Operation timed out
     Timeout,
     /// Error converting SetDifficulty to Message
@@ -255,6 +257,7 @@ impl fmt::Display for TproxyErrorKind {
             PoisonLock => write!(f, "Poison Lock error"),
             ChannelErrorReceiver(e) => write!(f, "Channel receive error: `{e:?}`"),
             ChannelErrorSender => write!(f, "Sender error"),
+            Sv1HandshakeMessageQueueFull => write!(f, "SV1 handshake message queue is full"),
             Timeout => write!(f, "Operation timed out"),
             SetDifficultyToMessage(e) => {
                 write!(f, "Error converting SetDifficulty to Message: `{e:?}`")

--- a/miner-apps/translator/src/lib/error.rs
+++ b/miner-apps/translator/src/lib/error.rs
@@ -221,6 +221,8 @@ pub enum TproxyErrorKind {
     DownstreamNotFoundWithChannelId(ChannelId),
     /// Channel not found
     ChannelNotFound,
+    /// An upstream identifier is already used by a different live channel scope.
+    ChannelIdAlreadyInUse(ChannelId),
     /// Failed to process SetNewPrevHash message
     FailedToProcessSetNewPrevHash,
     /// Failed to process NewExtendedMiningJob message
@@ -304,6 +306,9 @@ impl fmt::Display for TproxyErrorKind {
                 write!(f, "Downstream not found with channel id: {channel_id}")
             }
             ChannelNotFound => write!(f, "Channel not found"),
+            ChannelIdAlreadyInUse(channel_id) => {
+                write!(f, "Channel ID is already in use: {channel_id}")
+            }
             FailedToProcessSetNewPrevHash => write!(f, "Failed to process SetNewPrevHash message"),
             FailedToProcessNewExtendedMiningJob => {
                 write!(f, "Failed to process NewExtendedMiningJob message")

--- a/miner-apps/translator/src/lib/sv1/downstream.rs
+++ b/miner-apps/translator/src/lib/sv1/downstream.rs
@@ -5,14 +5,7 @@ use crate::{
 use async_channel::{Receiver, Sender};
 #[cfg(feature = "monitoring")]
 use std::net::IpAddr;
-use std::{
-    future::Future,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    time::Instant,
-};
+use std::{future::Future, sync::Arc, time::Instant};
 use stratum_apps::{
     channel_utils::ReceiverCleanup,
     fallback_coordinator::FallbackCoordinator,
@@ -63,6 +56,17 @@ impl DownstreamIo {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Sv1HandshakeState {
+    /// The original authorize-triggered notification flush has not started.
+    Pending,
+    /// One caller is flushing cached mining notifications. New notifications stay cached until
+    /// that caller observes an empty notify cache under the same lock and enables forwarding.
+    Completing,
+    /// Cached mining notifications were delivered and normal forwarding is enabled.
+    Complete,
+}
+
 #[derive(Debug)]
 pub struct DownstreamData {
     pub channel_id: Option<ChannelId>,
@@ -81,6 +85,7 @@ pub struct DownstreamData {
     pub sv1_worker_name: String,
     pub cached_set_difficulty: Option<json_rpc::Message>,
     pub cached_notify: Option<json_rpc::Message>,
+    pub(super) sv1_handshake_state: Sv1HandshakeState,
     // Next advertised SV1 target, applied when the corresponding
     // mining.set_difficulty is sent with a new mining.notify.
     pub pending_target: Option<Target>,
@@ -120,6 +125,7 @@ impl DownstreamData {
             sv1_worker_name: String::new(),
             cached_set_difficulty: None,
             cached_notify: None,
+            sv1_handshake_state: Sv1HandshakeState::Pending,
             pending_target: None,
             pending_hashrate: None,
             stable_hashrate: false,
@@ -171,8 +177,6 @@ pub struct Downstream {
     pub downstream_id: DownstreamId,
     pub downstream_data: SharedLock<DownstreamData>,
     pub downstream_io: DownstreamIo,
-    // Flag to track if SV1 handshake is complete (subscribe + authorize)
-    pub sv1_handshake_complete: Arc<AtomicBool>,
     /// Per-connection cancellation token (child of the global token).
     /// Cancelled when this downstream's task loop exits, causing
     /// the associated SV1 I/O task to shut down.
@@ -274,7 +278,6 @@ impl Downstream {
             downstream_id,
             downstream_data,
             downstream_io: downstream_channel_io,
-            sv1_handshake_complete: Arc::new(AtomicBool::new(false)),
             downstream_cancellation_token,
         }
     }
@@ -387,102 +390,75 @@ impl Downstream {
         match self.downstream_io.sv1_server_receiver.recv().await {
             Ok(message) => {
                 let downstream_id = self.downstream_id;
-                let handshake_complete = self.sv1_handshake_complete.load(Ordering::SeqCst);
 
-                // Handle messages based on message type and handshake state
                 if let Message::Notification(notification) = &message {
-                    // For notifications (mining.set_difficulty, mining.notify), only send if
-                    // handshake is complete
-                    if handshake_complete {
-                        match notification.method.as_str() {
-                            "mining.set_difficulty" => {
-                                // Cache the Sv1 set_difficulty message to be sent before the next
-                                // notify
-                                debug!(
-                                    "Down: Caching mining.set_difficulty to send before next mining.notify"
-                                );
-                                self.downstream_data
-                                    .with(|d| d.cached_set_difficulty = Some(message))
-                                    .map_err(TproxyError::shutdown)?;
-                                return Ok(());
-                            }
-                            "mining.notify" => {
-                                let (pending_set_difficulty, notify_opt) = self
-                                    .downstream_data
-                                    .with(|d| {
-                                        let cached_set_difficulty = d.cached_set_difficulty.take();
-
-                                        // Prepare the notify message and update state
-                                        let notify_result = server_to_client::Notify::try_from(
+                    match notification.method.as_str() {
+                        "mining.set_difficulty" => {
+                            // Difficulty changes are always paired with the next notify. Keeping
+                            // the handshake state and cache under the same lock prevents handshake
+                            // completion from draining a newly arrived difficulty by itself.
+                            let handshake_state = self
+                                .downstream_data
+                                .with(|data| {
+                                    data.cached_set_difficulty = Some(message);
+                                    data.sv1_handshake_state
+                                })
+                                .map_err(TproxyError::shutdown)?;
+                            debug!(
+                                ?handshake_state,
+                                "Down: Caching mining.set_difficulty to send before next mining.notify"
+                            );
+                            return Ok(());
+                        }
+                        "mining.notify" => {
+                            let messages_to_send = self
+                                .downstream_data
+                                .with(|data| {
+                                    if data.sv1_handshake_state != Sv1HandshakeState::Complete {
+                                        data.cached_notify = Some(message.clone());
+                                        let notify = server_to_client::Notify::try_from(
                                             notification.clone(),
-                                        );
-                                        if let Ok(mut notify) = notify_result {
-                                            if cached_set_difficulty.is_some() {
-                                                notify.clean_jobs = true;
-                                            }
-                                            d.last_job_version_field = Some(notify.version.0);
+                                        )
+                                        .expect("this must be a mining.notify");
+                                        data.last_job_version_field = Some(notify.version.0);
+                                        return None;
+                                    }
 
-                                            // Update target and hashrate if we're sending
-                                            // set_difficulty
-                                            if cached_set_difficulty.is_some() {
-                                                if let Some(new_target) = d.pending_target.take() {
-                                                    d.target = new_target;
-                                                }
-                                                if let Some(new_hashrate) =
-                                                    d.pending_hashrate.take()
-                                                {
-                                                    d.hashrate = Some(new_hashrate);
-                                                }
-                                            }
-                                            // Update last job received time for keepalive tracking
-                                            d.last_job_received_time = Some(Instant::now());
-                                            (cached_set_difficulty, Some(notify))
-                                        } else {
-                                            (cached_set_difficulty, None)
+                                    let cached_set_difficulty = data.cached_set_difficulty.take();
+                                    let mut notify =
+                                        server_to_client::Notify::try_from(notification.clone())
+                                            .expect("this must be a mining.notify");
+                                    if cached_set_difficulty.is_some() {
+                                        notify.clean_jobs = true;
+                                        if let Some(new_target) = data.pending_target.take() {
+                                            data.target = new_target;
                                         }
-                                    })
-                                    .map_err(TproxyError::shutdown)?;
+                                        if let Some(new_hashrate) = data.pending_hashrate.take() {
+                                            data.hashrate = Some(new_hashrate);
+                                        }
+                                    }
+                                    data.last_job_version_field = Some(notify.version.0);
+                                    data.last_job_received_time = Some(Instant::now());
+                                    Some((cached_set_difficulty, Message::from(notify)))
+                                })
+                                .map_err(TproxyError::shutdown)?;
 
-                                if let Some(set_difficulty_msg) = &pending_set_difficulty {
-                                    debug!(
-                                        "Down: Sending pending mining.set_difficulty before mining.notify"
-                                    );
-                                    self.downstream_io
-                                        .downstream_sv1_sender
-                                        .send(set_difficulty_msg.clone())
-                                        .await
-                                        .map_err(|e| {
-                                            error!(
-                                                "Down: Failed to send mining.set_difficulty to downstream: {:?}",
-                                                e
-                                            );
-                                            TproxyError::disconnect(TproxyErrorKind::ChannelErrorSender, downstream_id)
-                                        })?;
-                                }
-
-                                if let Some(notify) = notify_opt {
-                                    debug!("Down: Sending mining.notify");
-                                    self.downstream_io
-                                        .downstream_sv1_sender
-                                        .send(notify.into())
-                                        .await
-                                        .map_err(|e| {
-                                            error!("Down: Failed to send mining.notify to downstream: {:?}", e);
-                                            TproxyError::disconnect(TproxyErrorKind::ChannelErrorSender, downstream_id)
-                                        })?;
-                                }
+                            let Some((pending_set_difficulty, notify)) = messages_to_send else {
+                                debug!("Down: SV1 handshake not complete, caching mining.notify");
                                 return Ok(());
-                            }
-                            _ => {
-                                // Other notifications - forward if handshake complete
+                            };
+
+                            if let Some(set_difficulty) = pending_set_difficulty {
+                                debug!(
+                                    "Down: Sending pending mining.set_difficulty before mining.notify"
+                                );
                                 self.downstream_io
                                     .downstream_sv1_sender
-                                    .send(message.clone())
+                                    .send(set_difficulty)
                                     .await
-                                    .map_err(|e| {
+                                    .map_err(|error| {
                                         error!(
-                                            "Down: Failed to send notification to downstream: {:?}",
-                                            e
+                                            "Down: Failed to send mining.set_difficulty to downstream: {error:?}"
                                         );
                                         TproxyError::disconnect(
                                             TproxyErrorKind::ChannelErrorSender,
@@ -490,41 +466,54 @@ impl Downstream {
                                         )
                                     })?;
                             }
+
+                            debug!("Down: Sending mining.notify");
+                            self.downstream_io
+                                .downstream_sv1_sender
+                                .send(notify)
+                                .await
+                                .map_err(|error| {
+                                    error!(
+                                        "Down: Failed to send mining.notify to downstream: {error:?}"
+                                    );
+                                    TproxyError::disconnect(
+                                        TproxyErrorKind::ChannelErrorSender,
+                                        downstream_id,
+                                    )
+                                })?;
+                            return Ok(());
                         }
-                    } else {
-                        // Handshake not complete - cache mining notifications but skip others
-                        match notification.method.as_str() {
-                            "mining.set_difficulty" => {
-                                debug!(
-                                    "Down: SV1 handshake not complete, caching mining.set_difficulty"
-                                );
-                                self.downstream_data
-                                    .with(|d| d.cached_set_difficulty = Some(message))
-                                    .map_err(TproxyError::shutdown)?;
-                            }
-                            "mining.notify" => {
-                                debug!("Down: SV1 handshake not complete, caching mining.notify");
-                                self.downstream_data
-                                    .with(|d| {
-                                        d.cached_notify = Some(message.clone());
-                                        let notify = server_to_client::Notify::try_from(
-                                            notification.clone(),
-                                        )
-                                        .expect("this must be a mining.notify");
-                                        d.last_job_version_field = Some(notify.version.0);
-                                    })
-                                    .map_err(TproxyError::shutdown)?;
-                            }
-                            _ => {
+                        _ => {
+                            let handshake_complete = self
+                                .downstream_data
+                                .with(|data| {
+                                    data.sv1_handshake_state == Sv1HandshakeState::Complete
+                                })
+                                .map_err(TproxyError::shutdown)?;
+                            if !handshake_complete {
                                 debug!(
                                     "Down: SV1 handshake not complete, skipping other notification"
                                 );
+                                return Ok(());
                             }
+
+                            self.downstream_io
+                                .downstream_sv1_sender
+                                .send(message)
+                                .await
+                                .map_err(|error| {
+                                    error!(
+                                        "Down: Failed to send notification to downstream: {error:?}"
+                                    );
+                                    TproxyError::disconnect(
+                                        TproxyErrorKind::ChannelErrorSender,
+                                        downstream_id,
+                                    )
+                                })?;
                         }
                     }
                 } else {
-                    // Handshake not complete - skip non-notification messages.
-                    debug!("Down: SV1 handshake not complete, skipping non-notification message");
+                    debug!("Down: Skipping non-notification message from SV1 server");
                 }
             }
             Err(e) => {
@@ -572,75 +561,342 @@ impl Downstream {
 
     /// Handles SV1 handshake completion after mining.authorize.
     ///
-    /// This method is called when the downstream completes the SV1 handshake
-    /// (subscribe + authorize). It sends any cached messages in the correct order:
-    /// set_difficulty first, then notify.
+    /// The server calls this after queuing an authorize response. The first call flushes cached
+    /// mining notifications (difficulty before notify); repeated calls do nothing. State and cache
+    /// transitions share a lock so normal forwarding cannot overtake the flush or leave work
+    /// stranded in the cache.
     pub(super) async fn handle_sv1_handshake_completion(
         &self,
     ) -> TproxyResult<(), error::Downstream> {
-        let (cached_set_difficulty, cached_notify, downstream_id) = self
+        let cached_messages = self
             .downstream_data
-            .with(|d| {
-                self.sv1_handshake_complete
-                    .store(true, std::sync::atomic::Ordering::SeqCst);
-                (
-                    d.cached_set_difficulty.take(),
-                    d.cached_notify.take(),
-                    self.downstream_id,
-                )
+            .with(|data| {
+                if data.sv1_handshake_state != Sv1HandshakeState::Pending {
+                    return None;
+                }
+                data.sv1_handshake_state = Sv1HandshakeState::Completing;
+                Some((data.cached_set_difficulty.take(), data.cached_notify.take()))
             })
             .map_err(TproxyError::shutdown)?;
+        let Some((cached_set_difficulty, cached_notify)) = cached_messages else {
+            debug!(
+                "Down: Ignoring repeated SV1 handshake completion for downstream {}",
+                self.downstream_id
+            );
+            return Ok(());
+        };
+
         debug!("Down: SV1 handshake completed for downstream");
 
-        // Send cached messages in correct order: set_difficulty first, then notify
-        if let Some(set_difficulty_msg) = cached_set_difficulty {
+        self.send_cached_mining_notifications(cached_set_difficulty, cached_notify)
+            .await?;
+
+        // Notifications can arrive while the initial cached pair is being sent. Keep the state
+        // in `Completing` until every cached notify has been flushed. A difficulty that arrives
+        // without a notify remains cached for the next normal notify instead of being sent bare.
+        loop {
+            let next_messages = self
+                .downstream_data
+                .with(|data| {
+                    let Some(notify) = data.cached_notify.take() else {
+                        data.sv1_handshake_state = Sv1HandshakeState::Complete;
+                        return None;
+                    };
+                    Some((data.cached_set_difficulty.take(), Some(notify)))
+                })
+                .map_err(TproxyError::shutdown)?;
+
+            let Some((set_difficulty, notify)) = next_messages else {
+                break;
+            };
+            self.send_cached_mining_notifications(set_difficulty, notify)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Sends mining notifications already removed from the cache, not handshake responses.
+    /// Each call sends a new cached pair; a missing difficulty still permits notify delivery.
+    async fn send_cached_mining_notifications(
+        &self,
+        set_difficulty: Option<json_rpc::Message>,
+        notify: Option<json_rpc::Message>,
+    ) -> TproxyResult<(), error::Downstream> {
+        let mut did_send_difficulty = false;
+        if let Some(set_difficulty) = set_difficulty {
             debug!("Down: Sending cached mining.set_difficulty after handshake completion");
             self.downstream_io
                 .downstream_sv1_sender
-                .send(set_difficulty_msg)
+                .send(set_difficulty)
                 .await
-                .map_err(|e| {
+                .map_err(|error| {
                     error!(
-                        "Down: Failed to send cached mining.set_difficulty to downstream: {:?}",
-                        e
+                        "Down: Failed to send cached mining.set_difficulty to downstream: {error:?}"
                     );
-                    TproxyError::disconnect(TproxyErrorKind::ChannelErrorSender, downstream_id)
+                    TproxyError::disconnect(TproxyErrorKind::ChannelErrorSender, self.downstream_id)
                 })?;
 
-            // Update target and hashrate after sending set_difficulty
             self.downstream_data
-                .with(|d| {
-                    if let Some(new_target) = d.pending_target.take() {
-                        d.target = new_target;
+                .with(|data| {
+                    if let Some(new_target) = data.pending_target.take() {
+                        data.target = new_target;
                     }
-                    if let Some(new_hashrate) = d.pending_hashrate.take() {
-                        d.hashrate = Some(new_hashrate);
+                    if let Some(new_hashrate) = data.pending_hashrate.take() {
+                        data.hashrate = Some(new_hashrate);
                     }
                 })
                 .map_err(TproxyError::shutdown)?;
+            did_send_difficulty = true;
         }
 
-        if let Some(notify_msg) = cached_notify {
+        if let Some(notify_msg) = notify {
             debug!("Down: Sending cached mining.notify after handshake completion");
+            let mut notify_msg = notify_msg;
+            if did_send_difficulty {
+                if let json_rpc::Message::Notification(notification) = &notify_msg {
+                    let mut parsed = server_to_client::Notify::try_from(notification.clone())
+                        .expect("mining.notify is always valid here");
+                    parsed.clean_jobs = true;
+                    notify_msg = parsed.into();
+                }
+            }
             self.downstream_io
                 .downstream_sv1_sender
                 .send(notify_msg)
                 .await
-                .map_err(|e| {
-                    error!(
-                        "Down: Failed to send cached mining.notify to downstream: {:?}",
-                        e
-                    );
-                    TproxyError::disconnect(TproxyErrorKind::ChannelErrorSender, downstream_id)
+                .map_err(|error| {
+                    error!("Down: Failed to send cached mining.notify to downstream: {error:?}");
+                    TproxyError::disconnect(TproxyErrorKind::ChannelErrorSender, self.downstream_id)
                 })?;
-            // Update last job received time for keepalive tracking
             self.downstream_data
-                .with(|d| {
-                    d.last_job_received_time = Some(Instant::now());
-                })
+                .with(|data| data.last_job_received_time = Some(Instant::now()))
                 .map_err(TproxyError::shutdown)?;
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_channel::{bounded, unbounded};
+
+    fn notify(job_id: &str) -> Message {
+        serde_json::from_value(serde_json::json!({
+            "id": null,
+            "method": "mining.notify",
+            "params": [
+                job_id,
+                "00".repeat(32),
+                "00",
+                "00",
+                [],
+                "20000000",
+                "1d00ffff",
+                "00000001",
+                true
+            ]
+        }))
+        .unwrap()
+    }
+
+    fn set_difficulty() -> Message {
+        serde_json::from_value(serde_json::json!({
+            "id": null,
+            "method": "mining.set_difficulty",
+            "params": [1.0]
+        }))
+        .unwrap()
+    }
+
+    fn assert_message_eq(actual: &Message, expected: &Message) {
+        assert_eq!(
+            serde_json::to_value(actual).unwrap(),
+            serde_json::to_value(expected).unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_handshake_completion_preserves_cached_difficulty() {
+        let (downstream_sv1_sender, downstream_sv1_receiver) = unbounded();
+        let (_downstream_sender, downstream_receiver) = unbounded();
+        let (sv1_server_sender, _sv1_server_receiver) = unbounded();
+        let (_sv1_server_sender, sv1_server_receiver) = unbounded();
+        let old_target = Target::from_le_bytes([0x11; 32]);
+        let new_target = Target::from_le_bytes([0x22; 32]);
+        let downstream = Downstream::new(
+            1,
+            downstream_sv1_sender,
+            downstream_receiver,
+            sv1_server_sender,
+            sv1_server_receiver,
+            old_target,
+            None,
+            #[cfg(feature = "monitoring")]
+            "127.0.0.1".parse().unwrap(),
+            CancellationToken::new(),
+        );
+
+        downstream
+            .downstream_data
+            .with(|data| {
+                data.sv1_handshake_state = Sv1HandshakeState::Complete;
+                data.cached_set_difficulty = Some(set_difficulty());
+                data.pending_target = Some(new_target);
+            })
+            .unwrap();
+
+        downstream.handle_sv1_handshake_completion().await.unwrap();
+
+        assert!(downstream_sv1_receiver.try_recv().is_err());
+        downstream
+            .downstream_data
+            .with(|data| {
+                assert_eq!(data.target, old_target);
+                assert_eq!(data.pending_target, Some(new_target));
+                assert!(data.cached_set_difficulty.is_some());
+                assert_eq!(data.sv1_handshake_state, Sv1HandshakeState::Complete);
+            })
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn notify_arriving_during_handshake_completion_is_flushed() {
+        let (downstream_sv1_sender, downstream_sv1_receiver) = bounded(1);
+        let (_downstream_sender, downstream_receiver) = unbounded();
+        let (sv1_server_sender, _sv1_server_receiver) = unbounded();
+        let (sv1_server_message_sender, sv1_server_receiver) = unbounded();
+        let downstream = Downstream::new(
+            1,
+            downstream_sv1_sender.clone(),
+            downstream_receiver,
+            sv1_server_sender,
+            sv1_server_receiver,
+            Target::from_le_bytes([0x11; 32]),
+            None,
+            #[cfg(feature = "monitoring")]
+            "127.0.0.1".parse().unwrap(),
+            CancellationToken::new(),
+        );
+        let initial_notify = notify("initial");
+        let concurrent_notify = notify("concurrent");
+        downstream
+            .downstream_data
+            .with(|data| data.cached_notify = Some(initial_notify.clone()))
+            .unwrap();
+
+        // Fill the outbound queue so completion pauses while sending its initial cached notify.
+        downstream_sv1_sender.try_send(set_difficulty()).unwrap();
+        let completing_downstream = downstream.clone();
+        let completion = tokio::spawn(async move {
+            completing_downstream
+                .handle_sv1_handshake_completion()
+                .await
+        });
+        loop {
+            if downstream
+                .downstream_data
+                .with(|data| data.sv1_handshake_state == Sv1HandshakeState::Completing)
+                .unwrap()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        sv1_server_message_sender
+            .send(concurrent_notify.clone())
+            .await
+            .unwrap();
+        downstream.handle_sv1_server_message().await.unwrap();
+
+        // Unblock completion and verify it drains the notification that raced with it.
+        downstream_sv1_receiver.recv().await.unwrap();
+        assert_message_eq(
+            &downstream_sv1_receiver.recv().await.unwrap(),
+            &initial_notify,
+        );
+        assert_message_eq(
+            &downstream_sv1_receiver.recv().await.unwrap(),
+            &concurrent_notify,
+        );
+        completion.await.unwrap().unwrap();
+        downstream
+            .downstream_data
+            .with(|data| {
+                assert_eq!(data.sv1_handshake_state, Sv1HandshakeState::Complete);
+                assert!(data.cached_notify.is_none());
+            })
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn difficulty_arriving_during_completion_waits_for_next_notify() {
+        let (downstream_sv1_sender, downstream_sv1_receiver) = bounded(1);
+        let (_downstream_sender, downstream_receiver) = unbounded();
+        let (sv1_server_sender, _sv1_server_receiver) = unbounded();
+        let (sv1_server_message_sender, sv1_server_receiver) = unbounded();
+        let downstream = Downstream::new(
+            1,
+            downstream_sv1_sender.clone(),
+            downstream_receiver,
+            sv1_server_sender,
+            sv1_server_receiver,
+            Target::from_le_bytes([0x11; 32]),
+            None,
+            #[cfg(feature = "monitoring")]
+            "127.0.0.1".parse().unwrap(),
+            CancellationToken::new(),
+        );
+        let initial_notify = notify("initial");
+        let concurrent_difficulty = set_difficulty();
+        downstream
+            .downstream_data
+            .with(|data| data.cached_notify = Some(initial_notify.clone()))
+            .unwrap();
+
+        downstream_sv1_sender.try_send(set_difficulty()).unwrap();
+        let completing_downstream = downstream.clone();
+        let completion = tokio::spawn(async move {
+            completing_downstream
+                .handle_sv1_handshake_completion()
+                .await
+        });
+        loop {
+            if downstream
+                .downstream_data
+                .with(|data| data.sv1_handshake_state == Sv1HandshakeState::Completing)
+                .unwrap()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        sv1_server_message_sender
+            .send(concurrent_difficulty.clone())
+            .await
+            .unwrap();
+        downstream.handle_sv1_server_message().await.unwrap();
+
+        downstream_sv1_receiver.recv().await.unwrap();
+        assert_message_eq(
+            &downstream_sv1_receiver.recv().await.unwrap(),
+            &initial_notify,
+        );
+        completion.await.unwrap().unwrap();
+        assert!(downstream_sv1_receiver.try_recv().is_err());
+        downstream
+            .downstream_data
+            .with(|data| {
+                assert_eq!(data.sv1_handshake_state, Sv1HandshakeState::Complete);
+                assert_message_eq(
+                    data.cached_set_difficulty.as_ref().unwrap(),
+                    &concurrent_difficulty,
+                );
+            })
+            .unwrap();
     }
 }

--- a/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/difficulty_manager.rs
@@ -62,10 +62,14 @@ impl Sv1Server {
     /// This method implements the core vardiff logic:
     /// 1. For each downstream, calculate if a target update is needed
     /// 2. Always send UpdateChannel to keep upstream informed
-    /// 3. Compare new target with upstream target to decide when to send set_difficulty:
-    ///    - If new_target >= upstream_target: send set_difficulty immediately
-    ///    - If new_target < upstream_target: wait for SetTarget response before sending
-    ///      set_difficulty
+    /// 3. Compare the new target with the upstream target to decide when to send set_difficulty.
+    ///    Bitcoin targets are ordered inversely to difficulty: a larger target is easier.
+    ///    - If `new_target >= upstream_target`, advertise it immediately. This preserves every
+    ///      upstream-valid share; additional easier shares are revalidated against the actual
+    ///      upstream channel target by the channel manager and filtered locally.
+    ///    - If `new_target < upstream_target`, wait for SetTarget. Advertising a harder target
+    ///      early would prevent the miner from submitting shares that the upstream would still
+    ///      accept and reward.
     /// 4. Handle aggregated vs non-aggregated modes for UpdateChannel messages
     pub(super) async fn handle_vardiff_updates(&self) -> TproxyResult<(), error::Sv1Server> {
         let mut immediate_updates = Vec::new();
@@ -155,8 +159,10 @@ impl Sv1Server {
                     match upstream_target {
                         Some(upstream_target) => {
                             if new_target >= upstream_target {
-                                // Case 1: new_target >= upstream_target, send set_difficulty
-                                // immediately
+                                // A larger target is easier. Advertise it immediately so the miner
+                                // continues submitting every upstream-valid share; the channel
+                                // manager filters any additional shares that miss the actual
+                                // upstream target.
                                 trace!(
                                     "✅ Target comparison: new_target ({}) >= upstream_target ({}) for downstream {}, will send mining.set_difficulty immediately",
                                     new_target, upstream_target, downstream_id
@@ -171,8 +177,8 @@ impl Sv1Server {
                                 // difficulty.
                                 self.pending_target_updates.remove(&downstream_id);
                             } else {
-                                // Case 2: new_target < upstream_target, delay set_difficulty until
-                                // SetTarget
+                                // A smaller target is harder. Delay it until SetTarget confirms the
+                                // upstream no longer accepts the shares this target would suppress.
                                 trace!(
                                     "⏳ Target comparison: new_target ({}) < upstream_target ({}) for downstream {}, will delay mining.set_difficulty until SetTarget",
                                     new_target, upstream_target, downstream_id
@@ -545,8 +551,10 @@ impl Sv1Server {
                     return true; // keep pending (not relevant for this SetTarget)
                 }
 
+                // It is safe to advertise the pending target once it is at least as easy as the
+                // new upstream target. The miner will then submit every upstream-valid share;
+                // anything easier is filtered locally by channel-manager validation.
                 if *pending_target >= new_upstream_target {
-                    // Target is acceptable, can apply immediately
                     applicable_updates.push(PendingTargetUpdate {
                         downstream_id: *pending_downstream_id,
                         new_target: *pending_target,

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -2340,7 +2340,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn immediate_vardiff_update_clears_stale_pending_target() {
+    async fn easier_vardiff_target_does_not_wait_for_upstream() {
         use stratum_apps::stratum_core::channels_sv2::Vardiff;
 
         let server = create_test_sv1_server();
@@ -2378,20 +2378,38 @@ mod tests {
         // the pending-map bookkeeping we assert on happens before that.
         let _ = server.handle_vardiff_updates().await;
 
+        let pending_target = server
+            .downstreams
+            .with(&7, |downstream| {
+                downstream
+                    .downstream_data
+                    .with(|data| data.pending_target)
+                    .unwrap()
+            })
+            .unwrap()
+            .unwrap();
+        assert!(
+            pending_target > upstream_target,
+            "a larger target is easier and must preserve every upstream-valid share"
+        );
         assert!(
             !server.pending_target_updates.contains_key(&7),
-            "immediate update must clear the superseded pending target"
+            "an easier target must be advertised immediately and clear stale pending state"
         );
     }
 
     #[tokio::test]
-    async fn stale_set_target_keeps_pending_update_until_satisfied() {
+    async fn harder_vardiff_target_waits_until_upstream_accepts_it() {
         let server = create_test_sv1_server();
         register_test_downstream(&server, 7, Some(9), 100.0, false);
 
         // The downstream wants a harder (lower) target than the upstream currently has.
         let pending_target = hash_rate_to_target(200.0, 5.0).unwrap();
         let stale_upstream_target = hash_rate_to_target(100.0, 5.0).unwrap();
+        assert!(
+            pending_target < stale_upstream_target,
+            "a smaller target is harder and would suppress upstream-valid shares"
+        );
         server.pending_target_updates.insert(7, pending_target);
 
         // A SetTarget that does not satisfy the pending update (e.g. the reply to an

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -1416,6 +1416,9 @@ impl Sv1Server {
             Ok::<(), TproxyError<error::Sv1Server>>(())
         })?;
 
+        // Finish the broadcast before reporting a closed sender, otherwise one disconnected miner
+        // prevents healthy miners later in the iteration from receiving the new difficulty.
+        let mut disconnected_downstream = None;
         for (downstream_id, sender) in tasks {
             let set_difficulty_msg =
                 match build_sv1_set_difficulty_from_sv2_target_with_integer_power_of_two_rounding(
@@ -1436,10 +1439,7 @@ impl Sv1Server {
                     "Failed to send mining.set_difficulty to downstream {}: {:?}",
                     downstream_id, e
                 );
-                return Err(TproxyError::disconnect(
-                    TproxyErrorKind::ChannelErrorSender,
-                    downstream_id,
-                ));
+                disconnected_downstream.get_or_insert(downstream_id);
             } else {
                 debug!(
                     "Sent mining.set_difficulty to downstream {} (vardiff disabled)",
@@ -1447,6 +1447,14 @@ impl Sv1Server {
                 );
             }
         }
+
+        if let Some(downstream_id) = disconnected_downstream {
+            return Err(TproxyError::disconnect(
+                TproxyErrorKind::ChannelErrorSender,
+                downstream_id,
+            ));
+        }
+
         Ok(())
     }
 
@@ -1824,7 +1832,7 @@ mod tests {
         channel_id: Option<ChannelId>,
         hashrate: Hashrate,
         close_server_channel: bool,
-    ) {
+    ) -> Receiver<json_rpc::Message> {
         let (downstream_sv1_sender, _downstream_sv1_receiver) = unbounded();
         let (_miner_sender, miner_receiver) = unbounded();
         let (sv1_server_sender, sv1_server_receiver) = unbounded();
@@ -1838,7 +1846,7 @@ mod tests {
             downstream_sv1_sender,
             miner_receiver,
             server.sv1_server_io.downstream_to_sv1_server_sender.clone(),
-            sv1_server_receiver,
+            sv1_server_receiver.clone(),
             target,
             Some(hashrate),
             #[cfg(feature = "monitoring")]
@@ -1860,6 +1868,8 @@ mod tests {
             .sv1_server_io
             .sv1_server_to_downstream_sender
             .insert(downstream_id, sv1_server_sender);
+
+        sv1_server_receiver
     }
 
     #[test]
@@ -2260,7 +2270,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn closed_downstream_does_not_shutdown_on_aggregated_set_target() {
+    async fn closed_downstream_does_not_abort_aggregated_difficulty_broadcast() {
         let mut config = create_test_config();
         config.downstream_difficulty_config.enable_vardiff = false;
 
@@ -2269,7 +2279,30 @@ mod tests {
         let addr = "127.0.0.1:3333".parse().unwrap();
         let tproxy_mode = TproxyMode::from(config.aggregate_channels);
         let server = Sv1Server::new(addr, cm_receiver, cm_sender, config, tproxy_mode);
-        register_test_downstream(&server, 7, Some(9), 100.0, true);
+        let receivers = [
+            (
+                7,
+                register_test_downstream(&server, 7, Some(9), 100.0, false),
+            ),
+            (
+                8,
+                register_test_downstream(&server, 8, Some(10), 100.0, false),
+            ),
+        ];
+
+        let mut iteration_order = Vec::new();
+        server
+            .downstreams
+            .for_each(|downstream_id, _| iteration_order.push(downstream_id));
+        assert_eq!(iteration_order.len(), 2);
+        let closed_id = iteration_order[0];
+        let surviving_id = iteration_order[1];
+        receivers
+            .iter()
+            .find(|(downstream_id, _)| *downstream_id == closed_id)
+            .unwrap()
+            .1
+            .close();
 
         let target = hash_rate_to_target(200.0, 5.0).unwrap();
         let error = server
@@ -2280,8 +2313,18 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(matches!(error.action, Action::Disconnect(7)));
+        assert!(matches!(error.action, Action::Disconnect(id) if id == closed_id));
         assert!(matches!(error.kind, TproxyErrorKind::ChannelErrorSender));
+        assert!(
+            receivers
+                .iter()
+                .find(|(downstream_id, _)| *downstream_id == surviving_id)
+                .unwrap()
+                .1
+                .try_recv()
+                .is_ok(),
+            "a closed peer aborted the broadcast before the surviving miner received the new difficulty"
+        );
     }
 
     #[tokio::test]

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -76,6 +76,14 @@ use tracing::{debug, error, info, trace, warn};
 
 const SV1_MIN_DIFFICULTY_FOR_INTEGER_POWER_OF_TWO_ROUNDING: f64 = 1.0;
 
+// A miner can pipeline mining.configure, mining.subscribe, mining.extranonce.subscribe,
+// mining.suggest_difficulty, and mining.authorize while its SV2 channel is opening; some BIP 310
+// extensions also permit mining.configure to be repeated. Eight messages leave compatibility
+// headroom for that setup traffic while preventing an unauthenticated downstream from growing this
+// per-connection buffer without bound. The SV1 network reader separately limits each line to 64
+// KiB.
+const MAX_QUEUED_SV1_HANDSHAKE_MESSAGES: usize = 8;
+
 #[derive(Clone)]
 struct Sv1ServerIo {
     sv1_server_to_downstream_sender: SharedMap<DownstreamId, Sender<json_rpc::Message>>,
@@ -685,16 +693,25 @@ impl Sv1Server {
                     downstream_id
                 );
             }
-            debug!("Down: Queuing Sv1 message until channel is established");
             self.with_registered_downstream(downstream_id, |downstream| {
                 downstream
                     .downstream_data
                     .with(|data| {
-                        data.queued_sv1_handshake_messages
-                            .push(downstream_message.clone())
+                        if data.queued_sv1_handshake_messages.len()
+                            >= MAX_QUEUED_SV1_HANDSHAKE_MESSAGES
+                        {
+                            return Err(TproxyError::disconnect(
+                                TproxyErrorKind::Sv1HandshakeMessageQueueFull,
+                                downstream_id,
+                            ));
+                        }
+
+                        data.queued_sv1_handshake_messages.push(downstream_message);
+                        Ok(())
                     })
-                    .map_err(TproxyError::shutdown)
+                    .map_err(TproxyError::shutdown)?
             })?;
+            debug!("Down: Queuing Sv1 message until channel is established");
             return Ok(());
         }
 
@@ -1972,6 +1989,81 @@ mod tests {
         let error = server.handle_open_channel_request(7).await.unwrap_err();
 
         assert!(matches!(error.action, Action::Disconnect(7)));
+    }
+
+    #[tokio::test]
+    async fn pre_channel_sv1_message_queue_disconnects_at_limit() {
+        let (server_to_channel_manager_sender, _server_to_channel_manager_receiver) = unbounded();
+        let (_channel_manager_to_server_sender, channel_manager_to_server_receiver) = unbounded();
+        let config = create_test_config();
+        let addr = "127.0.0.1:3333".parse().unwrap();
+        let mode = TproxyMode::from(config.aggregate_channels);
+        let server = Sv1Server::new(
+            addr,
+            channel_manager_to_server_receiver,
+            server_to_channel_manager_sender,
+            config,
+            mode,
+        );
+        server.set_user_identity("test_user".to_string());
+        let downstream_id = 7;
+        let _downstream_receiver =
+            register_test_downstream(&server, downstream_id, None, 100.0, false);
+        let message = json_rpc::Message::StandardRequest(json_rpc::StandardRequest {
+            id: 1,
+            method: "mining.subscribe".to_string(),
+            params: serde_json::Value::Null,
+        });
+
+        for _ in 0..MAX_QUEUED_SV1_HANDSHAKE_MESSAGES {
+            server
+                .sv1_server_io
+                .downstream_to_sv1_server_sender
+                .send((downstream_id, message.clone()))
+                .await
+                .unwrap();
+            server.handle_downstream_message().await.unwrap();
+        }
+
+        server
+            .sv1_server_io
+            .downstream_to_sv1_server_sender
+            .send((downstream_id, message))
+            .await
+            .unwrap();
+        let error = server.handle_downstream_message().await.unwrap_err();
+
+        assert!(matches!(error.action, Action::Disconnect(7)));
+        assert!(matches!(
+            error.kind,
+            TproxyErrorKind::Sv1HandshakeMessageQueueFull
+        ));
+        assert_eq!(
+            server
+                .with_registered_downstream(downstream_id, |downstream| {
+                    downstream
+                        .downstream_data
+                        .with(|data| data.queued_sv1_handshake_messages.len())
+                        .map_err(TproxyError::shutdown)
+                })
+                .unwrap(),
+            MAX_QUEUED_SV1_HANDSHAKE_MESSAGES
+        );
+
+        let cancellation_token = CancellationToken::new();
+        let fallback_token = CancellationToken::new();
+        assert_eq!(
+            server
+                .handle_error_action(
+                    "pre_channel_sv1_message_queue_disconnects_at_limit",
+                    &error,
+                    &cancellation_token,
+                    &fallback_token,
+                )
+                .await,
+            LoopControl::Continue
+        );
+        assert!(!server.downstreams.contains_key(&downstream_id));
     }
 
     #[tokio::test]

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -21,7 +21,7 @@ pub mod downstream_message_handler;
 use crate::{
     config::TranslatorConfig,
     error::{self, Action, LoopControl, TproxyError, TproxyErrorKind, TproxyResult},
-    sv1::downstream::Downstream,
+    sv1::downstream::{Downstream, Sv1HandshakeState},
     utils::{
         AGGREGATED_CHANNEL_ID, KEEPALIVE_JOB_ID_DELIMITER, SubmitShareWithChannelId, TproxyMode,
         is_mining_authorize,
@@ -1583,7 +1583,7 @@ impl Sv1Server {
                         // 1. Handshake is complete
                         // 2. Enough time has passed since last job
                         let handshake_complete =
-                            downstream.sv1_handshake_complete.load(Ordering::SeqCst);
+                            d.sv1_handshake_state == Sv1HandshakeState::Complete;
 
                         if !handshake_complete {
                             return None;

--- a/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
+++ b/miner-apps/translator/src/lib/sv1/sv1_server/mod.rs
@@ -66,7 +66,7 @@ use stratum_apps::{
         },
         sv1_api::{IsServer, json_rpc, server_to_client, utils::HexU32Be},
     },
-    sync::SharedMap,
+    sync::{SharedLock, SharedMap},
     task_manager::TaskManager,
     utils::types::{ChannelId, DownstreamId, Hashrate, RequestId, SharesPerMinute},
 };
@@ -75,6 +75,9 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace, warn};
 
 const SV1_MIN_DIFFICULTY_FOR_INTEGER_POWER_OF_TWO_ROUNDING: f64 = 1.0;
+
+// Maximum keepalive nTime offset from the original upstream job.
+const MAX_FUTURE_BLOCK_TIME: u32 = 2 * 60 * 60;
 
 // A miner can pipeline mining.configure, mining.subscribe, mining.extranonce.subscribe,
 // mining.suggest_difficulty, and mining.authorize while its SV2 channel is opening; some BIP 310
@@ -190,6 +193,10 @@ pub struct Sv1Server {
     pub(crate) sequence_counter: Arc<AtomicU32>,
     pub(crate) miner_counter: Arc<AtomicU32>,
     pub(crate) keepalive_job_id_counter: Arc<AtomicU32>,
+    /// Wall-clock time of the last job appended to the shared aggregated history. This keeps
+    /// phased or unreachable downstreams from advancing the shared nTime more than once per
+    /// configured keepalive interval.
+    aggregated_job_mutation_time: SharedLock<Option<Instant>>,
     pub(crate) downstream_id_factory: Arc<AtomicUsize>,
     pub(crate) request_id_factory: Arc<AtomicU32>,
     pub(crate) downstreams: SharedMap<DownstreamId, Downstream>,
@@ -338,6 +345,7 @@ impl Sv1Server {
     fn cleanup(&self) {
         self.prevhashes.clear();
         self.valid_sv1_jobs.clear();
+        let _ = self.aggregated_job_mutation_time.set(None);
         if self.config.downstream_difficulty_config.enable_vardiff {
             self.vardiff.clear();
         }
@@ -403,6 +411,7 @@ impl Sv1Server {
             miner_counter: Arc::new(AtomicU32::new(0)),
             sequence_counter: Arc::new(AtomicU32::new(1)),
             keepalive_job_id_counter: Arc::new(AtomicU32::new(0)),
+            aggregated_job_mutation_time: SharedLock::new(None),
             downstream_id_factory: Arc::new(AtomicUsize::new(1)),
             request_id_factory: Arc::new(AtomicU32::new(1)),
             downstreams: SharedMap::new(),
@@ -1135,15 +1144,51 @@ impl Sv1Server {
                     let notify = build_sv1_notify_from_sv2(prevhash, m.clone(), clean_jobs)
                         .map_err(TproxyError::shutdown)?;
 
-                    // Update job storage based on the configured mode
-                    let notify_parsed = notify.clone();
-                    self.valid_sv1_jobs
-                        .with_mut_or_default(job_channel_id, |channel_jobs| {
-                            if clean_jobs {
-                                channel_jobs.clear();
+                    // A late joiner starts from the current shared work, including any rolled
+                    // nTime. Its bootstrap initializes only that miner's view, without mutating
+                    // the aggregate history or restarting the shared keepalive interval.
+                    if self.mode.is_aggregated() && m.channel_id != AGGREGATED_CHANNEL_ID {
+                        if let Some(current) = self.get_last_job(AGGREGATED_CHANNEL_ID) {
+                            let mut current = current;
+                            let original_job_id = Self::extract_original_job_id(&current.job_id)
+                                .unwrap_or_else(|| current.job_id.clone());
+                            if original_job_id != m.job_id.to_string() {
+                                warn!(
+                                    channel_id = m.channel_id,
+                                    job_id = m.job_id,
+                                    active_job_id = %current.job_id,
+                                    "Ignoring bootstrap that does not match the shared active job"
+                                );
+                                return Ok(());
                             }
-                            channel_jobs.push(notify_parsed);
-                        });
+                            current.clean_jobs = true;
+                            self.send_to_channel(m.channel_id, current.into()).await;
+                            return Ok(());
+                        }
+                    }
+
+                    // Real upstream jobs and generated keepalives share one history. Serialize
+                    // their mutations and restart the shared interval only when that history
+                    // advances. A bootstrap can also seed an otherwise empty history.
+                    let store_notify = || {
+                        self.valid_sv1_jobs
+                            .with_mut_or_default(job_channel_id, |channel_jobs| {
+                                if clean_jobs {
+                                    channel_jobs.clear();
+                                }
+                                channel_jobs.push(notify.clone());
+                            });
+                    };
+                    if self.mode.is_aggregated() && m.channel_id == AGGREGATED_CHANNEL_ID {
+                        self.aggregated_job_mutation_time
+                            .with(|last_mutation| {
+                                store_notify();
+                                *last_mutation = Some(Instant::now());
+                            })
+                            .map_err(TproxyError::shutdown)?;
+                    } else {
+                        store_notify();
+                    }
 
                     let notify_msg: stratum_apps::stratum_core::sv1_api::json_rpc::Message =
                         notify.into();
@@ -1589,7 +1634,6 @@ impl Sv1Server {
             .downstream_difficulty_config
             .job_keepalive_interval_secs;
 
-        let interval = Duration::from_secs(keepalive_interval_secs as u64);
         let check_interval =
             Duration::from_secs(keepalive_interval_secs as u64 / 2).max(Duration::from_secs(5));
         info!(
@@ -1599,132 +1643,170 @@ impl Sv1Server {
 
         loop {
             tokio::time::sleep(check_interval).await;
-            let mut keepalive_targets = Vec::new();
-            self.downstreams.try_for_each(|downstream_id, downstream| {
-                let keepalive_target = downstream
-                    .downstream_data
-                    .with(|d| {
-                        // Only send keepalive if:
-                        // 1. Handshake is complete
-                        // 2. Enough time has passed since last job
-                        let handshake_complete =
-                            d.sv1_handshake_state == Sv1HandshakeState::Complete;
+            self.send_keepalive_jobs(keepalive_interval_secs).await?;
+        }
+    }
 
-                        if !handshake_complete {
-                            return None;
-                        }
+    /// Sends work only to miners whose individual keepalive interval has elapsed.
+    /// Aggregated miners reuse the latest shared job between wall-clock-bounded mutations.
+    async fn send_keepalive_jobs(
+        &self,
+        keepalive_interval_secs: u16,
+    ) -> TproxyResult<(), error::Sv1Server> {
+        let interval = Duration::from_secs(keepalive_interval_secs as u64);
+        let mut keepalive_targets = Vec::new();
+        self.downstreams.try_for_each(|downstream_id, downstream| {
+            let keepalive_target = downstream
+                .downstream_data
+                .with(|d| {
+                    // Only send keepalive if:
+                    // 1. Handshake is complete
+                    // 2. Enough time has passed since last job
+                    let handshake_complete = d.sv1_handshake_state == Sv1HandshakeState::Complete;
 
-                        let needs_keepalive = match d.last_job_received_time {
-                            Some(last_time) => last_time.elapsed() >= interval,
-                            None => false, // No job received yet, don't send keepalive
-                        };
-
-                        if needs_keepalive {
-                            Some((downstream_id, d.channel_id))
-                        } else {
-                            None
-                        }
-                    })
-                    .map_err(TproxyError::shutdown)?;
-                if let Some(keepalive_target) = keepalive_target {
-                    keepalive_targets.push(keepalive_target);
-                }
-                Ok::<(), TproxyError<error::Sv1Server>>(())
-            })?;
-
-            // Send keepalive to each downstream that needs one
-            for (downstream_id, channel_id) in keepalive_targets {
-                // Get the appropriate job for this downstream's channel and create keepalive
-                let keepalive_job = self.get_last_job(channel_id).and_then(|last_job| {
-                    // Extract the original upstream job_id from the last job
-                    // If it's already a keepalive job, extract its original; otherwise use
-                    // as-is
-                    let original_job_id = Self::extract_original_job_id(&last_job.job_id)
-                        .unwrap_or_else(|| last_job.job_id.clone());
-
-                    // Find the original upstream job to get its base time
-                    let original_job = self.get_original_job(&original_job_id, channel_id);
-                    let base_time = original_job
-                        .as_ref()
-                        .map(|j| j.time.0)
-                        .unwrap_or(last_job.time.0);
-
-                    // Increment the time by the keepalive interval, but cap at
-                    // MAX_FUTURE_BLOCK_TIME from the original job's time to maintain consensus
-                    // validity (see https://github.com/bitcoin/bitcoin/blob/cd6e4c9235f763b8077cece69c2e3b2025cc8d0f/src/chain.h#L29)
-                    const MAX_FUTURE_BLOCK_TIME: u32 = 2 * 60 * 60;
-                    let new_time = last_job
-                        .time
-                        .0
-                        .saturating_add(keepalive_interval_secs as u32)
-                        .min(base_time.saturating_add(MAX_FUTURE_BLOCK_TIME));
-
-                    // If we've hit the cap, don't send another keepalive for this job
-                    if new_time == last_job.time.0 {
+                    if !handshake_complete {
                         return None;
                     }
 
-                    // Generate new keepalive job_id: {original_job_id}#{counter}
-                    let new_job_id = self.next_keepalive_job_id(&original_job_id);
-
-                    let mut keepalive_notify = last_job;
-                    keepalive_notify.job_id = new_job_id.clone();
-                    keepalive_notify.time = HexU32Be(new_time);
-
-                    // Add the keepalive job to valid jobs so shares can be validated
-                    let job_channel_id = if self.mode.is_aggregated() {
-                        Some(AGGREGATED_CHANNEL_ID)
-                    } else {
-                        channel_id
-                    };
-
-                    if let Some(ch_id) = job_channel_id {
-                        // Use with_mut (not with_mut_or_default) so we never
-                        // re-create a valid_sv1_jobs entry for a channel that was
-                        // already cleaned up.
-                        self.valid_sv1_jobs
-                            .with_mut(&ch_id, |jobs| jobs.push(keepalive_notify.clone()));
+                    let last_time = d.last_job_received_time?;
+                    if last_time.elapsed() < interval {
+                        return None;
                     }
 
-                    Some(keepalive_notify)
-                });
+                    // Keepalive eligibility implies an established channel, so the pre-channel
+                    // `None` never reaches the keepalive layer.
+                    Some((downstream_id, d.channel_id?))
+                })
+                .map_err(TproxyError::shutdown)?;
+            if let Some(keepalive_target) = keepalive_target {
+                keepalive_targets.push(keepalive_target);
+            }
+            Ok::<(), TproxyError<error::Sv1Server>>(())
+        })?;
 
-                if let Some(notify) = keepalive_job {
-                    debug!(
-                        "Sending keepalive job to downstream {} with job_id: {}, time: {}",
-                        downstream_id, notify.job_id, notify.time.0
-                    );
+        if keepalive_targets.is_empty() {
+            return Ok(());
+        }
 
-                    let sent = match self
-                        .sv1_server_io
-                        .sv1_server_to_downstream_sender
-                        .get_cloned(&downstream_id)
+        if self.mode.is_aggregated() {
+            // Every aggregated downstream shares one job history. Gate mutation on aggregate-wide
+            // wall time so phase-offset or unreachable miners cannot advance nTime on each poll.
+            let notify = self
+                .aggregated_job_mutation_time
+                .with(|last_mutation| {
+                    if last_mutation.is_some_and(|last_mutation| last_mutation.elapsed() < interval)
                     {
-                        Some(sender) => sender.send(notify.into()).await.is_ok(),
-                        None => false,
-                    };
-                    if !sent {
-                        warn!(
-                            "Failed to send keepalive job to downstream {}",
-                            downstream_id
-                        );
-                    } else if let Err(e) =
-                        self.with_registered_downstream(downstream_id, |downstream| {
-                            downstream
-                                .downstream_data
-                                .with(|d| {
-                                    d.last_job_received_time = Some(Instant::now());
-                                })
-                                .map_err(TproxyError::shutdown)
-                        })
-                    {
-                        if !matches!(e.kind, TproxyErrorKind::DownstreamNotPresent(_)) {
-                            return Err(e);
-                        }
+                        // A fresh upstream job is already queued to every miner. Only
+                        // keepalives need selective replay to miners becoming due later.
+                        return self
+                            .get_last_job(AGGREGATED_CHANNEL_ID)
+                            .filter(|job| Self::is_keepalive_job_id(&job.job_id));
                     }
+                    let notify =
+                        self.create_keepalive_job(AGGREGATED_CHANNEL_ID, keepalive_interval_secs)?;
+                    *last_mutation = Some(Instant::now());
+                    Some(notify)
+                })
+                .map_err(TproxyError::shutdown)?;
+            let Some(notify) = notify else {
+                return Ok(());
+            };
+
+            // A shared job need not reach every miner at once. Each recipient's own
+            // delivery resets its deadline; reuse does not restart the shared mutation gate.
+            for (downstream_id, _) in keepalive_targets {
+                self.send_keepalive_to_downstream(downstream_id, notify.clone())
+                    .await?;
+            }
+        } else {
+            // Non-aggregated downstreams have independent job histories and therefore need one
+            // mutation per channel.
+            for (downstream_id, channel_id) in keepalive_targets {
+                if let Some(notify) = self.create_keepalive_job(channel_id, keepalive_interval_secs)
+                {
+                    self.send_keepalive_to_downstream(downstream_id, notify)
+                        .await?;
                 }
             }
         }
+
+        Ok(())
+    }
+
+    fn create_keepalive_job(
+        &self,
+        channel_id: ChannelId,
+        keepalive_interval_secs: u16,
+    ) -> Option<server_to_client::Notify> {
+        let last_job = self.get_last_job(channel_id)?;
+        let original_job_id = Self::extract_original_job_id(&last_job.job_id)
+            .unwrap_or_else(|| last_job.job_id.clone());
+        let base_time = self
+            .get_original_job(&original_job_id, channel_id)
+            .as_ref()
+            .map(|job| job.time.0)
+            .unwrap_or(last_job.time.0);
+
+        // Keep nTime within Bitcoin Core's maximum future-time policy relative to the original
+        // upstream job.
+        let new_time = last_job
+            .time
+            .0
+            .saturating_add(keepalive_interval_secs as u32)
+            .min(base_time.saturating_add(MAX_FUTURE_BLOCK_TIME));
+        if new_time == last_job.time.0 {
+            return None;
+        }
+
+        let mut keepalive_notify = last_job;
+        keepalive_notify.job_id = self.next_keepalive_job_id(&original_job_id);
+        keepalive_notify.time = HexU32Be(new_time);
+
+        let job_channel_id = self.resolve_channel_id(channel_id);
+        // Do not recreate job history for a channel that was removed after targets were collected.
+        self.valid_sv1_jobs
+            .with_mut(&job_channel_id, |jobs| jobs.push(keepalive_notify.clone()))?;
+
+        Some(keepalive_notify)
+    }
+
+    async fn send_keepalive_to_downstream(
+        &self,
+        downstream_id: DownstreamId,
+        notify: server_to_client::Notify,
+    ) -> TproxyResult<(), error::Sv1Server> {
+        debug!(
+            "Sending keepalive job to downstream {} with job_id: {}, time: {}",
+            downstream_id, notify.job_id, notify.time.0
+        );
+
+        let Some(sender) = self
+            .sv1_server_io
+            .sv1_server_to_downstream_sender
+            .get_cloned(&downstream_id)
+        else {
+            warn!("No sender found for downstream {}", downstream_id);
+            return Ok(());
+        };
+        if sender.send(notify.into()).await.is_err() {
+            warn!(
+                "Failed to send keepalive job to downstream {}",
+                downstream_id
+            );
+            return Ok(());
+        }
+
+        if let Err(e) = self.with_registered_downstream(downstream_id, |downstream| {
+            downstream
+                .downstream_data
+                .with(|data| data.last_job_received_time = Some(Instant::now()))
+                .map_err(TproxyError::shutdown)
+        }) && !matches!(e.kind, TproxyErrorKind::DownstreamNotPresent(_))
+        {
+            return Err(e);
+        }
+
+        Ok(())
     }
 
     /// Generates a keepalive job ID by appending a mutation counter to the original job ID.
@@ -1751,15 +1833,22 @@ impl Sv1Server {
         job_id.contains(KEEPALIVE_JOB_ID_DELIMITER)
     }
 
+    /// Resolves the storage key for a channel's job history. Aggregated downstreams share the
+    /// single broadcast history keyed by `AGGREGATED_CHANNEL_ID`, while non-aggregated channels
+    /// store their jobs under their own channel ID.
+    fn resolve_channel_id(&self, channel_id: ChannelId) -> ChannelId {
+        if self.mode.is_aggregated() {
+            AGGREGATED_CHANNEL_ID
+        } else {
+            channel_id
+        }
+    }
+
     /// Gets the last job from the jobs storage.
     /// In aggregated mode, returns the last job from the shared job list.
     /// In non-aggregated mode, returns the last job for the specified channel.
-    fn get_last_job(&self, channel_id: Option<u32>) -> Option<server_to_client::Notify> {
-        let channel_id = if self.mode.is_aggregated() {
-            AGGREGATED_CHANNEL_ID
-        } else {
-            channel_id?
-        };
+    fn get_last_job(&self, channel_id: ChannelId) -> Option<server_to_client::Notify> {
+        let channel_id = self.resolve_channel_id(channel_id);
 
         self.valid_sv1_jobs
             .with(&channel_id, |jobs| jobs.last().cloned())
@@ -1771,13 +1860,9 @@ impl Sv1Server {
     fn get_original_job(
         &self,
         job_id: &str,
-        channel_id: Option<u32>,
+        channel_id: ChannelId,
     ) -> Option<server_to_client::Notify> {
-        let channel_id = if self.mode.is_aggregated() {
-            AGGREGATED_CHANNEL_ID
-        } else {
-            channel_id?
-        };
+        let channel_id = self.resolve_channel_id(channel_id);
 
         self.valid_sv1_jobs
             .with(&channel_id, |jobs| {
@@ -2290,7 +2375,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn aggregated_targeted_job_is_not_broadcast() {
+    async fn aggregated_bootstrap_reuses_latest_shared_job() {
         let (server_to_channel_manager_sender, _server_to_channel_manager_receiver) = unbounded();
         let (channel_manager_to_server_sender, channel_manager_to_server_receiver) = unbounded();
         let config = create_test_config();
@@ -2331,34 +2416,100 @@ mod tests {
             .await
             .unwrap();
 
+        let upstream_job = NewExtendedMiningJobOwned {
+            channel_id: AGGREGATED_CHANNEL_ID,
+            job_id: 1,
+            min_ntime: Sv2OptionOwned::new(None),
+            version: 0x20000000,
+            version_rolling_allowed: true,
+            merkle_path: Seq0255Owned::new(vec![]).unwrap(),
+            coinbase_tx_prefix: hex::decode("02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff265200162f5374726174756d2056322053524920506f6f6c2f2f08")
+                .unwrap()
+                .try_into()
+                .unwrap(),
+            coinbase_tx_suffix: hex::decode("feffffff0200f2052a01000000160014ebe1b7dcc293ccaa0ee743a86f89df8258c208fc0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf901000000")
+                .unwrap()
+                .try_into()
+                .unwrap(),
+        };
+        let target = Target::from_le_bytes([0xff; 32]);
         channel_manager_to_server_sender
-            .send(MiningOwned::NewExtendedMiningJob(
-                NewExtendedMiningJobOwned {
-                    channel_id: 7,
-                    job_id: 1,
-                    min_ntime: Sv2OptionOwned::new(None),
-                    version: 0x20000000,
-                    version_rolling_allowed: true,
-                    merkle_path: Seq0255Owned::new(vec![]).unwrap(),
-                    coinbase_tx_prefix: hex::decode("02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff265200162f5374726174756d2056322053524920506f6f6c2f2f08")
-                        .unwrap()
-                        .try_into()
-                        .unwrap(),
-                    coinbase_tx_suffix: hex::decode("feffffff0200f2052a01000000160014ebe1b7dcc293ccaa0ee743a86f89df8258c208fc0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf901000000")
-                        .unwrap()
-                        .try_into()
-                        .unwrap(),
-                },
-            ))
+            .send(MiningOwned::NewExtendedMiningJob(upstream_job.clone()))
             .await
             .unwrap();
-        server
-            .handle_upstream_message(Target::from_le_bytes([0xff; 32]))
-            .await
-            .unwrap();
+        server.handle_upstream_message(target).await.unwrap();
+        first_downstream_receiver.try_recv().unwrap();
+        second_downstream_receiver.try_recv().unwrap();
+        for _ in 0..3 {
+            server
+                .create_keepalive_job(AGGREGATED_CHANNEL_ID, 5)
+                .unwrap();
+        }
+        let current = server.get_last_job(AGGREGATED_CHANNEL_ID).unwrap();
+        let last_mutation = server.aggregated_job_mutation_time.get().unwrap();
 
-        assert!(first_downstream_receiver.try_recv().is_ok());
+        let mut bootstrap = upstream_job.clone();
+        bootstrap.channel_id = 7;
+        channel_manager_to_server_sender
+            .send(MiningOwned::NewExtendedMiningJob(bootstrap.clone()))
+            .await
+            .unwrap();
+        server.handle_upstream_message(target).await.unwrap();
+
+        let sent = first_downstream_receiver.try_recv().unwrap();
+        let json_rpc::Message::Notification(sent) = sent else {
+            panic!("expected mining.notify");
+        };
+        let sent = server_to_client::Notify::try_from(sent).unwrap();
+        assert_eq!(sent.job_id, current.job_id);
+        assert_eq!(sent.time, current.time);
+        assert!(
+            sent.clean_jobs,
+            "only the new miner starts with a clean view"
+        );
         assert!(second_downstream_receiver.try_recv().is_err());
+        assert_eq!(
+            serde_json::to_value(json_rpc::Message::from(
+                server.get_last_job(AGGREGATED_CHANNEL_ID).unwrap()
+            ))
+            .unwrap(),
+            serde_json::to_value(json_rpc::Message::from(current.clone())).unwrap()
+        );
+        assert_eq!(
+            server.aggregated_job_mutation_time.get().unwrap(),
+            last_mutation
+        );
+        assert_eq!(server.keepalive_job_id_counter.load(Ordering::Relaxed), 3);
+        assert_eq!(
+            server
+                .valid_sv1_jobs
+                .with(&AGGREGATED_CHANNEL_ID, |jobs| jobs.len()),
+            Some(4)
+        );
+        assert!(
+            server
+                .get_original_job("1", AGGREGATED_CHANNEL_ID)
+                .is_some()
+        );
+
+        let next = server
+            .create_keepalive_job(AGGREGATED_CHANNEL_ID, 5)
+            .unwrap();
+        assert_eq!(next.time.0, current.time.0 + 5);
+
+        // Never replace current work with an unrelated bootstrap.
+        bootstrap.job_id = 2;
+        channel_manager_to_server_sender
+            .send(MiningOwned::NewExtendedMiningJob(bootstrap))
+            .await
+            .unwrap();
+        server.handle_upstream_message(target).await.unwrap();
+        assert!(first_downstream_receiver.try_recv().is_err());
+        assert!(second_downstream_receiver.try_recv().is_err());
+        assert_eq!(
+            server.get_last_job(AGGREGATED_CHANNEL_ID).unwrap().job_id,
+            next.job_id
+        );
     }
 
     #[tokio::test]
@@ -2570,6 +2721,292 @@ mod tests {
             .await
             .unwrap();
         assert!(server.pending_target_updates.is_empty());
+    }
+
+    #[tokio::test]
+    async fn aggregated_keepalive_respects_individual_deadlines() {
+        let (server_to_channel_manager_sender, _server_to_channel_manager_receiver) = unbounded();
+        let (channel_manager_to_server_sender, channel_manager_to_server_receiver) = unbounded();
+        let mut config = create_test_config();
+        config
+            .downstream_difficulty_config
+            .job_keepalive_interval_secs = 60;
+        let addr = "127.0.0.1:3333".parse().unwrap();
+        let mode = TproxyMode::from(config.aggregate_channels);
+        let server = Sv1Server::new(
+            addr,
+            channel_manager_to_server_receiver,
+            server_to_channel_manager_sender,
+            config,
+            mode,
+        );
+        let first_receiver = register_test_downstream(&server, 1, Some(7), 100.0, false);
+        let second_receiver = register_test_downstream(&server, 2, Some(8), 100.0, false);
+        for downstream_id in [1, 2] {
+            server
+                .downstreams
+                .with(&downstream_id, |downstream| {
+                    downstream
+                        .downstream_data
+                        .with(|data| {
+                            data.sv1_handshake_state = Sv1HandshakeState::Complete;
+                        })
+                        .unwrap();
+                })
+                .unwrap();
+        }
+
+        channel_manager_to_server_sender
+            .send(MiningOwned::SetNewPrevHash(SetNewPrevHashOwned {
+                channel_id: AGGREGATED_CHANNEL_ID,
+                job_id: 1,
+                prev_hash: vec![0; 32].try_into().unwrap(),
+                min_ntime: 0,
+                nbits: 0x207fffff,
+            }))
+            .await
+            .unwrap();
+        server
+            .handle_upstream_message(Target::from_le_bytes([0xff; 32]))
+            .await
+            .unwrap();
+        channel_manager_to_server_sender
+            .send(MiningOwned::NewExtendedMiningJob(
+                NewExtendedMiningJobOwned {
+                    channel_id: AGGREGATED_CHANNEL_ID,
+                    job_id: 1,
+                    min_ntime: Sv2OptionOwned::new(None),
+                    version: 0x20000000,
+                    version_rolling_allowed: true,
+                    merkle_path: Seq0255Owned::new(vec![]).unwrap(),
+                    coinbase_tx_prefix: hex::decode("02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff265200162f5374726174756d2056322053524920506f6f6c2f2f08")
+                        .unwrap()
+                        .try_into()
+                        .unwrap(),
+                    coinbase_tx_suffix: hex::decode("feffffff0200f2052a01000000160014ebe1b7dcc293ccaa0ee743a86f89df8258c208fc0000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf901000000")
+                        .unwrap()
+                        .try_into()
+                        .unwrap(),
+                },
+            ))
+            .await
+            .unwrap();
+        server
+            .handle_upstream_message(Target::from_le_bytes([0xff; 32]))
+            .await
+            .unwrap();
+
+        // Drain the original job broadcast so the next messages are the keepalive under test.
+        first_receiver.recv().await.unwrap();
+        second_receiver.recv().await.unwrap();
+
+        let set_last_delivery = |downstream_id, time| {
+            server
+                .downstreams
+                .with(&downstream_id, |downstream| {
+                    downstream
+                        .downstream_data
+                        .with(|data| {
+                            data.last_job_received_time = Some(time);
+                        })
+                        .unwrap();
+                })
+                .unwrap();
+        };
+        let recent_delivery = Instant::now();
+        for downstream_id in [1, 2] {
+            set_last_delivery(downstream_id, recent_delivery);
+        }
+        let history_len = || {
+            server
+                .valid_sv1_jobs
+                .with(&AGGREGATED_CHANNEL_ID, |jobs| jobs.len())
+                .unwrap()
+        };
+        let original_time = server.get_last_job(AGGREGATED_CHANNEL_ID).unwrap().time.0;
+        let interval = Duration::from_secs(60);
+
+        // No miner is due, even if the aggregate could create another job.
+        server
+            .aggregated_job_mutation_time
+            .set(Some(Instant::now() - interval))
+            .unwrap();
+        server.send_keepalive_jobs(60).await.unwrap();
+        assert_eq!(history_len(), 1);
+        assert!(first_receiver.try_recv().is_err());
+        assert!(second_receiver.try_recv().is_err());
+
+        // A is due; B has just received work. Only A receives the newly created K1.
+        set_last_delivery(1, Instant::now() - interval);
+        // A fresh upstream job may still be queued while A's old deadline is due.
+        // Its normal delivery must not be duplicated by the keepalive path.
+        server
+            .aggregated_job_mutation_time
+            .set(Some(Instant::now()))
+            .unwrap();
+        server.send_keepalive_jobs(60).await.unwrap();
+        assert!(first_receiver.try_recv().is_err());
+        assert!(second_receiver.try_recv().is_err());
+        assert_eq!(history_len(), 1);
+        server
+            .aggregated_job_mutation_time
+            .set(Some(Instant::now() - interval))
+            .unwrap();
+        server.send_keepalive_jobs(60).await.unwrap();
+        let first_keepalive = first_receiver.try_recv().unwrap();
+        assert!(second_receiver.try_recv().is_err());
+        assert_eq!(history_len(), 2);
+        let latest = server.get_last_job(AGGREGATED_CHANNEL_ID).unwrap();
+        assert_eq!(latest.time.0, original_time + 60);
+
+        assert_eq!(
+            server
+                .downstreams
+                .with(&2, |downstream| {
+                    downstream
+                        .downstream_data
+                        .with(|data| data.last_job_received_time)
+                        .unwrap()
+                })
+                .unwrap(),
+            Some(recent_delivery)
+        );
+
+        // B becomes due halfway through the aggregate interval. Reuse K1 without
+        // advancing nTime, adding history, or restarting the aggregate timer.
+        let last_mutation = Instant::now() - Duration::from_secs(30);
+        server
+            .aggregated_job_mutation_time
+            .set(Some(last_mutation))
+            .unwrap();
+        set_last_delivery(2, Instant::now() - interval);
+        server.send_keepalive_jobs(60).await.unwrap();
+        let second_keepalive = second_receiver.try_recv().unwrap();
+        assert_eq!(
+            serde_json::to_value(&first_keepalive).unwrap(),
+            serde_json::to_value(&second_keepalive).unwrap()
+        );
+        assert!(first_receiver.try_recv().is_err());
+        assert_eq!(history_len(), 2);
+        assert_eq!(server.keepalive_job_id_counter.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            server.aggregated_job_mutation_time.get().unwrap(),
+            Some(last_mutation)
+        );
+
+        // Successful delivery starts only that miner's next interval.
+        server.send_keepalive_jobs(60).await.unwrap();
+        assert!(first_receiver.try_recv().is_err());
+        assert!(second_receiver.try_recv().is_err());
+
+        // When both are due, one new K2 is shared by both.
+        for downstream_id in [1, 2] {
+            set_last_delivery(downstream_id, Instant::now() - interval);
+        }
+        server
+            .aggregated_job_mutation_time
+            .set(Some(Instant::now() - interval))
+            .unwrap();
+        server.send_keepalive_jobs(60).await.unwrap();
+        assert_eq!(
+            serde_json::to_value(first_receiver.try_recv().unwrap()).unwrap(),
+            serde_json::to_value(second_receiver.try_recv().unwrap()).unwrap()
+        );
+        assert_eq!(history_len(), 3);
+        assert_eq!(
+            server.get_last_job(AGGREGATED_CHANNEL_ID).unwrap().time.0,
+            original_time + 120
+        );
+
+        // An unreachable miner remains due, but retries neither mutate shared work
+        // again nor send early keepalives to the healthy miner.
+        first_receiver.close();
+        let failed_delivery = Instant::now() - interval;
+        set_last_delivery(1, failed_delivery);
+        let last_mutation = server.aggregated_job_mutation_time.get().unwrap();
+        for missing_sender in [false, true] {
+            if missing_sender {
+                server
+                    .sv1_server_io
+                    .sv1_server_to_downstream_sender
+                    .remove(&1);
+            }
+            for _ in 0..2 {
+                server.send_keepalive_jobs(60).await.unwrap();
+            }
+            assert!(second_receiver.try_recv().is_err());
+            assert_eq!(history_len(), 3);
+            assert_eq!(server.keepalive_job_id_counter.load(Ordering::Relaxed), 2);
+            assert_eq!(
+                server.aggregated_job_mutation_time.get().unwrap(),
+                last_mutation
+            );
+            assert_eq!(
+                server
+                    .downstreams
+                    .with(&1, |downstream| {
+                        downstream
+                            .downstream_data
+                            .with(|data| data.last_job_received_time)
+                            .unwrap()
+                    })
+                    .unwrap(),
+                Some(failed_delivery)
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn keepalive_skips_miners_without_ready_channels_or_eligible_jobs() {
+        for aggregated in [false, true] {
+            let mut server = create_test_sv1_server();
+            server.mode = TproxyMode::from(aggregated);
+            let mut receivers = Vec::new();
+            for id in 1..=4 {
+                let channel_id = (id != 2).then_some(id as u32);
+                receivers.push(register_test_downstream(
+                    &server, id, channel_id, 100.0, false,
+                ));
+                server
+                    .downstreams
+                    .with(&id, |downstream| {
+                        downstream
+                            .downstream_data
+                            .with(|data| {
+                                if id != 1 {
+                                    data.sv1_handshake_state = Sv1HandshakeState::Complete;
+                                }
+                                // Miner 3 has no keepalive-eligible job.
+                                if id != 3 {
+                                    data.last_job_received_time =
+                                        Some(Instant::now() - Duration::from_secs(60));
+                                }
+                            })
+                            .unwrap();
+                    })
+                    .unwrap();
+            }
+            // Only miner 4 is eligible. Non-aggregated mode must use its own channel history.
+            let message: json_rpc::Message = serde_json::from_value(serde_json::json!({
+                "id": null, "method": "mining.notify",
+                "params": ["1", "00".repeat(32), "", "", [], "20000000", "1d00ffff", "00000001", false]
+            })).unwrap();
+            let json_rpc::Message::Notification(notification) = message else {
+                unreachable!()
+            };
+            let notify = server_to_client::Notify::try_from(notification).unwrap();
+            let channel_id = if aggregated { AGGREGATED_CHANNEL_ID } else { 4 };
+            server
+                .valid_sv1_jobs
+                .with_mut_or_default(channel_id, |jobs| {
+                    jobs.push(notify);
+                });
+            server.send_keepalive_jobs(60).await.unwrap();
+            for (index, receiver) in receivers.iter().enumerate() {
+                assert_eq!(receiver.try_recv().is_ok(), index == 3);
+            }
+            assert_eq!(server.keepalive_job_id_counter.load(Ordering::Relaxed), 1);
+        }
     }
 
     #[test]

--- a/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mining_message_handler.rs
@@ -25,7 +25,7 @@ use stratum_apps::{
         },
         parsers_sv2::{MiningOwned, Tlv},
     },
-    utils::types::{DownstreamId, Hashrate},
+    utils::types::{ChannelId, DownstreamId, Hashrate},
 };
 use tracing::{error, info, warn};
 
@@ -80,6 +80,17 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
                 TproxyError::log(TproxyErrorKind::PendingChannelNotFound(m.request_id))
             })?
             .1;
+
+        if let Some(conflicting_id) = self.colliding_channel_id(m.channel_id, m.group_channel_id) {
+            error!(
+                channel_id = m.channel_id,
+                group_channel_id = m.group_channel_id,
+                "Rejecting OpenExtendedMiningChannelSuccess with a colliding channel ID"
+            );
+            return Err(TproxyError::fallback(
+                TproxyErrorKind::ChannelIdAlreadyInUse(conflicting_id),
+            ));
+        }
 
         let success = {
             info!(
@@ -1122,69 +1133,131 @@ impl HandleMiningMessagesFromServerOwnedAsync for ChannelManager {
     ) -> Result<(), Self::Error> {
         info!("Received: {}", m);
 
-        // remove every channel from any group channels that end up empty
-        let mut group_channels_to_remove = Vec::new();
-
-        // check every group channel if it contains any of the channels in the new group
-        // channel
-        self.group_channels
-            .for_each_mut(|group_channel_id, group_channel| {
-                let channel_ids_to_remove = m.channel_ids.clone().into_inner();
-                for channel_id in channel_ids_to_remove {
-                    group_channel.remove_channel_id(channel_id);
-                }
-
-                if group_channel.is_empty() {
-                    group_channels_to_remove.push(group_channel_id);
-                }
-            });
-
-        // Now remove the empty group channels
-        for group_channel_id in group_channels_to_remove {
-            self.group_channels.remove(&group_channel_id);
+        if m.group_channel_id == AGGREGATED_CHANNEL_ID {
+            error!(
+                group_channel_id = m.group_channel_id,
+                "Rejecting SetGroupChannel that uses tProxy's reserved broadcast identifier"
+            );
+            return Err(TproxyError::fallback(
+                TproxyErrorKind::ChannelIdAlreadyInUse(m.group_channel_id),
+            ));
         }
 
         let new_channel_ids = m.channel_ids.clone().into_inner();
-        self.group_channels.with_mut_or_insert_with(
-            m.group_channel_id,
-            || GroupChannel::new(m.group_channel_id),
-            |group_channel| {
-                let current_channel_ids: Vec<u32> =
-                    group_channel.get_channel_ids().copied().collect();
+        let aggregated_channel = if self.mode.is_aggregated() {
+            Some(
+                self.extended_channels
+                    .with(&AGGREGATED_CHANNEL_ID, |channel| {
+                        (channel.get_channel_id(), channel.get_full_extranonce_size())
+                    })
+                    .ok_or_else(|| TproxyError::fallback(TproxyErrorKind::ChannelNotFound))?,
+            )
+        } else {
+            None
+        };
 
-                // Remove channels that are no longer in the new list
-                for channel_id in &current_channel_ids {
-                    if !new_channel_ids.contains(channel_id) {
-                        group_channel.remove_channel_id(*channel_id);
-                    }
-                }
+        // Validate the complete replacement before changing any existing group. In aggregated
+        // mode, SetGroupChannel carries the real upstream channel ID, while the corresponding
+        // local channel state is stored under AGGREGATED_CHANNEL_ID.
+        if let Some((aggregated_channel_id, _)) = aggregated_channel {
+            if m.group_channel_id == aggregated_channel_id {
+                return Err(TproxyError::fallback(
+                    TproxyErrorKind::ChannelIdAlreadyInUse(aggregated_channel_id),
+                ));
+            }
+        } else if self.extended_channels.contains_key(&m.group_channel_id) {
+            error!(
+                group_channel_id = m.group_channel_id,
+                "Rejecting SetGroupChannel that reinterprets an extended channel ID"
+            );
+            return Err(TproxyError::fallback(
+                TproxyErrorKind::ChannelIdAlreadyInUse(m.group_channel_id),
+            ));
+        }
 
-                // Add all channels from the message (inner HashSet ingores duplicates)
-                for channel_id in new_channel_ids {
-                    let full_extranonce_size = self
-                        .extended_channels
-                        .with(&channel_id, |extended_channel| {
-                            extended_channel.get_full_extranonce_size()
-                        })
-                        .ok_or_else(|| TproxyError::fallback(TproxyErrorKind::ChannelNotFound))?;
-                    group_channel
-                        .add_channel_id(channel_id, full_extranonce_size)
-                        .map_err(|e| {
-                            error!("Failed to add channel id to group channel: {:?}", e);
-                            TproxyError::fallback(
-                                TproxyErrorKind::FailedToAddChannelIdToGroupChannel(e),
-                            )
-                        })?;
+        let mut replacement_group = GroupChannel::new(m.group_channel_id);
+        for channel_id in &new_channel_ids {
+            if *channel_id == AGGREGATED_CHANNEL_ID {
+                return Err(TproxyError::fallback(
+                    TproxyErrorKind::ChannelIdAlreadyInUse(AGGREGATED_CHANNEL_ID),
+                ));
+            }
+
+            let full_extranonce_size = match aggregated_channel {
+                Some((aggregated_channel_id, full_extranonce_size))
+                    if *channel_id == aggregated_channel_id =>
+                {
+                    full_extranonce_size
                 }
-                Ok::<(), Self::Error>(())
-            },
-        )?;
+                Some(_) => {
+                    return Err(TproxyError::fallback(TproxyErrorKind::ChannelNotFound));
+                }
+                None => self
+                    .extended_channels
+                    .with(channel_id, |channel| channel.get_full_extranonce_size())
+                    .ok_or_else(|| TproxyError::fallback(TproxyErrorKind::ChannelNotFound))?,
+            };
+            replacement_group
+                .add_channel_id(*channel_id, full_extranonce_size)
+                .map_err(|error| {
+                    error!("Failed to add channel id to group channel: {error:?}");
+                    TproxyError::fallback(TproxyErrorKind::FailedToAddChannelIdToGroupChannel(
+                        error,
+                    ))
+                })?;
+        }
+
+        // Validation above makes this mutation phase infallible. Move the listed channels out of
+        // their previous groups, remove the old definition of the target group, then install the
+        // validated replacement.
+        let mut groups_to_remove = Vec::new();
+        self.group_channels.for_each_mut(|group_id, group| {
+            for channel_id in &new_channel_ids {
+                group.remove_channel_id(*channel_id);
+            }
+            if group.is_empty() {
+                groups_to_remove.push(group_id);
+            }
+        });
+        for group_id in groups_to_remove {
+            self.group_channels.remove(&group_id);
+        }
+        self.group_channels.remove(&m.group_channel_id);
+        if !new_channel_ids.is_empty() {
+            self.group_channels
+                .insert(m.group_channel_id, replacement_group);
+        }
 
         Ok(())
     }
 }
 
 impl ChannelManager {
+    /// Returns an ID that would collide when accepting an upstream channel-open success.
+    /// Wire channel and group IDs must differ and cannot use the broadcast sentinel. Only
+    /// non-aggregated mode stores wire channel IDs directly in the local channel maps; reusing
+    /// an existing group is valid, but reinterpreting a channel as a group (or vice versa) is not.
+    fn colliding_channel_id(
+        &self,
+        channel_id: ChannelId,
+        group_channel_id: ChannelId,
+    ) -> Option<ChannelId> {
+        if channel_id == AGGREGATED_CHANNEL_ID || group_channel_id == AGGREGATED_CHANNEL_ID {
+            return Some(AGGREGATED_CHANNEL_ID);
+        }
+        if !self.mode.is_aggregated() && self.extended_channels.contains_key(&group_channel_id) {
+            return Some(group_channel_id);
+        }
+        if channel_id == group_channel_id
+            || (!self.mode.is_aggregated()
+                && (self.extended_channels.contains_key(&channel_id)
+                    || self.group_channels.contains_key(&channel_id)))
+        {
+            return Some(channel_id);
+        }
+        None
+    }
+
     #[allow(clippy::result_large_err)]
     fn verify_payout_distribution(
         &self,
@@ -1205,5 +1278,390 @@ impl ChannelManager {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{TproxyMode, error::Action};
+    use async_channel::{Receiver, unbounded};
+
+    fn channel_manager_with_mode(mode: TproxyMode) -> (ChannelManager, Receiver<MiningOwned>) {
+        let (upstream_sender, _upstream_receiver_for_test) = unbounded();
+        let (_upstream_sender_for_test, upstream_receiver) = unbounded();
+        let (sv1_server_sender, sv1_server_receiver_for_test) = unbounded();
+        let (_sv1_server_sender_for_test, sv1_server_receiver) = unbounded();
+
+        (
+            ChannelManager::new(
+                upstream_sender,
+                upstream_receiver,
+                sv1_server_sender,
+                sv1_server_receiver,
+                vec![],
+                vec![],
+                mode,
+                None,
+                #[cfg(feature = "monitoring")]
+                true,
+            ),
+            sv1_server_receiver_for_test,
+        )
+    }
+
+    fn channel_manager() -> (ChannelManager, Receiver<MiningOwned>) {
+        channel_manager_with_mode(TproxyMode::NonAggregated)
+    }
+
+    fn open_success(
+        request_id: u32,
+        channel_id: u32,
+        group_channel_id: u32,
+        prefix_byte: u8,
+        extranonce_size: u16,
+    ) -> OpenExtendedMiningChannelSuccessOwned {
+        OpenExtendedMiningChannelSuccessOwned {
+            request_id,
+            channel_id,
+            target: [0xff; 32].into(),
+            extranonce_size,
+            extranonce_prefix: vec![prefix_byte; 4].try_into().unwrap(),
+            group_channel_id,
+        }
+    }
+
+    fn extended_channel(channel_id: u32) -> ExtendedChannel {
+        ExtendedChannel::new(
+            channel_id,
+            format!("miner-{channel_id}"),
+            ExtranoncePrefix::from_wire(vec![channel_id as u8; 4]).unwrap(),
+            Target::from_le_bytes([0xff; 32]),
+            1.0,
+            true,
+            4,
+            None,
+        )
+        .unwrap()
+    }
+
+    fn assert_collision(error: TproxyError<error::ChannelManager>, channel_id: u32) {
+        assert!(matches!(error.action, Action::Fallback));
+        assert!(matches!(
+            error.kind,
+            TproxyErrorKind::ChannelIdAlreadyInUse(id) if id == channel_id
+        ));
+    }
+
+    #[test]
+    fn collision_lookup_preserves_wire_and_local_namespaces() {
+        for mode in [TproxyMode::Aggregated, TproxyMode::NonAggregated] {
+            let (manager, _) = channel_manager_with_mode(mode);
+            manager.extended_channels.insert(7, extended_channel(7));
+            manager.group_channels.insert(100, GroupChannel::new(100));
+
+            let local_collision = |id| (!manager.mode.is_aggregated()).then_some(id);
+            for (channel_id, group_id, expected) in [
+                (8, 200, None),
+                (8, 100, None), // Another channel may join the existing group.
+                (8, 8, Some(8)),
+                (7, 7, Some(7)),
+                (7, 100, local_collision(7)),
+                (100, 200, local_collision(100)),
+                (8, 7, local_collision(7)),
+                (100, 7, local_collision(7)), // Report the conflicting group ID first.
+                (AGGREGATED_CHANNEL_ID, 7, Some(AGGREGATED_CHANNEL_ID)),
+                (7, AGGREGATED_CHANNEL_ID, Some(AGGREGATED_CHANNEL_ID)),
+            ] {
+                assert_eq!(
+                    manager.colliding_channel_id(channel_id, group_id),
+                    expected,
+                    "channel {channel_id}, group {group_id}, aggregated {}",
+                    manager.mode.is_aggregated()
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_open_success_that_reuses_a_live_channel_id() {
+        let (mut manager, sv1_server_receiver) = channel_manager();
+        manager
+            .pending_downstream_channels
+            .insert(1, ("first-miner".to_string(), 1.0, 4));
+        manager
+            .handle_open_extended_mining_channel_success(
+                None,
+                open_success(1, 7, 100, 0xaa, 4),
+                None,
+            )
+            .await
+            .unwrap();
+        sv1_server_receiver.recv().await.unwrap();
+
+        manager
+            .pending_downstream_channels
+            .insert(2, ("second-miner".to_string(), 1.0, 6));
+        let error = manager
+            .handle_open_extended_mining_channel_success(
+                None,
+                open_success(2, 7, 200, 0xbb, 6),
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert_collision(error, 7);
+        assert_eq!(
+            manager
+                .extended_channels
+                .with(&7, |channel| channel.get_full_extranonce_size()),
+            Some(8)
+        );
+        assert!(
+            manager
+                .group_channels
+                .with(&100, |group| group.has_channel_id(7))
+                .unwrap_or(false)
+        );
+        assert!(!manager.group_channels.contains_key(&200));
+        assert!(sv1_server_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_open_success_that_reinterprets_its_channel_as_a_group() {
+        let (mut manager, sv1_server_receiver) = channel_manager();
+        manager
+            .pending_downstream_channels
+            .insert(1, ("miner".to_string(), 1.0, 4));
+
+        let error = manager
+            .handle_open_extended_mining_channel_success(None, open_success(1, 7, 7, 0xaa, 4), None)
+            .await
+            .unwrap_err();
+
+        assert_collision(error, 7);
+        assert!(!manager.extended_channels.contains_key(&7));
+        assert!(!manager.group_channels.contains_key(&7));
+        assert!(sv1_server_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_open_success_that_shadows_a_live_group() {
+        let (mut manager, sv1_server_receiver) = channel_manager();
+        manager.group_channels.insert(7, GroupChannel::new(7));
+        manager
+            .pending_downstream_channels
+            .insert(1, ("miner".to_string(), 1.0, 4));
+
+        let error = manager
+            .handle_open_extended_mining_channel_success(
+                None,
+                open_success(1, 7, 100, 0xaa, 4),
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert_collision(error, 7);
+        assert!(manager.group_channels.contains_key(&7));
+        assert!(!manager.group_channels.contains_key(&100));
+        assert!(!manager.extended_channels.contains_key(&7));
+        assert!(sv1_server_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_group_id_that_shadows_a_live_extended_channel() {
+        let (mut manager, _sv1_server_receiver) = channel_manager();
+        manager.extended_channels.insert(7, extended_channel(7));
+        manager.extended_channels.insert(8, extended_channel(8));
+
+        let error = manager
+            .handle_set_group_channel(
+                None,
+                SetGroupChannelOwned {
+                    group_channel_id: 7,
+                    channel_ids: vec![8].try_into().unwrap(),
+                },
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert_collision(error, 7);
+        assert!(!manager.group_channels.contains_key(&7));
+        assert!(manager.extended_channels.contains_key(&7));
+        assert!(manager.extended_channels.contains_key(&8));
+    }
+
+    #[tokio::test]
+    async fn rejects_reserved_channel_id_in_aggregated_mode() {
+        let (mut manager, sv1_server_receiver) = channel_manager_with_mode(TproxyMode::Aggregated);
+        manager
+            .pending_downstream_channels
+            .insert(1, ("miner".to_string(), 1.0, 4));
+
+        let error = manager
+            .handle_open_extended_mining_channel_success(
+                None,
+                open_success(1, AGGREGATED_CHANNEL_ID, 100, 0xaa, 4),
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert_collision(error, AGGREGATED_CHANNEL_ID);
+        assert!(manager.extended_channels.is_empty());
+        assert!(manager.group_channels.is_empty());
+        assert!(sv1_server_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn rejects_reserved_group_id() {
+        let (mut manager, sv1_server_receiver) = channel_manager();
+        manager
+            .pending_downstream_channels
+            .insert(1, ("miner".to_string(), 1.0, 4));
+
+        let error = manager
+            .handle_open_extended_mining_channel_success(
+                None,
+                open_success(1, 7, AGGREGATED_CHANNEL_ID, 0xaa, 4),
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert_collision(error, AGGREGATED_CHANNEL_ID);
+        assert!(manager.extended_channels.is_empty());
+        assert!(manager.group_channels.is_empty());
+        assert!(sv1_server_receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn invalid_set_group_channel_does_not_mutate_existing_groups() {
+        let (mut manager, _sv1_server_receiver) = channel_manager();
+        manager.extended_channels.insert(7, extended_channel(7));
+        let mut original_group = GroupChannel::new(100);
+        original_group.add_channel_id(7, 8).unwrap();
+        manager.group_channels.insert(100, original_group);
+
+        let error = manager
+            .handle_set_group_channel(
+                None,
+                SetGroupChannelOwned {
+                    group_channel_id: 200,
+                    channel_ids: vec![7, 999].try_into().unwrap(),
+                },
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error.action, Action::Fallback));
+        assert!(matches!(error.kind, TproxyErrorKind::ChannelNotFound));
+        assert!(
+            manager
+                .group_channels
+                .with(&100, |group| group.has_channel_id(7))
+                .unwrap_or(false)
+        );
+        assert!(!manager.group_channels.contains_key(&200));
+    }
+
+    #[tokio::test]
+    async fn aggregated_set_group_channel_uses_the_wire_channel_id() {
+        let (mut manager, _sv1_server_receiver) = channel_manager_with_mode(TproxyMode::Aggregated);
+        manager
+            .extended_channels
+            .insert(AGGREGATED_CHANNEL_ID, extended_channel(7));
+        let mut original_group = GroupChannel::new(100);
+        original_group.add_channel_id(7, 8).unwrap();
+        manager.group_channels.insert(100, original_group);
+
+        manager
+            .handle_set_group_channel(
+                None,
+                SetGroupChannelOwned {
+                    group_channel_id: 200,
+                    channel_ids: vec![7].try_into().unwrap(),
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(!manager.group_channels.contains_key(&100));
+        assert!(
+            manager
+                .group_channels
+                .with(&200, |group| group.has_channel_id(7))
+                .unwrap_or(false)
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_aggregated_set_group_channel_preserves_existing_group() {
+        let (mut manager, _sv1_server_receiver) = channel_manager_with_mode(TproxyMode::Aggregated);
+        manager
+            .extended_channels
+            .insert(AGGREGATED_CHANNEL_ID, extended_channel(7));
+        let mut original_group = GroupChannel::new(100);
+        original_group.add_channel_id(7, 8).unwrap();
+        manager.group_channels.insert(100, original_group);
+
+        let error = manager
+            .handle_set_group_channel(
+                None,
+                SetGroupChannelOwned {
+                    group_channel_id: 200,
+                    channel_ids: vec![8].try_into().unwrap(),
+                },
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error.action, Action::Fallback));
+        assert!(matches!(error.kind, TproxyErrorKind::ChannelNotFound));
+        assert!(
+            manager
+                .group_channels
+                .with(&100, |group| group.has_channel_id(7))
+                .unwrap_or(false)
+        );
+        assert!(!manager.group_channels.contains_key(&200));
+    }
+
+    #[tokio::test]
+    async fn aggregated_set_group_channel_rejects_reserved_group_id_without_mutation() {
+        let (mut manager, _sv1_server_receiver) = channel_manager_with_mode(TproxyMode::Aggregated);
+        manager
+            .extended_channels
+            .insert(AGGREGATED_CHANNEL_ID, extended_channel(7));
+        let mut original_group = GroupChannel::new(100);
+        original_group.add_channel_id(7, 8).unwrap();
+        manager.group_channels.insert(100, original_group);
+
+        let error = manager
+            .handle_set_group_channel(
+                None,
+                SetGroupChannelOwned {
+                    group_channel_id: AGGREGATED_CHANNEL_ID,
+                    channel_ids: vec![7].try_into().unwrap(),
+                },
+                None,
+            )
+            .await
+            .unwrap_err();
+
+        assert_collision(error, AGGREGATED_CHANNEL_ID);
+        assert!(
+            manager
+                .group_channels
+                .with(&100, |group| group.has_channel_id(7))
+                .unwrap_or(false)
+        );
+        assert!(!manager.group_channels.contains_key(&AGGREGATED_CHANNEL_ID));
     }
 }


### PR DESCRIPTION
This PR:
- Clarify the intentional vardiff target-ordering policy.
- Make SV1 handshake completion idempotent.
- Continue difficulty broadcasts after an individual downstream disconnects.
- Bound SV1 handshake messages buffered before channel establishment.
- Document that payout verification defaults to disabled and that this trusts the upstream payout policy.
- Reject upstream channel and group identifiers that collide in non-aggregated mode.
- Generate and retain one shared aggregated keepalive job per tick, then deliver it to every eligible downstream.


Closes project-loupe/audit-sv2-apps#26
Closes #743
Closes project-loupe/audit-sv2-apps#126
Closes project-loupe/audit-sv2-apps#127
Closes #744
Closes project-loupe/audit-sv2-apps#130
Closes #745
Closes project-loupe/audit-sv2-apps#187
Closes project-loupe/audit-sv2-apps#185
Closes #811 
Closes project-loupe/audit-sv2-apps#188
Closes #812
Closes project-loupe/audit-sv2-apps#195
Closes #813