### PR TITLE
feat(monitoring): opt-in per-SV1-client hashrate metric

### DIFF
--- a/miner-apps/translator/config-examples/mainnet/tproxy-config-hosted-pool-example.toml
+++ b/miner-apps/translator/config-examples/mainnet/tproxy-config-hosted-pool-example.toml
@@ -37,6 +37,10 @@ supported_extensions = [
 # Monitoring HTTP server address for exposing channel data (optional)
 monitoring_address = "0.0.0.0:9092"
 monitoring_cache_refresh_secs = 15
+# One Prometheus series per connected SV1 miner (`sv1_client_hashrate`).
+# Off by default: series count scales with miner count. The JSON API at
+# /api/v1/sv1/clients serves per-client state either way.
+# monitoring_sv1_per_client_metrics = true
 
 # LAN subnet containing ASIC miner web/API addresses (for example, 192.168.1.0/24).
 [miner_telemetry]

--- a/miner-apps/translator/config-examples/mainnet/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/mainnet/tproxy-config-local-jdc-example.toml
@@ -37,6 +37,10 @@ supported_extensions = [
 # Monitoring HTTP server address for exposing channel data (optional)
 monitoring_address = "0.0.0.0:9092"
 monitoring_cache_refresh_secs = 15
+# One Prometheus series per connected SV1 miner (`sv1_client_hashrate`).
+# Off by default: series count scales with miner count. The JSON API at
+# /api/v1/sv1/clients serves per-client state either way.
+# monitoring_sv1_per_client_metrics = true
 
 # LAN subnet containing ASIC miner web/API addresses (for example, 192.168.1.0/24).
 [miner_telemetry]

--- a/miner-apps/translator/config-examples/mainnet/tproxy-config-local-pool-example.toml
+++ b/miner-apps/translator/config-examples/mainnet/tproxy-config-local-pool-example.toml
@@ -37,6 +37,10 @@ supported_extensions = [
 # Monitoring HTTP server address for exposing channel data (optional)
 monitoring_address = "0.0.0.0:9092"
 monitoring_cache_refresh_secs = 15
+# One Prometheus series per connected SV1 miner (`sv1_client_hashrate`).
+# Off by default: series count scales with miner count. The JSON API at
+# /api/v1/sv1/clients serves per-client state either way.
+# monitoring_sv1_per_client_metrics = true
 
 # LAN subnet containing ASIC miner web/API addresses (for example, 192.168.1.0/24).
 [miner_telemetry]

--- a/miner-apps/translator/config-examples/signet/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/signet/tproxy-config-local-jdc-example.toml
@@ -37,6 +37,10 @@ supported_extensions = [
 # Monitoring HTTP server address for exposing channel data (optional)
 monitoring_address = "0.0.0.0:9092"
 monitoring_cache_refresh_secs = 15
+# One Prometheus series per connected SV1 miner (`sv1_client_hashrate`).
+# Off by default: series count scales with miner count. The JSON API at
+# /api/v1/sv1/clients serves per-client state either way.
+# monitoring_sv1_per_client_metrics = true
 
 # LAN subnet containing ASIC miner web/API addresses (for example, 192.168.1.0/24).
 [miner_telemetry]

--- a/miner-apps/translator/config-examples/signet/tproxy-config-local-pool-example.toml
+++ b/miner-apps/translator/config-examples/signet/tproxy-config-local-pool-example.toml
@@ -37,6 +37,10 @@ supported_extensions = [
 # Monitoring HTTP server address for exposing channel data (optional)
 monitoring_address = "0.0.0.0:9092"
 monitoring_cache_refresh_secs = 15
+# One Prometheus series per connected SV1 miner (`sv1_client_hashrate`).
+# Off by default: series count scales with miner count. The JSON API at
+# /api/v1/sv1/clients serves per-client state either way.
+# monitoring_sv1_per_client_metrics = true
 
 # LAN subnet containing ASIC miner web/API addresses (for example, 192.168.1.0/24).
 [miner_telemetry]

--- a/miner-apps/translator/config-examples/testnet4/tproxy-config-hosted-pool-example.toml
+++ b/miner-apps/translator/config-examples/testnet4/tproxy-config-hosted-pool-example.toml
@@ -37,6 +37,10 @@ supported_extensions = [
 # Monitoring HTTP server address for exposing channel data (optional)
 monitoring_address = "0.0.0.0:9092"
 monitoring_cache_refresh_secs = 15
+# One Prometheus series per connected SV1 miner (`sv1_client_hashrate`).
+# Off by default: series count scales with miner count. The JSON API at
+# /api/v1/sv1/clients serves per-client state either way.
+# monitoring_sv1_per_client_metrics = true
 
 # LAN subnet containing ASIC miner web/API addresses (for example, 192.168.1.0/24).
 [miner_telemetry]

--- a/miner-apps/translator/config-examples/testnet4/tproxy-config-local-jdc-example.toml
+++ b/miner-apps/translator/config-examples/testnet4/tproxy-config-local-jdc-example.toml
@@ -37,6 +37,10 @@ supported_extensions = [
 # Monitoring HTTP server address for exposing channel data (optional)
 monitoring_address = "0.0.0.0:9092"
 monitoring_cache_refresh_secs = 15
+# One Prometheus series per connected SV1 miner (`sv1_client_hashrate`).
+# Off by default: series count scales with miner count. The JSON API at
+# /api/v1/sv1/clients serves per-client state either way.
+# monitoring_sv1_per_client_metrics = true
 
 # LAN subnet containing ASIC miner web/API addresses (for example, 192.168.1.0/24).
 [miner_telemetry]

--- a/miner-apps/translator/config-examples/testnet4/tproxy-config-local-pool-example.toml
+++ b/miner-apps/translator/config-examples/testnet4/tproxy-config-local-pool-example.toml
@@ -37,6 +37,10 @@ supported_extensions = [
 # Monitoring HTTP server address for exposing channel data (optional)
 monitoring_address = "0.0.0.0:9092"
 monitoring_cache_refresh_secs = 15
+# One Prometheus series per connected SV1 miner (`sv1_client_hashrate`).
+# Off by default: series count scales with miner count. The JSON API at
+# /api/v1/sv1/clients serves per-client state either way.
+# monitoring_sv1_per_client_metrics = true
 
 # LAN subnet containing ASIC miner web/API addresses (for example, 192.168.1.0/24).
 [miner_telemetry]

--- a/miner-apps/translator/src/lib/config.rs
+++ b/miner-apps/translator/src/lib/config.rs
@@ -61,6 +61,13 @@ pub struct TranslatorConfig {
     monitoring_address: Option<SocketAddr>,
     #[serde(default)]
     monitoring_cache_refresh_secs: Option<u64>,
+    /// Emit one Prometheus series per connected SV1 miner (`sv1_client_hashrate`).
+    ///
+    /// Off by default: the series count scales with miner count. The JSON API at
+    /// `/api/v1/sv1/clients` serves per-client state either way; this only adds
+    /// per-miner history to Prometheus.
+    #[serde(default)]
+    monitoring_sv1_per_client_metrics: Option<bool>,
     #[serde(default)]
     miner_telemetry: MinerTelemetryConfig,
 }
@@ -137,8 +144,15 @@ impl TranslatorConfig {
             log_file: None,
             monitoring_address,
             monitoring_cache_refresh_secs,
+            monitoring_sv1_per_client_metrics: None,
             miner_telemetry: MinerTelemetryConfig::default(),
         }
+    }
+
+    /// Whether to emit one Prometheus series per connected SV1 miner. Off unless
+    /// explicitly enabled.
+    pub fn monitoring_sv1_per_client_metrics(&self) -> bool {
+        self.monitoring_sv1_per_client_metrics.unwrap_or(false)
     }
 
     /// Returns the monitoring server bind address (if enabled)
@@ -572,5 +586,45 @@ mod tests {
         assert_eq!(config.upstreams.len(), 2);
         assert_eq!(config.upstreams[0].user_identity, "sri/solo/bc1qprimary");
         assert_eq!(config.upstreams[1].user_identity, "bc1qbackup.worker");
+    }
+
+    #[test]
+    fn sv1_per_client_metrics_defaults_off_and_parses_when_set() {
+        let pubkey = "9bDuixKmZqAJnrmP746n8zU1wyAQRrus7th9dxnkPg6RzQvCnan";
+        let config_toml = |extra: &str| {
+            format!(
+                r#"
+                downstream_address = "0.0.0.0"
+                downstream_port = 34255
+                max_supported_version = 2
+                min_supported_version = 2
+                downstream_extranonce2_size = 8
+                aggregate_channels = false
+                {extra}
+
+                [downstream_difficulty_config]
+                min_individual_miner_hashrate = 10000000.0
+                shares_per_minute = 6.0
+                enable_vardiff = false
+                job_keepalive_interval_secs = 60
+
+                [[upstreams]]
+                address = "127.0.0.1"
+                port = 3333
+                authority_pubkey = "{pubkey}"
+                user_identity = "sri/solo/bc1qprimary"
+                "#
+            )
+        };
+
+        let off: TranslatorConfig = toml::from_str(&config_toml("")).unwrap();
+        assert!(
+            !off.monitoring_sv1_per_client_metrics(),
+            "per-client SV1 metrics must be off unless explicitly enabled"
+        );
+
+        let on: TranslatorConfig =
+            toml::from_str(&config_toml("monitoring_sv1_per_client_metrics = true")).unwrap();
+        assert!(on.monitoring_sv1_per_client_metrics());
     }
 }

--- a/miner-apps/translator/src/lib/translator_runtime.rs
+++ b/miner-apps/translator/src/lib/translator_runtime.rs
@@ -499,7 +499,10 @@ impl TranslatorRuntime<UpstreamReady> {
         .map_err(|e| {
             TproxyErrorKind::General(format!("failed to initialize monitoring server: {e}"))
         })?
-        .with_sv1_monitoring(self.state.sv1_server.clone())
+        .with_sv1_monitoring(
+            self.state.sv1_server.clone(),
+            self.translator.config.monitoring_sv1_per_client_metrics(),
+        )
         .map_err(|e| TproxyErrorKind::General(format!("failed to add SV1 monitoring: {e}")))?;
 
         let cancellation_token_clone = self.translator.cancellation_token.clone();

--- a/stratum-apps/src/monitoring/README.md
+++ b/stratum-apps/src/monitoring/README.md
@@ -93,3 +93,9 @@ tokio::spawn(async move {
 **Sv1 (Translator Proxy only):**
 - `sv1_clients_total` - Sv1 client count
 - `sv1_hashrate_total` - Sv1 total hashrate
+- `sv1_client_hashrate{user_identity}` - Per-miner hashrate. **Opt-in**, via
+  `monitoring_sv1_per_client_metrics = true`, because the series count scales with
+  connected miners. Labelled by SV1 username rather than a connection id, so a
+  reconnecting miner continues the same series; hashrates of connections sharing a
+  username are summed. Series for departed miners are removed on the next refresh.
+  `/api/v1/sv1/clients` serves per-client state regardless of this setting.

--- a/stratum-apps/src/monitoring/http_server.rs
+++ b/stratum-apps/src/monitoring/http_server.rs
@@ -198,9 +198,15 @@ impl MonitoringServer {
     /// Add Sv1 clients monitoring (optional, for Translator Proxy only)
     ///
     /// This must be called before `run()` if you want SV1 monitoring.
+    ///
+    /// `per_client_metrics` additionally registers `sv1_client_hashrate`, one
+    /// series per connected miner. It is off in production by default because
+    /// the series count scales with miner count; the JSON API always serves
+    /// per-client state regardless.
     pub fn with_sv1_monitoring(
         mut self,
         sv1_monitoring: Arc<dyn Sv1ClientsMonitoring + Send + Sync + 'static>,
+        per_client_metrics: bool,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         // Determine what sources the cache already has
         let snapshot = self.state.cache.get_snapshot();
@@ -209,6 +215,11 @@ impl MonitoringServer {
 
         // Create metrics with SV1 monitoring enabled
         let metrics = PrometheusMetrics::new(has_server, has_sv2_clients, true)?;
+        let metrics = if per_client_metrics {
+            metrics.with_sv1_per_client()?
+        } else {
+            metrics
+        };
 
         // Add Sv1 clients source and attach new metrics to the cache
         let cache = Arc::new(

--- a/stratum-apps/src/monitoring/prometheus_metrics.rs
+++ b/stratum-apps/src/monitoring/prometheus_metrics.rs
@@ -27,6 +27,9 @@ pub struct PrometheusMetrics {
     // SV1 metrics
     pub sv1_clients_total: Option<Gauge>,
     pub sv1_hashrate_total: Option<Gauge>,
+    /// Per-SV1-client hashrate. Cardinality scales with miner count, so this is
+    /// opt-in via `with_sv1_per_client` rather than registered by default.
+    pub sv1_client_hashrate: Option<GaugeVec>,
 }
 
 impl PrometheusMetrics {
@@ -210,7 +213,23 @@ impl PrometheusMetrics {
             sv2_client_blocks_found_total,
             sv1_clients_total,
             sv1_hashrate_total,
+            sv1_client_hashrate: None,
         })
+    }
+
+    /// Register the per-SV1-client hashrate `GaugeVec`.
+    ///
+    /// Kept opt-in because the series count scales with connected miners. The
+    /// label is `user_identity` (the SV1 username) rather than a connection
+    /// identifier, so a reconnecting miner continues the same series.
+    pub fn with_sv1_per_client(mut self) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let metric = GaugeVec::new(
+            Opts::new("sv1_client_hashrate", "Hashrate per individual SV1 client"),
+            &["user_identity"],
+        )?;
+        self.registry.register(Box::new(metric.clone()))?;
+        self.sv1_client_hashrate = Some(metric);
+        Ok(self)
     }
 }
 

--- a/stratum-apps/src/monitoring/snapshot_cache.rs
+++ b/stratum-apps/src/monitoring/snapshot_cache.rs
@@ -89,6 +89,8 @@ struct PreviousPrometheusLabelSets {
     /// Labels for client per-rejection GaugeVecs: [client_id, channel_id, user_identity,
     /// error_code]
     client_rejected_share_labels: HashSet<[String; 4]>,
+    /// Labels for the per-SV1-client GaugeVec: [user_identity]
+    sv1_client_labels: HashSet<[String; 1]>,
 }
 
 /// Cached snapshot of monitoring data.
@@ -154,6 +156,7 @@ impl Clone for SnapshotCache {
                 client_rejected_share_labels: previous_metrics_labels
                     .client_rejected_share_labels
                     .clone(),
+                sv1_client_labels: previous_metrics_labels.sv1_client_labels.clone(),
             }),
         }
     }
@@ -257,6 +260,7 @@ impl SnapshotCache {
         let mut current_server_rejected_labels: HashSet<[String; 3]> = HashSet::new();
         let mut current_client_labels: HashSet<[String; 3]> = HashSet::new();
         let mut current_client_rejected_labels: HashSet<[String; 4]> = HashSet::new();
+        let mut current_sv1_client_labels: HashSet<[String; 1]> = HashSet::new();
 
         // Server metrics
         if let Some(ref summary) = snapshot.server_summary {
@@ -486,6 +490,22 @@ impl SnapshotCache {
             }
         }
 
+        // Per-SV1-client series, when opted in. Keyed on `user_identity` so a
+        // reconnecting miner continues its existing series; hashrates are summed
+        // because two connections can authorise under the same username.
+        if let Some(ref m) = metrics.sv1_client_hashrate {
+            let mut by_user: std::collections::HashMap<&str, f64> =
+                std::collections::HashMap::new();
+            for client in snapshot.sv1_clients.as_deref().unwrap_or(&[]) {
+                *by_user.entry(client.sv1_username.as_str()).or_default() +=
+                    client.hashrate.unwrap_or(0.0) as f64;
+            }
+            for (user, hashrate) in by_user {
+                m.with_label_values(&[user]).set(hashrate);
+                current_sv1_client_labels.insert([user.to_string()]);
+            }
+        }
+
         // Remove stale label combinations that are no longer in the snapshot
         let mut previous_metrics_labels = self
             .previous_metrics_labels
@@ -550,10 +570,23 @@ impl SnapshotCache {
             }
         }
 
+        for stale in previous_metrics_labels
+            .sv1_client_labels
+            .difference(&current_sv1_client_labels)
+        {
+            let label_refs: Vec<&str> = stale.iter().map(|s| s.as_str()).collect();
+            if let Some(ref m) = metrics.sv1_client_hashrate {
+                if let Err(e) = m.remove_label_values(&label_refs) {
+                    debug!(labels = ?label_refs, error = %e, "failed to remove stale sv1 client label");
+                }
+            }
+        }
+
         previous_metrics_labels.server_channel_labels = current_server_labels;
         previous_metrics_labels.server_rejected_share_labels = current_server_rejected_labels;
         previous_metrics_labels.client_channel_labels = current_client_labels;
         previous_metrics_labels.client_rejected_share_labels = current_client_rejected_labels;
+        previous_metrics_labels.sv1_client_labels = current_sv1_client_labels;
     }
 
     /// Get the refresh interval
@@ -740,5 +773,107 @@ mod tests {
             total_cache_requests > 2,
             "Cache should have processed requests",
         );
+    }
+
+    // ── per-SV1-client metrics ───────────────────────────────────────
+
+    fn sv1_client(username: &str, hashrate: f32) -> Sv1ClientInfo {
+        Sv1ClientInfo {
+            client_id: 1,
+            channel_id: Some(1),
+            connection_ip: "192.0.2.1".parse().expect("test IP must be valid"),
+            #[cfg(feature = "asic-rs-telemetry")]
+            management_ip: None,
+            sv1_username: username.to_string(),
+            sv1_worker_name: username.to_string(),
+            target_hex: "00ff".to_string(),
+            hashrate: Some(hashrate),
+            stable_hashrate: false,
+            extranonce1_hex: "aabb".to_string(),
+            extranonce2_len: 8,
+            version_rolling_mask: None,
+            version_rolling_min_bit: None,
+            #[cfg(feature = "asic-rs-telemetry")]
+            miner_telemetry: None,
+            #[cfg(feature = "asic-rs-telemetry")]
+            miner_telemetry_status: None,
+        }
+    }
+
+    struct Sv1Miners(Mutex<Vec<Sv1ClientInfo>>);
+
+    impl Sv1ClientsMonitoring for Sv1Miners {
+        fn get_sv1_clients(&self) -> Vec<Sv1ClientInfo> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    /// Every `sv1_client_hashrate` series currently registered, as (label, value).
+    fn sv1_series(metrics: &PrometheusMetrics) -> Vec<(String, f64)> {
+        metrics
+            .registry
+            .gather()
+            .iter()
+            .find(|f| f.get_name() == "sv1_client_hashrate")
+            .map(|f| {
+                f.get_metric()
+                    .iter()
+                    .map(|m| {
+                        (
+                            m.get_label()[0].get_value().to_string(),
+                            m.get_gauge().get_value(),
+                        )
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn sv1_per_client_series_sums_duplicates_and_is_reaped_on_disconnect() {
+        let miners = Arc::new(Sv1Miners(Mutex::new(vec![
+            sv1_client("acct.rig-a", 10.0),
+            // Same username on a second connection: hashrate must add, not clobber.
+            sv1_client("acct.rig-a", 5.0),
+            sv1_client("acct.rig-b", 7.0),
+        ])));
+        let metrics = PrometheusMetrics::new(false, false, true)
+            .expect("metrics")
+            .with_sv1_per_client()
+            .expect("per-client metrics");
+        let cache = SnapshotCache::new(Duration::from_secs(5), None, None)
+            .with_sv1_clients_source(miners.clone())
+            .with_metrics(metrics.clone());
+
+        cache.refresh();
+        let mut series = sv1_series(&metrics);
+        series.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            series,
+            vec![
+                ("acct.rig-a".to_string(), 15.0),
+                ("acct.rig-b".to_string(), 7.0)
+            ]
+        );
+
+        // Miners disconnect; their series must not linger.
+        miners.0.lock().unwrap().clear();
+        cache.refresh();
+        assert!(
+            sv1_series(&metrics).is_empty(),
+            "series for departed miners were not removed"
+        );
+    }
+
+    #[test]
+    fn sv1_per_client_series_absent_unless_opted_in() {
+        let miners = Arc::new(Sv1Miners(Mutex::new(vec![sv1_client("acct.rig-a", 10.0)])));
+        let metrics = PrometheusMetrics::new(false, false, true).expect("metrics");
+        let cache = SnapshotCache::new(Duration::from_secs(5), None, None)
+            .with_sv1_clients_source(miners)
+            .with_metrics(metrics.clone());
+
+        cache.refresh();
+        assert!(sv1_series(&metrics).is_empty());
     }
 }


### PR DESCRIPTION
The tProxy exposes only `sv1_clients_total` and `sv1_hashrate_total`, so Prometheus cannot answer "what was this miner's hashrate over the last six hours." The per-client data is already collected on every refresh and then dropped: `refresh()` populates `sv1_clients`, but `update_metrics()` consumes only the aggregates. This emits a series from data already in hand.

SV1 miners behind the translator are typically the on-premise machines an operator most needs to inspect individually. `/api/v1/sv1/clients` answers "what is this miner doing now" well, but has no history, so that question currently has no answer on any surface.

## Changes

- `sv1_client_hashrate{user_identity}`, sourced from the existing `sv1_clients` snapshot.
- **Opt-in.** Registered only via `PrometheusMetrics::with_sv1_per_client`, selected by a new `per_client_metrics` flag on `with_sv1_monitoring`, driven by a `monitoring_sv1_per_client_metrics` config field on the translator that defaults to off. Existing deployments are unaffected, and the JSON API serves per-client state either way.
- Documented in `monitoring/README.md` and, commented out, in the tproxy config examples.

## Design notes

**Label choice.** `user_identity` (the SV1 username) rather than `client_id`, because `client_id` changes on every reconnect and would fragment a miner's history into a new series per connection. Connections sharing a username are **summed** rather than clobbering one another, since that is the operator-meaningful answer.

**Series are reaped.** Departed miners are removed on the next refresh through the existing stale-label mechanism, so a disconnect does not leak a series. Covered by a test that asserts the series set is empty after all miners disconnect — this is the part most likely to regress silently.

**Cardinality.** Opt-in is the only bound here. A tighter mechanism (top-N by hashrate, or an allowlist) can layer on if wanted; I left it out because opt-in already prevents an unbounded default and I would rather not invent a bounding policy unilaterally. Happy to add one if you'd prefer it in this PR.

## Caveat worth documenting

The per-client `hashrate` is vardiff-driven, and #262 records it going stale when `enable_vardiff = false` and the upstream adjusts difficulty via `SetTarget`. This metric inherits that, so it is an estimate rather than measured throughput.

## Verified

`stratum-apps` 110/110 with `monitoring` and 120/120 with `asic-rs-telemetry` (the translator's default); `translator_sv2` 48/48; integration-tests and pool still compile; `clippy` and `fmt` clean. Config knob deserialization is covered by a test asserting both the default-off and explicitly-enabled cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
