### PR TITLE
feat(monitoring): expose per-channel share work to Prometheus

### DIFF
--- a/stratum-apps/src/monitoring/README.md
+++ b/stratum-apps/src/monitoring/README.md
@@ -86,6 +86,11 @@ tokio::spawn(async move {
 - `sv2_client_channels{channel_type}` - Client channels by type (extended/standard)
 - `sv2_client_hashrate_total` - Total client hashrate
 - `sv2_client_channel_hashrate{client_id, channel_id, user_identity}` - Per-channel hashrate
+  as *declared* by the miner (`nominal_hashrate`), not measured
+- `sv2_client_channel_share_work_total{client_id, channel_id, user_identity}` - Cumulative
+  validated share work per channel. Monotonic while the channel lives, so `rate()` over it
+  gives *measured* work per second — the counterpart to the declared value above. Use it
+  where you need what a miner actually produced rather than what it announced.
 - `sv2_client_shares_accepted_total{client_id, channel_id, user_identity}` - Per-channel shares
 - `sv2_client_shares_rejected_total{client_id, channel_id, user_identity, error_code}` - Per-channel rejected shares by error code
 - `sv2_client_blocks_found_total` - Total blocks found across all current client channels

--- a/stratum-apps/src/monitoring/prometheus_metrics.rs
+++ b/stratum-apps/src/monitoring/prometheus_metrics.rs
@@ -21,6 +21,9 @@ pub struct PrometheusMetrics {
     pub sv2_client_channels: Option<GaugeVec>,
     pub sv2_client_hashrate_total: Option<Gauge>,
     pub sv2_client_channel_hashrate: Option<GaugeVec>,
+    /// Cumulative validated share work per client channel. `nominal_hashrate` is the
+    /// value the miner declared; `rate()` over this is what it actually produced.
+    pub sv2_client_channel_share_work_total: Option<GaugeVec>,
     pub sv2_client_shares_accepted_total: Option<GaugeVec>,
     pub sv2_client_shares_rejected_total: Option<GaugeVec>,
     pub sv2_client_blocks_found_total: Option<Gauge>,
@@ -113,6 +116,7 @@ impl PrometheusMetrics {
             sv2_client_channels,
             sv2_client_hashrate_total,
             sv2_client_channel_hashrate,
+            sv2_client_channel_share_work_total,
             sv2_client_shares_accepted_total,
             sv2_client_shares_rejected_total,
             sv2_client_blocks_found_total,
@@ -141,6 +145,15 @@ impl PrometheusMetrics {
                 &["client_id", "channel_id", "user_identity"],
             )?;
             registry.register(Box::new(channel_hashrate.clone()))?;
+
+            let channel_share_work = GaugeVec::new(
+                Opts::new(
+                    "sv2_client_channel_share_work_total",
+                    "Cumulative validated share work per client channel",
+                ),
+                &["client_id", "channel_id", "user_identity"],
+            )?;
+            registry.register(Box::new(channel_share_work.clone()))?;
 
             let shares_accepted = GaugeVec::new(
                 Opts::new(
@@ -171,12 +184,13 @@ impl PrometheusMetrics {
                 Some(channels),
                 Some(hashrate),
                 Some(channel_hashrate),
+                Some(channel_share_work),
                 Some(shares_accepted),
                 Some(shares_rejected),
                 Some(blocks_found),
             )
         } else {
-            (None, None, None, None, None, None, None)
+            (None, None, None, None, None, None, None, None)
         };
 
         // SV1 metrics
@@ -205,6 +219,7 @@ impl PrometheusMetrics {
             sv2_client_channels,
             sv2_client_hashrate_total,
             sv2_client_channel_hashrate,
+            sv2_client_channel_share_work_total,
             sv2_client_shares_accepted_total,
             sv2_client_shares_rejected_total,
             sv2_client_blocks_found_total,

--- a/stratum-apps/src/monitoring/snapshot_cache.rs
+++ b/stratum-apps/src/monitoring/snapshot_cache.rs
@@ -425,6 +425,10 @@ impl SnapshotCache {
                         m.with_label_values(&[&client_id, &channel_id, user])
                             .set(channel.nominal_hashrate as f64);
                     }
+                    if let Some(ref m) = metrics.sv2_client_channel_share_work_total {
+                        m.with_label_values(&[&client_id, &channel_id, user])
+                            .set(channel.share_work_sum);
+                    }
                     current_client_labels.insert(labels);
                     client_blocks_total += channel.blocks_found as u64;
                 }
@@ -465,6 +469,10 @@ impl SnapshotCache {
                     if let Some(ref m) = metrics.sv2_client_channel_hashrate {
                         m.with_label_values(&[&client_id, &channel_id, user])
                             .set(channel.nominal_hashrate as f64);
+                    }
+                    if let Some(ref m) = metrics.sv2_client_channel_share_work_total {
+                        m.with_label_values(&[&client_id, &channel_id, user])
+                            .set(channel.share_work_sum);
                     }
                     current_client_labels.insert(labels);
                     client_blocks_total += channel.blocks_found as u64;
@@ -534,6 +542,11 @@ impl SnapshotCache {
             if let Some(ref m) = metrics.sv2_client_channel_hashrate {
                 if let Err(e) = m.remove_label_values(&label_refs) {
                     debug!(labels = ?label_refs, error = %e, "failed to remove stale client hashrate label");
+                }
+            }
+            if let Some(ref m) = metrics.sv2_client_channel_share_work_total {
+                if let Err(e) = m.remove_label_values(&label_refs) {
+                    debug!(labels = ?label_refs, error = %e, "failed to remove stale client share work label");
                 }
             }
         }
@@ -739,6 +752,104 @@ mod tests {
         assert!(
             total_cache_requests > 2,
             "Cache should have processed requests",
+        );
+    }
+
+    // ── per-channel share work ───────────────────────────────────────
+
+    use super::super::client::ExtendedChannelInfo;
+
+    /// Deliberately distinct `nominal_hashrate` and `share_work_sum` so wiring the
+    /// wrong field fails rather than coincidentally passing.
+    fn channel_with_work(channel_id: u32, nominal: f32, work: f64) -> ExtendedChannelInfo {
+        ExtendedChannelInfo {
+            channel_id,
+            user_identity: format!("worker-{channel_id}"),
+            nominal_hashrate: nominal,
+            stable_hashrate: false,
+            target_hex: "00ff".to_string(),
+            requested_max_target_hex: "00ff".to_string(),
+            extranonce_prefix_hex: "aa".to_string(),
+            full_extranonce_size: 16,
+            rollable_extranonce_size: 4,
+            expected_shares_per_minute: 1.0,
+            shares_accepted: 1,
+            shares_rejected: 0,
+            shares_rejected_by_reason: std::collections::HashMap::new(),
+            share_work_sum: work,
+            last_share_sequence_number: 1,
+            best_diff: 1.0,
+            last_batch_accepted: 0,
+            last_batch_work_sum: 0,
+            share_batch_size: 1,
+            blocks_found: 0,
+        }
+    }
+
+    struct MutableClients(Mutex<Vec<Sv2ClientInfo>>);
+
+    impl Sv2ClientsMonitoring for MutableClients {
+        fn get_sv2_clients(&self) -> Vec<Sv2ClientInfo> {
+            self.0.lock().unwrap().clone()
+        }
+    }
+
+    /// All `sv2_client_channel_share_work_total` series, as (user_identity, value).
+    fn share_work_series(metrics: &PrometheusMetrics) -> Vec<(String, f64)> {
+        metrics
+            .registry
+            .gather()
+            .iter()
+            .find(|f| f.get_name() == "sv2_client_channel_share_work_total")
+            .map(|f| {
+                f.get_metric()
+                    .iter()
+                    .map(|m| {
+                        let user = m
+                            .get_label()
+                            .iter()
+                            .find(|l| l.get_name() == "user_identity")
+                            .map(|l| l.get_value().to_string())
+                            .unwrap_or_default();
+                        (user, m.get_gauge().get_value())
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn share_work_is_emitted_per_channel_and_reaped_on_disconnect() {
+        let clients = Arc::new(MutableClients(Mutex::new(vec![Sv2ClientInfo::new(
+            1,
+            vec![
+                channel_with_work(1, 100.0, 4242.0),
+                channel_with_work(2, 100.0, 7.5),
+            ],
+            vec![],
+        )])));
+        let metrics = PrometheusMetrics::new(false, true, false).expect("metrics");
+        let cache = SnapshotCache::new(Duration::from_secs(5), None, Some(clients.clone()))
+            .with_metrics(metrics.clone());
+
+        cache.refresh();
+        let mut series = share_work_series(&metrics);
+        series.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(
+            series,
+            vec![
+                ("worker-1".to_string(), 4242.0),
+                ("worker-2".to_string(), 7.5)
+            ],
+            "share work must come from share_work_sum, not nominal_hashrate"
+        );
+
+        // Client disconnects; its per-channel series must not linger.
+        clients.0.lock().unwrap().clear();
+        cache.refresh();
+        assert!(
+            share_work_series(&metrics).is_empty(),
+            "share work series for a departed client were not removed"
         );
     }
 }


### PR DESCRIPTION
`sv2_client_channel_hashrate` reports `nominal_hashrate` — the value a miner declared when opening the channel, not what it produced. A dashboard built on it shows nameplate for a throttled or dead miner.

That number has been wrong in three separate ways already (#242 — not updated on `SetTarget`; #262 — stale when `enable_vardiff = false`; #670 — idle downstreams inflating the aggregate). And #248 was resolved by *deleting* `sv2_client_channel_shares_per_minute`, which likewise reported a configuration value as a measurement.

## Change

Expose `sv2_client_channel_share_work_total` from the `share_work_sum` each channel already accumulates. `rate()` over it gives measured work per second, alongside the declared figure rather than replacing it — the divergence between the two is itself useful.

Labels mirror `sv2_client_channel_hashrate` exactly, so the existing stale-label bookkeeping removes both together when a channel goes away. **No new label dimension**, so the per-channel series count goes from 10 to 11 rather than multiplying.

The value is cumulative per channel. A per-channel series ending when that miner disconnects is the intended behaviour for a per-miner view, so no process-level accounting is needed here — unlike #802, which fixes a *total* that must outlive the channel that produced it.

## On adding a series

This does add one series per channel, which is worth stating plainly given cardinality is under discussion elsewhere. Two things bound it: it introduces no new label dimension, and the far larger per-channel cost is the eight pre-seeded `shares_rejected` codes, which are a total rather than a per-channel quantity and could move to process scope. I'd like to propose that separately. Net, the direction is a reduction; this is the one addition I think earns its place, because the alternative is a hashrate panel that cannot distinguish a throttled miner from a healthy one.

## Scope

**Client-side only.** The server-side structs carry `acknowledged_work_sum` and `validated_work_sum` rather than `share_work_sum`. Choosing between them — or exposing their divergence, which is arguably the more interesting signal, because it is work we validated that upstream did not acknowledge — is a separate question I'd rather not answer incidentally here.

**Label hygiene is also out of scope.** `client_id` churns on every reconnect and fragments a miner's history, which affects every per-channel metric equally. Worth addressing across all of them at once rather than diverging one.

## Naming

`_total` because the value is cumulative, matching the convention already used for `sv2_client_shares_accepted_total` (also a cumulative `Gauge`). It also keeps `rate()` and `increase()` free of the `PossibleNonCounterInfo` annotation, which is a name-suffix heuristic. Counter-reset correction is applied by value rather than by declared type, so a monotonic gauge rates correctly, including across the resets that occur when a channel's accounting is reset.

## Verified

`stratum-apps` 109/109 with `monitoring` and 119/119 with `asic-rs-telemetry`; `clippy` and `fmt` clean; pool and miner-apps unaffected; `openapi.json` byte-identical, because this touches no API type.

The test uses deliberately distinct `nominal_hashrate` and `share_work_sum` values, and I confirmed it fails when the wrong field is wired — `[100.0, 100.0]` instead of `[4242.0, 7.5]` — because silently reporting the declared value is exactly the failure mode #248 was about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
