### PR TITLE
fix(translator): log shares dropped on the submit path

### DIFF
--- a/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
+++ b/miner-apps/translator/src/lib/sv2/channel_manager/mod.rs
@@ -17,7 +17,11 @@ use stratum_apps::{
     payout::PayoutMode,
     stratum_core::{
         channels_sv2::{
-            client::{extended::ExtendedChannel, group::GroupChannel},
+            client::{
+                extended::ExtendedChannel,
+                group::GroupChannel,
+                share_accounting::{ShareValidationError, ShareValidationResult},
+            },
             extranonce_manager::{ExtranonceAllocator, bytes_needed},
         },
         codec_sv2::StandardSv2Frame,
@@ -617,7 +621,7 @@ impl ChannelManager {
                         .with_mut(&AGGREGATED_CHANNEL_ID, |aggregated_channel| {
                             aggregated_channel.validate_share(m.clone())
                         });
-                    if let Some(Ok(_result)) = value {
+                    if let Some(Ok(_result)) = &value {
                         info!(
                             "SubmitSharesExtended: valid share, forwarding it to upstream | channel_id: {}, sequence_number: {} ☑️",
                             upstream_extended_channel_id, m.sequence_number
@@ -627,6 +631,7 @@ impl ChannelManager {
                         m.sequence_number =
                             self.next_share_sequence_number(upstream_extended_channel_id);
                     } else {
+                        warn_dropped_share(&value, upstream_extended_channel_id, m.sequence_number);
                         return Ok(());
                     }
                 } else {
@@ -635,7 +640,7 @@ impl ChannelManager {
                         .with_mut(&m.channel_id, |extended_channel| {
                             extended_channel.validate_share(m.clone())
                         });
-                    if let Some(Ok(_result)) = value {
+                    if let Some(Ok(_result)) = &value {
                         info!(
                             "SubmitSharesExtended: valid share, forwarding it to upstream | channel_id: {}, sequence_number: {} ☑️",
                             m.channel_id, m.sequence_number
@@ -674,6 +679,7 @@ impl ChannelManager {
                                 new_extranonce.try_into().map_err(TproxyError::shutdown)?;
                         }
                     } else {
+                        warn_dropped_share(&value, m.channel_id, m.sequence_number);
                         return Ok(());
                     }
                 }
@@ -1066,6 +1072,27 @@ impl ChannelManager {
                 *counter += 1;
                 *counter
             })
+    }
+}
+
+/// Logs a share that is about to be dropped instead of forwarded upstream.
+///
+/// The SV1 server has already answered the miner `result: true` by this point, so
+/// neither a validation failure nor a missing channel may pass silently: the work
+/// is credited downstream and then discarded, and nothing else records it.
+fn warn_dropped_share(
+    value: &Option<Result<ShareValidationResult, ShareValidationError>>,
+    channel_id: u32,
+    sequence_number: u32,
+) {
+    match value {
+        Some(Err(e)) => warn!(
+            "SubmitSharesExtended: share rejected by local validation, dropping it | channel_id: {channel_id}, sequence_number: {sequence_number}, error: {e:?} ❌"
+        ),
+        None => warn!(
+            "SubmitSharesExtended: no channel for share, dropping it | channel_id: {channel_id}, sequence_number: {sequence_number} ❌"
+        ),
+        Some(Ok(_)) => {}
     }
 }
 


### PR DESCRIPTION
Shares that fail local validation in the translator are discarded without a log line at any level, after the SV1 server has already told the miner `result: true`. The work is credited downstream, never forwarded upstream, and nothing records that it happened.

Both `SubmitSharesExtended` branches in `channel_manager` collapse every non-success outcome of `validate_share` into `else { return Ok(()) }`:

- `miner-apps/translator/src/lib/sv2/channel_manager/mod.rs` — aggregated branch
- same file — non-aggregated branch

That `else` swallows two distinct cases: `Some(Err(_))`, a real validation failure, and `None`, the share's channel not being found. jd-client (`channel_manager/downstream_message_handler.rs`) and pool (`channel_manager/mining_message_handler.rs`) both match on `ShareValidationError` explicitly on their share paths, so the translator is the outlier here.

## Why it matters

Reported in #650. Against a pool serving `NewExtendedMiningJob.version_rolling_allowed: false`, the SV1 miner rolled the version anyway, the translator's own channel rejected every resulting share, and the run produced **1028 local rejections and 0 shares forwarded** with nothing in the log to explain it. Diagnosing it required patching a log line in by hand.

The upstream trigger in that report turned out to be a non-transparent proxy in my test path rather than pool misbehaviour, and I have retracted that part. This defect is independent of what caused the rejections: a share discarded *after* being acked downstream must be visible whatever the reason.

## What this changes

Adds `warn_dropped_share`, called from both `else` arms, logging the channel id, sequence number, and — for a validation failure — the `ShareValidationError`. The success path is untouched; the only change to it is taking `value` by reference so the failure arm can still read it.

## Notes for review

**Log volume.** This warns once per dropped share, so a pathological upstream can produce one line per submit. That is deliberate: a healthy setup drops approximately zero shares, and the silence is exactly what hid a 100% loss for an entire run. Happy to throttle or downgrade to `debug` past the first occurrence per channel if you would rather.

**No counter, deliberately.** I said in #650 that I would add a rejection counter. On writing it, the natural home is `ShareAccounting`, which already tracks `rejected_shares` keyed by error code and already surfaces it through monitoring as `shares_rejected` / `shares_rejected_by_reason` — but it is only written by `on_share_rejection` (upstream `SubmitSharesError`), and `ExtendedChannel` exposes only an immutable `get_share_accounting`. Recording local rejections there is a stratum-core change, and a parallel counter in the translator would be a second source of truth that monitoring does not read. Better as a companion PR against stratum-core than as duplicated state here.

**No new test.** The change adds no observable state, and asserting on `tracing` output needs a subscriber-capture harness the crate does not currently have. Existing tests pass (48).

## Verified

`cargo build`, `cargo clippy --all-targets` (no warnings), `cargo fmt --check` (clean), `cargo test -p translator_sv2` (48 passed).

## Contributions

- Identified the silent-drop path and distinguished the two failure cases it conflated
- Restored parity with jd-client and pool, which already log share-validation failures
- Documented why the counter belongs in `ShareAccounting` upstream rather than here
